### PR TITLE
Implement conventions in linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "copy:gh-pages": "cp -R $npm_package_config_styleguide_dist/* ./gh-pages",
     "semantic:watch": "gulp watch --gulpfile $npm_package_config_semantic_gulpfile",
     "semantic:build": "gulp build-css build-assets --gulpfile $npm_package_config_semantic_gulpfile",
-    "lint": "eslint . --ext .js",
+    "lint": "eslint . --ext .js,.jsx",
     "lint:debug": "npm run lint -- --debug",
     "lint:fix": "npm run lint -- --fix",
     "styleguide:build": "styleguidist build --config $npm_package_config_styleguide_config",

--- a/tools/eslint/config.js
+++ b/tools/eslint/config.js
@@ -2,6 +2,7 @@ const importNoUnresolved = require('./rule-options/import.no-unresolved');
 const importOrder = require('./rule-options/import.order');
 const prettierPrettier = require('./rule-options/prettier.prettier');
 const reactBooleanPropNaming = require('./rule-options/react.boolean-prop-naming');
+const reactJsxFilenameExtension = require('./rule-options/react.jsx-filename-extension');
 const requireJsdoc = require('./rule-options/requireJsdoc');
 
 module.exports = {
@@ -28,6 +29,7 @@ module.exports = {
   },
   rules: {
     'import/named': 2,
+    'import/no-default-export': 2,
     'import/no-unresolved': [2, importNoUnresolved],
     'import/order': [2, importOrder],
     'no-console': 2,
@@ -40,6 +42,7 @@ module.exports = {
     'react/forbid-prop-types': 2,
     'react/jsx-boolean-value': [2, 'never'],
     'react/jsx-curly-brace-presence': [2, 'never'],
+    'react/jsx-filename-extension': [2, reactJsxFilenameExtension],
     'react/jsx-no-undef': 2,
     'react/jsx-uses-react': 2,
     'react/jsx-uses-vars': 2,

--- a/tools/eslint/rule-options/react.jsx-filename-extension.js
+++ b/tools/eslint/rule-options/react.jsx-filename-extension.js
@@ -1,0 +1,1 @@
+module.exports = { extensions: ['.js'] };


### PR DESCRIPTION
### What **one** thing does this PR do?
Add linting rules to enforce no default exports and no .jsx filenames
