### PR TITLE
TE-264 PropertyFooter

### DIFF
--- a/src/components/widgets/PropertyFooter/Readme.md
+++ b/src/components/widgets/PropertyFooter/Readme.md
@@ -1,0 +1,12 @@
+```jsx
+const { guestsOptions, locationOptions } = require('./mock-data/options');
+
+<Grid>
+  <GridRow>
+    <PropertyFooter
+      guestsOptions={guestsOptions}
+      locationOptions={locationOptions}
+    />
+  </GridRow>
+</Grid>
+```

--- a/src/components/widgets/PropertyFooter/component.js
+++ b/src/components/widgets/PropertyFooter/component.js
@@ -1,0 +1,93 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import { Form } from 'semantic-ui-react';
+
+import { GridColumn } from 'layout/GridColumn';
+import { Dropdown } from 'elements/Dropdown';
+import { DateRangePicker } from 'elements/DateRangePicker';
+import { Button } from 'elements/Button';
+import { Icon } from 'elements/Icon';
+
+/**
+ * The standard widget for displaying the Check Availability Search Bar of a property.
+ * @extends {React.PureComponent}
+ */
+export class Component extends PureComponent {
+  state = {};
+
+  persistInputChange = (name, value) => {
+    this.setState({ [name]: value });
+  };
+
+  handleSubmit = () => {
+    this.props.onSubmit(this.state);
+  };
+
+  render = () => {
+    const { getIsDayBlocked, guestsOptions } = this.props;
+    return (
+      <GridColumn width={12}>
+        <Form onSubmit={this.handleSubmit}>
+          <Form.Group>
+            <Form.Field width="four">
+              <Icon label="Property Summary" name="home" />
+            </Form.Field>
+            <Form.Field width="four">
+              <DateRangePicker
+                endDatePlaceholderText="Check-out"
+                getIsDayBlocked={getIsDayBlocked}
+                name="dates"
+                onChange={this.persistInputChange}
+                startDatePlaceholderText="Check-in"
+              />
+            </Form.Field>
+            <Form.Field width="two">
+              <Dropdown
+                icon="users"
+                label="Guests"
+                name="guests"
+                onChange={this.persistInputChange}
+                options={guestsOptions}
+              />
+            </Form.Field>
+            <Form.Field width="two">
+              <Button isRounded>Check Availability</Button>
+            </Form.Field>
+          </Form.Group>
+        </Form>
+      </GridColumn>
+    );
+  };
+}
+
+Component.displayName = 'PropertyFooter';
+
+Component.defaultProps = {
+  getIsDayBlocked: Function.prototype,
+  onSubmit: Function.prototype,
+};
+
+Component.propTypes = {
+  /**
+   * A function called for each day to be displayed in the DateRangePicker. Returning true blocks that day in the date range picker.
+   * @param   {Moment}  day - The day to test.
+   * @returns {Boolean}     - Is the day blocked.
+   */
+  getIsDayBlocked: PropTypes.func,
+  /** The options which the user can select in the guests field. */
+  guestsOptions: PropTypes.arrayOf(
+    PropTypes.shape({
+      /** The visible text for the option. */
+      text: PropTypes.string.isRequired,
+      /** The underlying value for the option. */
+      value: PropTypes.any,
+    })
+  ).isRequired,
+  /** The function to call when the availability check is submitted.
+   *  @param {Object} values - The values of the inputs in check availability bar.
+   *  @param {Object} values.dates
+   *  @param {String} values.guests
+   *  @param {String} values.location
+   */
+  onSubmit: PropTypes.func,
+};

--- a/src/components/widgets/PropertyFooter/component.spec.js
+++ b/src/components/widgets/PropertyFooter/component.spec.js
@@ -1,38 +1,53 @@
 import React from 'react';
-import { shallow, mount } from 'enzyme';
-import { Icon, Form } from 'semantic-ui-react';
+import { shallow } from 'enzyme';
+import { Form } from 'semantic-ui-react';
 
+import { GridColumn } from 'layout/GridColumn';
 import { Dropdown } from 'elements/Dropdown';
 import { DateRangePicker } from 'elements/DateRangePicker';
 import { Button } from 'elements/Button';
+import { Icon } from 'elements/Icon';
 
-import { Component as SearchBar } from './component';
+import { Component as PropertyFooter } from './component';
 import { guestsOptions, locationOptions } from './mock-data/options';
 
-const getSearchBar = () =>
+const getPropertyFooter = () =>
   shallow(
-    <SearchBar
+    <PropertyFooter
       guestsOptions={guestsOptions}
       locationOptions={locationOptions}
     />
   );
-const getForm = () => getSearchBar().find(Form);
-const getFormGroup = () => getSearchBar().find(Form.Group);
+const getGridColumn = () => getPropertyFooter().find(GridColumn);
+const getForm = () => getPropertyFooter().find(Form);
+const getFormGroup = () => getPropertyFooter().find(Form.Group);
 const getFormField = index =>
-  getSearchBar()
+  getPropertyFooter()
     .find(Form.Field)
     .at(index);
 const getDropdown = index =>
-  getSearchBar()
+  getPropertyFooter()
     .find(Dropdown)
     .at(index);
-const getButton = () => getSearchBar().find(Button);
+const getButton = () => getPropertyFooter().find(Button);
 
-describe('<SearchBar />', () => {
+describe('<PropertyFooter />', () => {
   it('should render a single Semantic UI `Form` component', () => {
-    const wrapper = getSearchBar();
+    const wrapper = getPropertyFooter();
     const actual = wrapper.find(Form);
     expect(actual).toHaveLength(1);
+  });
+
+  describe('the `GridColumn` component', () => {
+    it('should have the right props', () => {
+      const wrapper = getGridColumn();
+      const actual = wrapper.props();
+      expect(actual).toEqual(
+        expect.objectContaining({
+          width: 12,
+        })
+      );
+    });
   });
 
   describe('the `Form` component', () => {
@@ -67,31 +82,15 @@ describe('<SearchBar />', () => {
       const actual = wrapper.props();
       expect(actual).toEqual(
         expect.objectContaining({
-          width: 'three',
+          width: 'four',
         })
       );
     });
 
-    it('should render a single Lodgify UI `Dropdown` component', () => {
+    it('should render a single Lodgify UI `Icon` component', () => {
       const wrapper = getFormField(0);
-      const actual = wrapper.find(Dropdown);
+      const actual = wrapper.find(Icon);
       expect(actual).toHaveLength(1);
-    });
-  });
-
-  describe('the first `Dropdown` component', () => {
-    it('should have the right props', () => {
-      const wrapper = getDropdown(0);
-      const actual = wrapper.props();
-      expect(actual).toEqual(
-        expect.objectContaining({
-          icon: 'map pin',
-          label: 'Location',
-          name: 'location',
-          onChange: expect.any(Function),
-          options: locationOptions,
-        })
-      );
     });
   });
 
@@ -101,7 +100,7 @@ describe('<SearchBar />', () => {
       const actual = wrapper.props();
       expect(actual).toEqual(
         expect.objectContaining({
-          width: 'seven',
+          width: 'four',
         })
       );
     });
@@ -115,7 +114,7 @@ describe('<SearchBar />', () => {
 
   describe('the `DateRangePicker` component', () => {
     it('should have the right props', () => {
-      const wrapper = getSearchBar().find(DateRangePicker);
+      const wrapper = getPropertyFooter().find(DateRangePicker);
       const actual = wrapper.props();
       expect(actual).toEqual(
         expect.objectContaining({
@@ -135,7 +134,7 @@ describe('<SearchBar />', () => {
       const actual = wrapper.props();
       expect(actual).toEqual(
         expect.objectContaining({
-          width: 'three',
+          width: 'two',
         })
       );
     });
@@ -147,9 +146,9 @@ describe('<SearchBar />', () => {
     });
   });
 
-  describe('the second `Dropdown` component', () => {
+  describe('the `Dropdown` component', () => {
     it('should have the right props', () => {
-      const wrapper = getDropdown(1);
+      const wrapper = getDropdown(0);
       const actual = wrapper.props();
       expect(actual).toEqual(
         expect.objectContaining({
@@ -169,7 +168,7 @@ describe('<SearchBar />', () => {
       const actual = wrapper.props();
       expect(actual).toEqual(
         expect.objectContaining({
-          width: 'three',
+          width: 'two',
         })
       );
     });
@@ -192,15 +191,15 @@ describe('<SearchBar />', () => {
       );
     });
 
-    it('should render a single Semantic UI `Icon` component', () => {
+    it('should not render a single Semantic UI `Icon` component', () => {
       const wrapper = getButton();
       const actual = wrapper.find(Icon);
-      expect(actual).toHaveLength(1);
+      expect(actual).toHaveLength(0);
     });
 
-    it('should render the string `Search`', () => {
+    it('should render the string `Check Availability`', () => {
       const wrapper = getButton();
-      const actual = wrapper.contains('Search');
+      const actual = wrapper.contains('Check Availability');
       expect(actual).toBe(true);
     });
   });
@@ -209,7 +208,7 @@ describe('<SearchBar />', () => {
     it('should persist the value in component state', () => {
       const name = 'location';
       const value = '🍰';
-      const wrapper = getSearchBar();
+      const wrapper = getPropertyFooter();
       const input = wrapper.find(Dropdown).first();
       input.simulate('change', name, value);
       const actual = wrapper.state(name);
@@ -220,8 +219,8 @@ describe('<SearchBar />', () => {
   describe('Interaction: onSubmit the form', () => {
     it('should call `props.onSubmit` with the state', () => {
       const onSubmit = jest.fn();
-      const wrapper = mount(
-        <SearchBar
+      const wrapper = shallow(
+        <PropertyFooter
           guestsOptions={guestsOptions}
           locationOptions={locationOptions}
           onSubmit={onSubmit}
@@ -233,8 +232,8 @@ describe('<SearchBar />', () => {
     });
   });
 
-  it('should have `displayName` `SearchBar`', () => {
-    const actual = SearchBar.displayName;
-    expect(actual).toBe('SearchBar');
+  it('should have `displayName` `PropertyFooter`', () => {
+    const actual = PropertyFooter.displayName;
+    expect(actual).toBe('PropertyFooter');
   });
 });

--- a/src/components/widgets/PropertyFooter/index.js
+++ b/src/components/widgets/PropertyFooter/index.js
@@ -1,0 +1,1 @@
+export { Component as PropertyFooter } from './component';

--- a/src/components/widgets/PropertyFooter/mock-data/options.js
+++ b/src/components/widgets/PropertyFooter/mock-data/options.js
@@ -1,0 +1,13 @@
+export const locationOptions = [
+  { text: 'Barcelona', value: 'barcelona' },
+  { text: 'Valencia', value: 'valencia' },
+  { text: 'Madrid', value: 'madrid' },
+  { text: 'Bilbao', value: 'bilbao' },
+];
+
+export const guestsOptions = [
+  { text: '1', value: '1' },
+  { text: '2', value: '2' },
+  { text: '3', value: '3' },
+  { text: '4', value: '4' },
+];

--- a/src/components/widgets/SearchBar/component.js
+++ b/src/components/widgets/SearchBar/component.js
@@ -54,7 +54,7 @@ export class Component extends PureComponent {
             />
           </Form.Field>
           <Form.Field width="three">
-            <Button>
+            <Button isRounded>
               <Icon name="search" />
               Search
             </Button>


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-264)

### What **one** thing does this PR do?
Adding the `<PropertyFooter />` widget.

### Any other notes
- There is an `<Icon />` rendered in place of the `<PropertySummary />`, which is ongoing for now.
  - Property Summary info needs to be added by props and propagated down to the `<PropertySummary />` widget.
- Found certain icons don't render correctly. [TE-282 created for this](https://youtrack.lodgify.net/issue/TE-282).
- Found that Search buttons need a creation of a `<SearchButton />` component receiving props like `isMultiProperties` by props and caring about how different texts display. [TE-281 created for this](https://youtrack.lodgify.net/issue/TE-281).
  - If single property: Search with icon.
  - If multi properties: Check Availability without icon.
- Stickiness of this bar will be developed in a HoC apart.

<img width="1362" alt="screen shot 2018-04-10 at 12 00 41 pm" src="https://user-images.githubusercontent.com/84540/38550653-6685d3c6-3cb7-11e8-9775-da0ac8cca529.png">
