### PR TITLE
TE-328 Responsive keyfacts

### DIFF
--- a/src/components/widgets/KeyFacts/Readme.md
+++ b/src/components/widgets/KeyFacts/Readme.md
@@ -1,27 +1,5 @@
 ```jsx
 const { keyFacts } = require('./mock-data/keyFacts');
 
-<Grid>
-  <GridRow>
-    <KeyFacts keyFacts={keyFacts} />
-  </GridRow>
-</Grid>
-```
-
-### Variations
-
-#### Width
-
-```jsx
-const { keyFacts } = require('./mock-data/keyFacts');
-
-<Grid>
-  <GridRow>
-    <KeyFacts keyFacts={keyFacts} />
-  </GridRow>
-  <Divider hasLine />
-  <GridRow>
-    <KeyFacts keyFacts={keyFacts} width={6} />
-  </GridRow>
-</Grid>
+<KeyFacts keyFacts={keyFacts} />
 ```

--- a/src/components/widgets/KeyFacts/component.js
+++ b/src/components/widgets/KeyFacts/component.js
@@ -4,6 +4,8 @@ import { Label } from 'semantic-ui-react';
 
 import { getUniqueKey } from 'lib/get-unique-key';
 import { Heading } from 'typography/Heading';
+import { Grid } from 'layout/Grid';
+import { GridColumn } from 'layout/GridColumn';
 import { IconCard } from 'elements/IconCard';
 
 /**
@@ -11,20 +13,33 @@ import { IconCard } from 'elements/IconCard';
  * @returns {Object}
  */
 export const Component = ({ keyFacts }) => (
-  <div>
-    <Heading>Key facts</Heading>
-    <Label.Group>
-      {keyFacts.map(({ iconName, isDisabled, label }, index) => (
-        <IconCard
-          isDisabled={isDisabled}
-          isFilled
-          key={getUniqueKey(label, index)}
-          label={label}
-          name={iconName}
-        />
-      ))}
-    </Label.Group>
-  </div>
+  <Grid>
+    <GridColumn width={12}>
+      <Heading>Key facts</Heading>
+    </GridColumn>
+    <GridColumn width={12}>
+      <Label.Group>
+        <Grid>
+          {keyFacts.map(({ iconName, isDisabled, label }, index) => (
+            <GridColumn
+              computer={2}
+              tablet={3}
+              mobile={4}
+              streched
+              key={getUniqueKey(label, index)}
+            >
+              <IconCard
+                isDisabled={isDisabled}
+                isFilled
+                label={label}
+                name={iconName}
+              />
+            </GridColumn>
+          ))}
+        </Grid>
+      </Label.Group>
+    </GridColumn>
+  </Grid>
 );
 
 Component.displayName = 'KeyFacts';

--- a/src/components/widgets/KeyFacts/component.js
+++ b/src/components/widgets/KeyFacts/component.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Label } from 'semantic-ui-react';
 
 import { getUniqueKey } from 'lib/get-unique-key';
 import { Heading } from 'typography/Heading';
@@ -18,26 +17,24 @@ export const Component = ({ keyFacts }) => (
       <Heading>Key facts</Heading>
     </GridColumn>
     <GridColumn width={12}>
-      <Label.Group>
-        <Grid>
-          {keyFacts.map(({ iconName, isDisabled, label }, index) => (
-            <GridColumn
-              computer={2}
-              tablet={3}
-              mobile={4}
-              streched
-              key={getUniqueKey(label, index)}
-            >
-              <IconCard
-                isDisabled={isDisabled}
-                isFilled
-                label={label}
-                name={iconName}
-              />
-            </GridColumn>
-          ))}
-        </Grid>
-      </Label.Group>
+      <Grid>
+        {keyFacts.map(({ iconName, isDisabled, label }, index) => (
+          <GridColumn
+            computer={2}
+            tablet={3}
+            mobile={4}
+            streched
+            key={getUniqueKey(label, index)}
+          >
+            <IconCard
+              isDisabled={isDisabled}
+              isFilled
+              label={label}
+              name={iconName}
+            />
+          </GridColumn>
+        ))}
+      </Grid>
     </GridColumn>
   </Grid>
 );

--- a/src/components/widgets/KeyFacts/component.spec.js
+++ b/src/components/widgets/KeyFacts/component.spec.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Label } from 'semantic-ui-react';
 
 import {
   expectComponentToHaveChildren,
   expectComponentToHaveProps,
+  expectComponentToHaveDisplayName,
   expectComponentToBe,
 } from 'lib/expect-helpers';
 import { getArrayOfLengthOfItem } from 'lib/get-array-of-length-of-item';
@@ -38,27 +38,16 @@ describe('<KeyFacts />', () => {
     });
   });
 
-  describe('the `Label.Group` component', () => {
-    it('should render a `Grid` component inside of it', () => {
-      const wrapper = getKeyFacts().find(Label.Group);
-      expectComponentToHaveChildren(wrapper, Grid);
-    });
-
-    it('should render an `GridColumn` for each item in `props.keyFacts`', () => {
-      const wrapper = getKeyFacts()
-        .find(Label.Group)
-        .find(Grid);
-      expectComponentToHaveChildren(
-        wrapper,
-        ...getArrayOfLengthOfItem(keyFacts.length, GridColumn)
-      );
-    });
-
-    it('should render `GridColumns` with the right props', () => {
-      const wrapper = getKeyFacts()
-        .find(Label.Group)
+  describe('the inner `GridColumn` components', () => {
+    const getInnerColumn = () =>
+      getKeyFacts()
         .find(Grid)
-        .find(GridColumn);
+        .at(1)
+        .find(GridColumn)
+        .at(0);
+
+    it('should render with the right props', () => {
+      const wrapper = getInnerColumn();
 
       wrapper.children().forEach((element, index) =>
         expectComponentToHaveProps(wrapper.at(index), {
@@ -71,10 +60,7 @@ describe('<KeyFacts />', () => {
     });
 
     it('should render an `IconCard` for each item in `props.keyFacts`', () => {
-      const wrapper = getKeyFacts()
-        .find(Label.Group)
-        .find(Grid)
-        .find(GridColumn);
+      const wrapper = getInnerColumn();
 
       wrapper
         .children()
@@ -102,8 +88,7 @@ describe('<KeyFacts />', () => {
     });
   });
 
-  it('should have `displayName` `KeyFacts`', () => {
-    const actual = KeyFacts.displayName;
-    expect(actual).toBe('KeyFacts');
+  it('should have displayName `KeyFacts`', () => {
+    expectComponentToHaveDisplayName(KeyFacts, 'KeyFacts');
   });
 });

--- a/src/components/widgets/KeyFacts/component.spec.js
+++ b/src/components/widgets/KeyFacts/component.spec.js
@@ -5,10 +5,13 @@ import { Label } from 'semantic-ui-react';
 import {
   expectComponentToHaveChildren,
   expectComponentToHaveProps,
+  expectComponentToBe,
 } from 'lib/expect-helpers';
 import { getArrayOfLengthOfItem } from 'lib/get-array-of-length-of-item';
 import { Heading } from 'typography/Heading';
 import { IconCard } from 'elements/IconCard';
+import { Grid } from 'layout/Grid';
+import { GridColumn } from 'layout/GridColumn';
 
 import { keyFacts } from './mock-data/keyFacts';
 import { Component as KeyFacts } from './component';
@@ -18,14 +21,13 @@ const getKeyFacts = () => shallow(<KeyFacts keyFacts={keyFacts} />);
 describe('<KeyFacts />', () => {
   it('should render a single Lodgify UI `GridColumn` component', () => {
     const wrapper = getKeyFacts();
-    const actual = wrapper.is('div');
-    expect(actual).toBe(true);
+    expectComponentToBe(wrapper, Grid);
   });
 
-  describe('the `div` element', () => {
+  describe('the `Grid` component', () => {
     it('should render the right children', () => {
       const wrapper = getKeyFacts();
-      expectComponentToHaveChildren(wrapper, Heading, Label.Group);
+      expectComponentToHaveChildren(wrapper, GridColumn, GridColumn);
     });
   });
 
@@ -37,12 +39,51 @@ describe('<KeyFacts />', () => {
   });
 
   describe('the `Label.Group` component', () => {
-    it('should render an `IconCard` for each item in `props.keyFacts`', () => {
+    it('should render a `Grid` component inside of it', () => {
       const wrapper = getKeyFacts().find(Label.Group);
+      expectComponentToHaveChildren(wrapper, Grid);
+    });
+
+    it('should render an `GridColumn` for each item in `props.keyFacts`', () => {
+      const wrapper = getKeyFacts()
+        .find(Label.Group)
+        .find(Grid);
       expectComponentToHaveChildren(
         wrapper,
-        ...getArrayOfLengthOfItem(keyFacts.length, IconCard)
+        ...getArrayOfLengthOfItem(keyFacts.length, GridColumn)
       );
+    });
+
+    it('should render `GridColumns` with the right props', () => {
+      const wrapper = getKeyFacts()
+        .find(Label.Group)
+        .find(Grid)
+        .find(GridColumn);
+
+      wrapper.children().forEach((element, index) =>
+        expectComponentToHaveProps(wrapper.at(index), {
+          computer: 2,
+          tablet: 3,
+          mobile: 4,
+          streched: true,
+        })
+      );
+    });
+
+    it('should render an `IconCard` for each item in `props.keyFacts`', () => {
+      const wrapper = getKeyFacts()
+        .find(Label.Group)
+        .find(Grid)
+        .find(GridColumn);
+
+      wrapper
+        .children()
+        .forEach((element, index) =>
+          expectComponentToHaveChildren(
+            wrapper.at(index),
+            ...getArrayOfLengthOfItem(1, IconCard)
+          )
+        );
     });
   });
 

--- a/src/semantic/src/themes/livingstone/elements/label.overrides
+++ b/src/semantic/src/themes/livingstone/elements/label.overrides
@@ -7,6 +7,8 @@
 --------------------*/
 
 .ui.label {
+  height: @keyFactsHeight;
+  width: @keyFactsWidth;
 
   /* Group */
 

--- a/src/semantic/src/themes/livingstone/elements/label.overrides
+++ b/src/semantic/src/themes/livingstone/elements/label.overrides
@@ -26,6 +26,7 @@
       line-height: @iconCardTextLineHeight;
       margin: @iconCardTextMargin;
       text-align: center;
+      white-space: nowrap;
     }
   }
 

--- a/src/semantic/src/themes/livingstone/elements/label.variables
+++ b/src/semantic/src/themes/livingstone/elements/label.variables
@@ -53,9 +53,10 @@
 --------------------*/
 
 /* Basic */
+@keyFactsWidth: 9em;
+@keyFactsHeight: 9.5em;
 @basicBorderColor: @greyThree;
 @basicBorder: @basicBorderWidth solid @basicBorderColor;
-
 @basicFontWeight: @bold;
 
 /* Tag */


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-328)

### What **one** thing does this PR do?
Gives the `KeyFacts` widget a mobile friendly layout

![screen shot 2018-04-23 at 6 06 15 pm](https://user-images.githubusercontent.com/84540/39138926-1ab49ea4-4721-11e8-9f0f-f0158deccbd6.png)
![screen shot 2018-04-23 at 6 06 22 pm](https://user-images.githubusercontent.com/84540/39138934-1d85793c-4721-11e8-8a8c-ae44dfd3119e.png)
![screen shot 2018-04-23 at 6 06 31 pm](https://user-images.githubusercontent.com/84540/39138944-20c91158-4721-11e8-8169-ee1fff2483f5.png)
