### PR TITLE
TE-329 Sleeping Arrangements responsive

### DIFF
--- a/src/components/widgets/SleepingArrangements/Readme.md
+++ b/src/components/widgets/SleepingArrangements/Readme.md
@@ -1,27 +1,12 @@
 ```jsx
-const { sleepingArrangements } = require('./mock-data/sleepingArrangements');
+const sleepingArrangements = [
+  { iconName: 'bed', label: '1 king bed' },
+  { iconName: 'bed', label: '2 single beds' },
+  { iconName: 'paw', label: '1 kennel' },
+  { iconName: 'paw', label: '1 cat' },
+  { iconName: 'paw', label: '3 dogs' },
+  { iconName: 'paw', label: '2 okapis' },
+];
 
 <SleepingArrangements sleepingArrangements={sleepingArrangements} />
-```
-
-### Variations
-
-#### Width
-
-```jsx
-const { sleepingArrangements } = require('./mock-data/sleepingArrangements');
-
-<Grid>
-  <GridRow>
-    <GridColumn>
-      <SleepingArrangements sleepingArrangements={sleepingArrangements} />
-    </GridColumn>
-  </GridRow>
-  <Divider hasLine />
-  <GridRow>
-    <GridColumn>
-      <SleepingArrangements sleepingArrangements={sleepingArrangements} width={6} />
-    </GridColumn>
-  </GridRow>
-</Grid>
 ```

--- a/src/components/widgets/SleepingArrangements/component.js
+++ b/src/components/widgets/SleepingArrangements/component.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Label } from 'semantic-ui-react';
 
 import { getUniqueKey } from 'lib/get-unique-key';
 import { Heading } from 'typography/Heading';
+import { Grid } from 'layout/Grid';
+import { GridColumn } from 'layout/GridColumn';
 import { IconCard } from 'elements/IconCard';
 
 /**
@@ -13,16 +14,18 @@ import { IconCard } from 'elements/IconCard';
 export const Component = ({ sleepingArrangements }) => (
   <div>
     <Heading>Sleeping arrangements</Heading>
-    <Label.Group>
+    <Grid>
       {sleepingArrangements.map(({ iconName, label }, index) => (
-        <IconCard
-          isLeftAligned
+        <GridColumn
+          computer={2}
+          tablet={4}
+          mobile={4}
           key={getUniqueKey(label, index)}
-          label={label}
-          name={iconName}
-        />
+        >
+          <IconCard isLeftAligned label={label} name={iconName} />
+        </GridColumn>
       ))}
-    </Label.Group>
+    </Grid>
   </div>
 );
 

--- a/src/components/widgets/SleepingArrangements/component.spec.js
+++ b/src/components/widgets/SleepingArrangements/component.spec.js
@@ -1,17 +1,22 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Label } from 'semantic-ui-react';
 
 import {
   expectComponentToHaveChildren,
   expectComponentToHaveProps,
 } from 'lib/expect-helpers';
-import { getArrayOfLengthOfItem } from 'lib/get-array-of-length-of-item';
+import { Grid } from 'layout/Grid';
+import { GridColumn } from 'layout/GridColumn';
 import { Heading } from 'typography/Heading';
 import { IconCard } from 'elements/IconCard';
 
-import { sleepingArrangements } from './mock-data/sleepingArrangements';
 import { Component as SleepingArrangements } from './component';
+
+const sleepingArrangements = [
+  { iconName: 'bed', label: '1 king bed' },
+  { iconName: 'bed', label: '2 single beds' },
+  { iconName: 'paw', label: '1 kennel' },
+];
 
 const getSleepingArrangements = () =>
   shallow(<SleepingArrangements sleepingArrangements={sleepingArrangements} />);
@@ -26,7 +31,7 @@ describe('<SleepingArrangements />', () => {
   describe('the `div` element', () => {
     it('should render the right children', () => {
       const wrapper = getSleepingArrangements();
-      expectComponentToHaveChildren(wrapper, Heading, Label.Group);
+      expectComponentToHaveChildren(wrapper, Heading, Grid);
     });
   });
 
@@ -37,13 +42,12 @@ describe('<SleepingArrangements />', () => {
     });
   });
 
-  describe('the `Label.Group` component', () => {
+  describe('the `Grid` component', () => {
     it('should render an `IconCard` for each item in `props.sleepingArrangements`', () => {
-      const wrapper = getSleepingArrangements().find('LabelGroup');
-      expectComponentToHaveChildren(
-        wrapper,
-        ...getArrayOfLengthOfItem(sleepingArrangements.length, IconCard)
-      );
+      const wrapper = getSleepingArrangements().find(GridColumn);
+      wrapper.forEach((element, index) => {
+        expectComponentToHaveChildren(wrapper.at(index), IconCard);
+      });
     });
   });
 

--- a/src/components/widgets/SleepingArrangements/mock-data/sleepingArrangements.js
+++ b/src/components/widgets/SleepingArrangements/mock-data/sleepingArrangements.js
@@ -1,5 +1,0 @@
-export const sleepingArrangements = [
-  { iconName: 'bed', label: '1 king bed' },
-  { iconName: 'bed', label: '2 single beds' },
-  { iconName: 'paw', label: '1 kennel' },
-];


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-329)

### What **one** thing does this PR do?
Presenting the responsive version of the `SleepingArrangements` widget.

![screen shot 2018-04-24 at 9 45 01 am](https://user-images.githubusercontent.com/84540/39173174-3948d05a-47a4-11e8-8f14-a528ca803bfb.png)
![screen shot 2018-04-24 at 9 45 13 am](https://user-images.githubusercontent.com/84540/39173176-3b385228-47a4-11e8-9162-1ee64be3fa79.png)
