### PR TITLE
TE-303 Change h5 -> span in Subheading.

### DIFF
--- a/src/components/typography/Subheading/component.js
+++ b/src/components/typography/Subheading/component.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
  * @return {Object}
  */
 export const Component = ({ children }) => (
-  <h5 className="ui sub header">{children}</h5>
+  <span className="ui sub header">{children}</span>
 );
 
 Component.displayName = 'Subheading';

--- a/src/components/typography/Subheading/component.spec.js
+++ b/src/components/typography/Subheading/component.spec.js
@@ -15,9 +15,9 @@ const children = '🚸';
 const getSubheading = () => shallow(<Subheading>{children}</Subheading>);
 
 describe('<Subheading />', () => {
-  it('should render a single `h5` element', () => {
+  it('should render a single `span` element', () => {
     const wrapper = getSubheading();
-    expectComponentToBe(wrapper, 'h5');
+    expectComponentToBe(wrapper, 'span');
   });
 
   it('should get the right props', () => {


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-303)

### What **one** thing does this PR do?
Responds to [this PR comment](https://github.com/lodgify/lodgify-ui/pull/103#discussion_r183292562), changing `h5` to `span` in Subheading.
