### PR TITLE
TE-332 Property Rules Responsive

### DIFF
--- a/src/components/widgets/PropertyRules/component.js
+++ b/src/components/widgets/PropertyRules/component.js
@@ -13,7 +13,7 @@ import { Icon } from 'elements/Icon';
  * @returns {Object}
  */
 export const Component = ({ checkInTime, checkOutTime, rules }) => (
-  <Grid>
+  <Grid stackable>
     <GridColumn width={12}>
       <Heading size="small">House Rules</Heading>
     </GridColumn>

--- a/src/components/widgets/PropertyRules/component.spec.js
+++ b/src/components/widgets/PropertyRules/component.spec.js
@@ -31,12 +31,20 @@ const props = {
   rules,
 };
 
-const getPropertyRules = () => shallow(<PropertyRules {...props} />);
+const getPropertyRules = otherProps =>
+  shallow(<PropertyRules {...props} {...otherProps} />);
 
 describe('<PropertyRules />', () => {
   it('should render a single Lodgify UI `Grid` component', () => {
     const wrapper = getPropertyRules();
     expectComponentToBe(wrapper, Grid);
+  });
+
+  it('should have the right props', () => {
+    const wrapper = getPropertyRules();
+    expectComponentToHaveProps(wrapper, {
+      stackable: true,
+    });
   });
 
   describe('the first `Grid` component', () => {


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-332)

### What **one** thing does this PR do?
Gives the PropertyRules widget a mobile friendly layout

<img width="318" alt="screen shot 2018-04-23 at 12 43 40 pm" src="https://user-images.githubusercontent.com/84540/39122086-062bd312-46f4-11e8-9222-b1a58f369f35.png">

