### PR TITLE
TE-337 DateRangePicker open up

### DIFF
--- a/src/components/elements/DateRangePicker/Readme.md
+++ b/src/components/elements/DateRangePicker/Readme.md
@@ -42,6 +42,12 @@
 />
 ```
 
+#### Calendar opens above input
+
+```jsx
+<DateRangePicker willOpenAbove />
+```
+
 ### Usage
 
 #### Block days

--- a/src/components/elements/DateRangePicker/component.js
+++ b/src/components/elements/DateRangePicker/component.js
@@ -10,6 +10,7 @@ import { Icon } from 'elements/Icon';
 import { InputController } from 'elements/InputController';
 
 import { pickDatesFromState } from './utils/pickDatesFromState';
+import { getOpenDirection } from './utils/getOpenDirection';
 import { getNumberOfMonths } from './utils/getNumberOfMonths';
 import { MAXIMUM_SCREEN_WIDTH_FOR_TWO_MONTH_CALENDAR } from './constants';
 
@@ -55,6 +56,7 @@ class Component extends PureComponent {
       isValid,
       name,
       startDatePlaceholderText,
+      willOpenAbove,
       windowInnerWidth,
     } = this.props;
     const { endDate, focusedInput, startDate } = this.state;
@@ -72,6 +74,7 @@ class Component extends PureComponent {
           displayFormat={displayFormat}
           endDatePlaceholderText={endDatePlaceholderText}
           isDayBlocked={getIsDayBlocked}
+          openDirection={getOpenDirection(willOpenAbove)}
           startDatePlaceholderText={startDatePlaceholderText}
           // Controlled props
           endDate={endDate}
@@ -108,6 +111,7 @@ Component.defaultProps = {
   name: '',
   onChange: Function.prototype,
   startDatePlaceholderText: '',
+  willOpenAbove: false,
   windowInnerWidth: MAXIMUM_SCREEN_WIDTH_FOR_TWO_MONTH_CALENDAR,
 };
 
@@ -138,6 +142,8 @@ Component.propTypes = {
   onChange: PropTypes.func,
   /** The visible placeholder text for the start date input. */
   startDatePlaceholderText: PropTypes.string,
+  /** Will the calendar open above the input. */
+  willOpenAbove: PropTypes.bool,
   /**
    * Is the user on a mobile device.
    * Provided by `withResponsive` so ignored in the styleguide.

--- a/src/components/elements/DateRangePicker/component.spec.js
+++ b/src/components/elements/DateRangePicker/component.spec.js
@@ -66,6 +66,7 @@ describe('<DateRangePicker />', () => {
         displayFormat: 'DD/MM/YYYY',
         endDatePlaceholderText: '',
         isDayBlocked: Function.prototype,
+        openDirection: expect.any(String),
         startDatePlaceholderText: '',
       });
     });

--- a/src/components/elements/DateRangePicker/utils/getOpenDirection.js
+++ b/src/components/elements/DateRangePicker/utils/getOpenDirection.js
@@ -1,0 +1,2 @@
+export const getOpenDirection = willOpenAbove =>
+  willOpenAbove ? 'up' : 'down';

--- a/src/components/elements/DateRangePicker/utils/getOpenDirection.spec.js
+++ b/src/components/elements/DateRangePicker/utils/getOpenDirection.spec.js
@@ -1,0 +1,13 @@
+import { getOpenDirection } from './getOpenDirection';
+
+describe('getOpenDirection', () => {
+  it('should return `up` if `willOpenAbove` is true', () => {
+    const actual = getOpenDirection(true);
+    expect(actual).toBe('up');
+  });
+
+  it('should return `down` if `willOpenAbove` is false', () => {
+    const actual = getOpenDirection(false);
+    expect(actual).toBe('down');
+  });
+});


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-337)

### What **one** thing does this PR do?
Exposes a new prop on `DateRangePicker` to get the calendar to open above the input.