### PR TITLE
TE-276 PropertyPictures

### DIFF
--- a/src/components/widgets/PropertyPictures/Readme.md
+++ b/src/components/widgets/PropertyPictures/Readme.md
@@ -1,0 +1,9 @@
+```jsx
+const { pictures } = require('./mock-data/pictures');
+
+<Grid>
+  <GridRow>
+    <PropertyPictures pictures={pictures} />
+  </GridRow>
+</Grid>
+```

--- a/src/components/widgets/PropertyPictures/component.js
+++ b/src/components/widgets/PropertyPictures/component.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { getUniqueKey } from 'lib/get-unique-key';
+import { Grid } from 'layout/Grid';
+import { GridColumn } from 'layout/GridColumn';
+import { Heading } from 'typography/Heading';
+import { ResponsiveImage } from 'widgets/ResponsiveImage';
+import { Link } from 'elements/Link';
+
+/**
+ * The standard widget for displaying pictures of a property.
+ * @returns {Object}
+ */
+export const Component = ({ pictures, width }) => (
+  <GridColumn width={width}>
+    <Heading size="tiny">Property pictures</Heading>
+    <Grid>
+      {pictures.map(({ imageUrl, label }, i) => (
+        <GridColumn key={getUniqueKey(label, i)} width={4}>
+          <ResponsiveImage imageUrl={imageUrl} label={label} />
+        </GridColumn>
+      ))}
+      <GridColumn width={12}>
+        <Link>Explore all pictures</Link>
+      </GridColumn>
+    </Grid>
+  </GridColumn>
+);
+
+Component.displayName = 'PropertyPictures';
+
+Component.defaultProps = {
+  width: 12,
+};
+
+Component.propTypes = {
+  /** The pictures to display as responsive images. */
+  pictures: PropTypes.arrayOf(
+    PropTypes.shape({
+      /** URL pointing to the image to display. */
+      imageUrl: PropTypes.string.isRequired,
+      /** A visible label for the image. */
+      label: PropTypes.string.isRequired,
+    })
+  ).isRequired,
+  /** The number of columns the widget occupies. */
+  width: PropTypes.oneOf([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
+};

--- a/src/components/widgets/PropertyPictures/component.spec.js
+++ b/src/components/widgets/PropertyPictures/component.spec.js
@@ -1,0 +1,149 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { Grid } from 'layout/Grid';
+import { GridColumn } from 'layout/GridColumn';
+import { Heading } from 'typography/Heading';
+import { ResponsiveImage } from 'widgets/ResponsiveImage';
+import { Link } from 'elements/Link';
+
+import { pictures } from './mock-data/pictures';
+import { Component as PropertyPictures } from './component';
+
+const getPropertyPictures = () =>
+  shallow(<PropertyPictures pictures={pictures} />);
+
+describe('<PropertyPictures />', () => {
+  it('should render a single Lodgify UI `GridColumn` component', () => {
+    const wrapper = getPropertyPictures();
+    const actual = wrapper.is(GridColumn);
+    expect(actual).toBe(true);
+  });
+
+  describe('the `GridColumn` component', () => {
+    it('should have the right props', () => {
+      const wrapper = getPropertyPictures();
+      const actual = wrapper.props();
+      expect(actual).toEqual(
+        expect.objectContaining({
+          width: 12,
+        })
+      );
+    });
+
+    it('should render the right children', () => {
+      const children = ['Heading', 'Grid'];
+      const wrapper = getPropertyPictures();
+      children.forEach((child, index) => {
+        const actual = wrapper.childAt(index).name();
+        expect(actual).toBe(child);
+      });
+    });
+  });
+
+  describe('the `Heading` component', () => {
+    const getHeading = () => getPropertyPictures().find(Heading);
+
+    it('should have the right props', () => {
+      const wrapper = getHeading();
+      const actual = wrapper.props();
+      expect(actual).toEqual(
+        expect.objectContaining({
+          size: 'tiny',
+        })
+      );
+    });
+
+    it('should render the right children', () => {
+      const wrapper = getHeading();
+      const actual = wrapper.prop('children');
+      expect(actual).toBe('Property pictures');
+    });
+  });
+
+  describe('the `Grid` component', () => {
+    const getGrid = () => getPropertyPictures().find(Grid);
+
+    it('should render a `GridColumn` for each item in `props.pictures` plus one for the Link', () => {
+      const wrapper = getGrid();
+      const actual = wrapper.children(GridColumn);
+      expect(actual).toHaveLength(pictures.length + 1);
+    });
+  });
+
+  describe('each `GridColumn` component wrapping an image', () => {
+    const getFirstGridColumnWithImage = () =>
+      getPropertyPictures()
+        .find(GridColumn)
+        .at(1);
+
+    it('should get the right props', () => {
+      const wrapper = getFirstGridColumnWithImage();
+      const actual = wrapper.props();
+      expect(actual).toEqual(
+        expect.objectContaining({
+          width: 4,
+        })
+      );
+    });
+
+    it('should render the right children', () => {
+      const wrapper = getFirstGridColumnWithImage();
+      const actual = wrapper.find(ResponsiveImage);
+      expect(actual).toHaveLength(1);
+    });
+  });
+
+  describe('each `ResponsiveImage` component', () => {
+    it('should get the right props', () => {
+      const wrapper = getPropertyPictures()
+        .find(ResponsiveImage)
+        .at(0);
+      const actual = wrapper.props();
+      const { imageUrl, label } = pictures[0];
+      expect(actual).toEqual(
+        expect.objectContaining({
+          imageUrl,
+          label,
+        })
+      );
+    });
+  });
+
+  describe('the `GridColumn` component wrapping the link', () => {
+    const getGridColumnWithLink = () =>
+      getPropertyPictures()
+        .find(GridColumn)
+        .at(6);
+
+    it('should get the right props', () => {
+      const wrapper = getGridColumnWithLink();
+      const actual = wrapper.props();
+      expect(actual).toEqual(
+        expect.objectContaining({
+          width: 12,
+        })
+      );
+    });
+
+    it('should render the right children', () => {
+      const wrapper = getGridColumnWithLink();
+      const actual = wrapper.find(Link);
+      expect(actual).toHaveLength(1);
+    });
+  });
+
+  describe('the `Link` component', () => {
+    it('should render the right children', () => {
+      const wrapper = getPropertyPictures().find(Link);
+      const actual = wrapper.prop('children');
+
+      expect(actual).toBe('Explore all pictures');
+    });
+  });
+
+  it('should have `displayName` `PropertyPictures`', () => {
+    const actual = PropertyPictures.displayName;
+    expect(actual).toBe('PropertyPictures');
+  });
+});

--- a/src/components/widgets/PropertyPictures/index.js
+++ b/src/components/widgets/PropertyPictures/index.js
@@ -1,0 +1,1 @@
+export { Component as PropertyPictures } from './component';

--- a/src/components/widgets/PropertyPictures/mock-data/pictures.js
+++ b/src/components/widgets/PropertyPictures/mock-data/pictures.js
@@ -1,0 +1,10 @@
+const imageUrl =
+  '//li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max';
+
+export const pictures = [
+  { imageUrl, label: 'Entrance' },
+  { imageUrl, label: 'Kitchen' },
+  { imageUrl, label: 'Living room' },
+  { imageUrl, label: 'Studio' },
+  { imageUrl, label: 'Garden room' },
+];


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-276)

### What **one** thing does this PR do?
Creates component, examples and tests for PropertyPictures.

### Any other notes.
At the moment the 'Explore all pictures' link/button has no funcionality. This can be added when we know what it does.

<img width="915" alt="screen shot 2018-04-06 at 18 00 32" src="https://user-images.githubusercontent.com/8591501/38431425-6d8b4ca0-39c4-11e8-96b5-ec6bf9854073.png">

