### PR TITLE
TE-338 Fix label

### DIFF
--- a/src/components/elements/IconCard/component.js
+++ b/src/components/elements/IconCard/component.js
@@ -17,7 +17,10 @@ export const Component = ({
   label,
   name,
 }) => (
-  <Label basic={!isFilled} className={cx({ 'left aligned': isLeftAligned })}>
+  <Label
+    basic={!isFilled}
+    className={cx('icon-card', { 'left aligned': isLeftAligned })}
+  >
     <Icon isDisabled={isDisabled} name={name} size="big" />
     {label && <Paragraph>{label}</Paragraph>}
   </Label>

--- a/src/components/elements/IconCard/component.spec.js
+++ b/src/components/elements/IconCard/component.spec.js
@@ -26,7 +26,7 @@ describe('<IconCard />', () => {
       expect(actual).toEqual(
         expect.objectContaining({
           basic: true,
-          className: '',
+          className: 'icon-card',
         })
       );
     });

--- a/src/semantic/src/themes/livingstone/elements/label.overrides
+++ b/src/semantic/src/themes/livingstone/elements/label.overrides
@@ -7,8 +7,6 @@
 --------------------*/
 
 .ui.label {
-  height: @keyFactsHeight;
-  width: @keyFactsWidth;
 
   /* Group */
 
@@ -19,16 +17,21 @@
   /* Link */
 
   /* Icon */
-  & > i.icon {
-    text-align: center;
-    width: 100%;
+  &.icon-card {
+    height: @iconCardHeight;
+    width: @iconCardWidth;
 
-    & + p {
-      display: block;
-      line-height: @iconCardTextLineHeight;
-      margin: @iconCardTextMargin;
+    & > i.icon {
       text-align: center;
-      white-space: nowrap;
+      width: 100%;
+
+      & + p {
+        display: block;
+        line-height: @iconCardTextLineHeight;
+        margin: @iconCardTextMargin;
+        text-align: center;
+        white-space: nowrap;
+      }
     }
   }
 
@@ -96,7 +99,7 @@
 
   /* Left aligned */
 
-  &.left.aligned {
+  &.left.aligned.icon-card {
 
     & > i.icon {
       margin-right: @leftAlignedIconCardMarginRight;

--- a/src/semantic/src/themes/livingstone/elements/label.variables
+++ b/src/semantic/src/themes/livingstone/elements/label.variables
@@ -23,6 +23,9 @@
 /* Link */
 
 /* Icon */
+@iconCardWidth: 8em;
+@iconCardHeight: 8.5em;
+
 @iconCardTextLineHeight: @12px;
 @iconCardTextMargin: @12px 0 0;
 
@@ -53,8 +56,6 @@
 --------------------*/
 
 /* Basic */
-@keyFactsWidth: 8em;
-@keyFactsHeight: 8.5em;
 @basicBorderColor: @greyThree;
 @basicBorder: @basicBorderWidth solid @basicBorderColor;
 @basicFontWeight: @bold;


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-338)

### What **one** thing does this PR do?
Fixes the breaking change on Semantic UI .ui.label

<img width="251" alt="screen shot 2018-04-26 at 14 54 36" src="https://user-images.githubusercontent.com/8591501/39306922-c42f2124-4961-11e8-80de-a8a3a65b0bb6.png">

Something *is* right...
