### PR TITLE
TE-343 Rules fixes

### DIFF
--- a/src/components/property-page-widgets/Rules/component.js
+++ b/src/components/property-page-widgets/Rules/component.js
@@ -22,9 +22,9 @@ export const Component = ({ checkInTime, checkOutTime, rules }) => (
       <List items={rules.map(rule => <Paragraph>{rule}</Paragraph>)} />
     </GridColumn>
     <GridColumn computer={9} tablet={7}>
-      <Icon label={`Check in: ${checkInTime}`} name="checkin" />
+      <Icon label={`Check in: ${checkInTime}`} name="question mark" />
       <Divider />
-      <Icon label={`Check out: ${checkOutTime}`} name="checkout" />
+      <Icon label={`Check out: ${checkOutTime}`} name="question mark" />
     </GridColumn>
   </Grid>
 );

--- a/src/components/property-page-widgets/Rules/component.js
+++ b/src/components/property-page-widgets/Rules/component.js
@@ -2,10 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { List } from 'semantic-ui-react';
 
-import { getParagraphsFromStrings } from 'lib/get-paragraphs-from-strings';
 import { Grid } from 'layout/Grid';
 import { GridColumn } from 'layout/GridColumn';
+import { Divider } from 'elements/Divider';
 import { Heading } from 'typography/Heading';
+import { Paragraph } from 'typography/Paragraph';
 import { Icon } from 'elements/Icon';
 
 /**
@@ -15,36 +16,15 @@ import { Icon } from 'elements/Icon';
 export const Component = ({ checkInTime, checkOutTime, rules }) => (
   <Grid stackable>
     <GridColumn width={12}>
-      <Heading size="small">House Rules</Heading>
+      <Heading>House Rules</Heading>
     </GridColumn>
-    <GridColumn width={3}>
-      <List items={getParagraphsFromStrings(rules.join('\n'))} />
+    <GridColumn computer={3} tablet={5}>
+      <List items={rules.map(rule => <Paragraph>{rule}</Paragraph>)} />
     </GridColumn>
-    <GridColumn width={2}>
-      <Grid verticalAlign="middle">
-        <GridColumn width={3}>
-          <Icon name="bed" />
-        </GridColumn>
-        <GridColumn width={9}>
-          <div>
-            <b>Check-in</b>
-          </div>
-          <span className="header">{checkInTime}</span>
-        </GridColumn>
-      </Grid>
-    </GridColumn>
-    <GridColumn width={2}>
-      <Grid verticalAlign="middle">
-        <GridColumn width={3}>
-          <Icon name="question mark" />
-        </GridColumn>
-        <GridColumn width={9}>
-          <div>
-            <b>Check-out</b>
-          </div>
-          <span className="header">{checkOutTime}</span>
-        </GridColumn>
-      </Grid>
+    <GridColumn computer={9} tablet={7}>
+      <Icon label={`Check in: ${checkInTime}`} name="checkin" />
+      <Divider />
+      <Icon label={`Check out: ${checkOutTime}`} name="checkout" />
     </GridColumn>
   </Grid>
 );

--- a/src/components/property-page-widgets/Rules/component.spec.js
+++ b/src/components/property-page-widgets/Rules/component.spec.js
@@ -9,9 +9,9 @@ import {
   expectComponentToBe,
 } from 'lib/expect-helpers';
 import { getArrayOfLengthOfItem } from 'lib/get-array-of-length-of-item';
-import { getParagraphsFromStrings } from 'lib/get-paragraphs-from-strings';
 import { Grid } from 'layout/Grid';
 import { GridColumn } from 'layout/GridColumn';
+import { Divider } from 'elements/Divider';
 import { Heading } from 'typography/Heading';
 import { Icon } from 'elements/Icon';
 
@@ -51,7 +51,7 @@ describe('<Rules />', () => {
       const wrapper = getRules();
       expectComponentToHaveChildren(
         wrapper,
-        ...getArrayOfLengthOfItem(4, GridColumn)
+        ...getArrayOfLengthOfItem(3, GridColumn)
       );
     });
   });
@@ -76,17 +76,8 @@ describe('<Rules />', () => {
   });
 
   describe('the `Heading` component', () => {
-    const getHeading = () => getRules().find(Heading);
-
-    it('should have the right props', () => {
-      const wrapper = getHeading();
-      expectComponentToHaveProps(wrapper, {
-        size: 'small',
-      });
-    });
-
     it('should render the right children', () => {
-      const wrapper = getHeading();
+      const wrapper = getRules().find(Heading);
       expectComponentToHaveChildren(wrapper, 'House Rules');
     });
   });
@@ -100,7 +91,8 @@ describe('<Rules />', () => {
     it('should have the right props', () => {
       const wrapper = getSecondGridColumn();
       expectComponentToHaveProps(wrapper, {
-        width: 3,
+        computer: 3,
+        tablet: 5,
       });
     });
 
@@ -110,32 +102,12 @@ describe('<Rules />', () => {
     });
   });
 
-  describe('the second `GridColumn` component', () => {
-    const getSecondGridColumn = () =>
-      getRules()
-        .find(GridColumn)
-        .at(1);
-
+  describe('the `List` component', () => {
     it('should have the right props', () => {
-      const wrapper = getSecondGridColumn();
+      const wrapper = getRules().find(List);
       expectComponentToHaveProps(wrapper, {
-        width: 3,
+        items: expect.any(Array),
       });
-    });
-
-    it('should render the right children', () => {
-      const wrapper = getSecondGridColumn();
-      expectComponentToHaveChildren(wrapper, List);
-    });
-
-    it('should have the right props', () => {
-      const wrapper = getSecondGridColumn().find(List);
-      const actual = wrapper.props();
-      expect(actual).toEqual(
-        expect.objectContaining({
-          items: getParagraphsFromStrings(rules.join('\n')),
-        })
-      );
     });
   });
 
@@ -148,82 +120,38 @@ describe('<Rules />', () => {
     it('should have the right props', () => {
       const wrapper = getThirdGridColumn();
       expectComponentToHaveProps(wrapper, {
-        width: 2,
+        computer: 9,
+        tablet: 7,
       });
     });
 
     it('should render the right children', () => {
       const wrapper = getThirdGridColumn();
-      expectComponentToHaveChildren(wrapper, Grid);
+      expectComponentToHaveChildren(wrapper, Icon, Divider, Icon);
     });
   });
 
-  describe('the second `Grid` component', () => {
-    it('should render the right children', () => {
+  describe('the first `Icon` in the second `Grid` component', () => {
+    it('should have the right props', () => {
       const wrapper = getRules()
-        .find(Grid)
-        .at(1);
-
-      expectComponentToHaveChildren(
-        wrapper,
-        ...getArrayOfLengthOfItem(2, GridColumn)
-      );
-    });
-  });
-
-  describe('each `GridColumn` in the second `Grid` component', () => {
-    const getGridColumnInSecondGrid = () =>
-      getRules()
-        .find(Grid)
-        .at(1)
-        .children(GridColumn)
-        .first();
-
-    it('should have the right props', () => {
-      const wrapper = getGridColumnInSecondGrid();
-      expectComponentToHaveProps(wrapper, {
-        width: 3,
-      });
-    });
-
-    it('should render the right children', () => {
-      const wrapper = getGridColumnInSecondGrid();
-      expectComponentToHaveChildren(wrapper, Icon);
-    });
-  });
-
-  describe('each `Icon` in the second `Grid` component', () => {
-    const getIconCardInSecondGrid = () =>
-      getRules()
-        .find(Grid)
-        .at(1)
         .find(Icon)
-        .first();
-
-    it('should have the right props', () => {
-      const wrapper = getIconCardInSecondGrid();
+        .at(0);
       expectComponentToHaveProps(wrapper, {
-        name: expect.any(String),
+        label: expect.stringContaining('Check in:'),
+        name: 'question mark',
       });
     });
   });
 
-  describe('the fourth `GridColumn` component', () => {
-    const getFourthGridColumn = () =>
-      getRules()
-        .find(GridColumn)
-        .at(5);
-
+  describe('the second `Icon` in the second `Grid` component', () => {
     it('should have the right props', () => {
-      const wrapper = getFourthGridColumn();
+      const wrapper = getRules()
+        .find(Icon)
+        .at(1);
       expectComponentToHaveProps(wrapper, {
-        width: 2,
+        label: expect.stringContaining('Check out:'),
+        name: 'question mark',
       });
-    });
-
-    it('should render the right children', () => {
-      const wrapper = getFourthGridColumn();
-      expectComponentToHaveChildren(wrapper, Grid);
     });
   });
 


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-343)

### What **one** thing does this PR do?
Fixes errors in the responsive behaviour of the Rules widget.

### Any other notes
I agreed with Julio to use a simple `Icon` with a label for Checkin/Checkout. Saves a bunch of complication.

Desktop
<img width="491" alt="screen shot 2018-04-26 at 15 10 23" src="https://user-images.githubusercontent.com/8591501/39307781-0b34bffa-4964-11e8-8ce1-f07dab287293.png">

Tablet
<img width="477" alt="screen shot 2018-04-26 at 15 10 37" src="https://user-images.githubusercontent.com/8591501/39307782-0b5e2aac-4964-11e8-84f9-e990b13a90f7.png">

Mobile
<img width="368" alt="screen shot 2018-04-26 at 15 10 47" src="https://user-images.githubusercontent.com/8591501/39307783-0b7b938a-4964-11e8-915f-4dac986babd2.png">


