### PR TITLE
TE-346 PropertyReviews responsive fix

### DIFF
--- a/src/components/general-widgets/Review/component.js
+++ b/src/components/general-widgets/Review/component.js
@@ -31,7 +31,7 @@ export const Component = ({
       <Card.Meta>
         <Grid>
           <GridRow verticalAlign="middle">
-            <GridColumn mobile={7} computer={6} floated="left">
+            <GridColumn mobile={7} tablet={7} computer={6} floated="left">
               <Subheading>
                 {getReviewerNameAndLocationString(
                   reviewerName,
@@ -41,6 +41,7 @@ export const Component = ({
             </GridColumn>
             <GridColumn
               mobile={5}
+              tablet={5}
               computer={6}
               floated="right"
               textAlign="right"

--- a/src/components/general-widgets/Review/component.spec.js
+++ b/src/components/general-widgets/Review/component.spec.js
@@ -143,6 +143,7 @@ describe('<Review />', () => {
       const wrapper = getFirstGridColumn();
       expectComponentToHaveProps(wrapper, {
         mobile: 7,
+        tablet: 7,
         computer: 6,
         floated: 'left',
       });
@@ -177,6 +178,7 @@ describe('<Review />', () => {
       const wrapper = getSecondGridColumn();
       expectComponentToHaveProps(wrapper, {
         mobile: 5,
+        tablet: 5,
         computer: 6,
         floated: 'right',
         textAlign: 'right',

--- a/src/components/property-page-widgets/Reviews/component.js
+++ b/src/components/property-page-widgets/Reviews/component.js
@@ -25,6 +25,7 @@ export const Component = ({ reviews, ratingAverage }) => (
     <GridRow verticalAlign="middle">
       <GridColumn
         mobile={5}
+        tablet={5}
         computer={6}
         textAlign="left"
         verticalAlign="middle"
@@ -40,6 +41,7 @@ export const Component = ({ reviews, ratingAverage }) => (
       </GridColumn>
       <GridColumn
         mobile={7}
+        tablet={7}
         computer={6}
         verticalAlign="middle"
         floated="right"

--- a/src/components/property-page-widgets/Reviews/component.spec.js
+++ b/src/components/property-page-widgets/Reviews/component.spec.js
@@ -117,6 +117,7 @@ describe('<Reviews />', () => {
 
         expectComponentToHaveProps(wrapper, {
           mobile: 5,
+          tablet: 5,
           computer: 6,
           textAlign: 'left',
           verticalAlign: 'middle',
@@ -143,6 +144,7 @@ describe('<Reviews />', () => {
 
         expectComponentToHaveProps(wrapper, {
           mobile: 7,
+          tablet: 7,
           computer: 6,
           verticalAlign: 'middle',
           floated: 'right',


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-346)

### What **one** thing does this PR do?
Adds a breakpoint for the tablet size so columns don't go out of line

### Any other notes
Did the same fix for the Review component as well

#### Reviews Widget
Desktop
![image](https://user-images.githubusercontent.com/10498995/39249934-14f76bd8-48a0-11e8-8f2d-d1e913d3927a.png)

Tablet
![image](https://user-images.githubusercontent.com/10498995/39256811-27170818-48b0-11e8-8bcc-95bcf28d4b2a.png)


Mobile
![image](https://user-images.githubusercontent.com/10498995/39249961-26621954-48a0-11e8-8e5b-bbdd00f61488.png)

#### Review widget

Desktop
![image](https://user-images.githubusercontent.com/10498995/39256773-0d84a752-48b0-11e8-8050-c82fa3452e7c.png)

Tablet
![image](https://user-images.githubusercontent.com/10498995/39256759-05201c86-48b0-11e8-8a3a-bdf449f6181f.png)

Mobile
![image](https://user-images.githubusercontent.com/10498995/39256733-eeac5636-48af-11e8-82bd-3147f22fa420.png)
