### PR TITLE
TE-316 Deleting build folder so only the latest is added

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,6 +41,7 @@ pipeline {
         }
 
         sh "rm -rf ./${BRANCH_NAME}/*"
+        sh "rm -rf ./${BRANCH_NAME}/build"
         sh "rm -rf ./${BRANCH_NAME}/.github"
         sh "rm -rf ./${BRANCH_NAME}/.babelrc ./${BRANCH_NAME}/.eslintrc ./${BRANCH_NAME}/.eslintignore"
         sh "npm i && npm run docs:build"


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-316)

### What **one** thing does this PR do?
- Deleting also `build/` so that the latest build JS file is added on each release.
