### PR TITLE
TE-267 Divider hasLine prop

### DIFF
--- a/src/components/elements/Divider/Readme.md
+++ b/src/components/elements/Divider/Readme.md
@@ -1,3 +1,11 @@
 ```jsx
 <Divider />
 ```
+
+### Variations
+
+#### Line
+
+```jsx
+<Divider hasLine />
+```

--- a/src/components/elements/Divider/component.js
+++ b/src/components/elements/Divider/component.js
@@ -1,10 +1,20 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Divider } from 'semantic-ui-react';
 
 /**
  * A divider adds whitespace between other elements.
  * @return {Object}
  */
-export const Component = () => <Divider hidden />;
+export const Component = ({ hasLine }) => <Divider hidden={!hasLine} />;
 
 Component.displayName = 'Divider';
+
+Component.defaultProps = {
+  hasLine: false,
+};
+
+Component.propTypes = {
+  /** Does the divider have a visible line. */
+  hasLine: PropTypes.bool,
+};

--- a/src/components/elements/Divider/component.spec.js
+++ b/src/components/elements/Divider/component.spec.js
@@ -4,21 +4,35 @@ import { Divider as SemanticDivider } from 'semantic-ui-react';
 
 import { Component as Divider } from './component';
 
+const getDivider = props => shallow(<Divider {...props} />);
+
 describe('<Divider />', () => {
   it('should render a single Semantic UI `Divider` component', () => {
-    const divider = shallow(<Divider />);
-    const actual = divider.find(SemanticDivider).length;
+    const wrapper = getDivider();
+    const actual = wrapper.find(SemanticDivider).length;
     expect(actual).toBe(1);
   });
 
-  it('should pass the `Divider` component the right props', () => {
-    const textInput = shallow(<Divider />);
-    const actual = textInput.find('Divider').props();
-    expect(actual).toEqual(
-      expect.objectContaining({
-        hidden: true,
-      })
-    );
+  describe('the Semantic UI `Divider` component', () => {
+    it('should get the right props', () => {
+      const wrapper = getDivider();
+      const actual = wrapper.find('Divider').props();
+      expect(actual).toEqual(
+        expect.objectContaining({
+          hidden: true,
+        })
+      );
+    });
+
+    it('should get `props.hidden` as false if the parent `props.hasLine` is true', () => {
+      const wrapper = getDivider({ hasLine: true });
+      const actual = wrapper.find('Divider').props();
+      expect(actual).toEqual(
+        expect.objectContaining({
+          hidden: false,
+        })
+      );
+    });
   });
 
   it('should have `displayName` Divider', () => {


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-267)

### What **one** thing does this PR do?
Adds the `hasLine` prop to the Divider component.