### PR TITLE
TE-348 Multiline Label

### DIFF
--- a/src/components/elements/IconCard/Readme.md
+++ b/src/components/elements/IconCard/Readme.md
@@ -18,6 +18,14 @@
 <div>
   <IconCard label="Fireplace" name="fire" />
   <Divider />
+  <IconCard
+    label={`
+      Wow
+      Multiline
+    `}
+    name="fire"
+  />
+  <Divider />
   <IconCard isDisabled label="Fireplace" name="fire" />
 </div>
 ```

--- a/src/components/elements/IconCard/component.js
+++ b/src/components/elements/IconCard/component.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import { Label } from 'semantic-ui-react';
 import cx from 'classnames';
 
+import { getParagraphsFromStrings } from 'lib/get-paragraphs-from-strings';
+import { getUniqueKey } from 'lib/get-unique-key';
 import { Icon } from 'elements/Icon';
 import { Paragraph } from 'typography/Paragraph';
 
@@ -22,7 +24,10 @@ export const Component = ({
     className={cx('icon-card', { 'left aligned': isLeftAligned })}
   >
     <Icon isDisabled={isDisabled} name={name} size="big" />
-    {label && <Paragraph>{label}</Paragraph>}
+    {label &&
+      getParagraphsFromStrings(label).map((paragraph, index) => (
+        <Paragraph key={getUniqueKey(paragraph, index)}>{paragraph}</Paragraph>
+      ))}
   </Label>
 );
 

--- a/src/components/elements/IconCard/component.spec.js
+++ b/src/components/elements/IconCard/component.spec.js
@@ -2,6 +2,12 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { Label } from 'semantic-ui-react';
 
+import {
+  expectComponentToBe,
+  expectComponentToHaveProps,
+  expectComponentToHaveChildren,
+  expectComponentToHaveDisplayName,
+} from 'lib/expect-helpers';
 import { Icon } from 'elements/Icon';
 import { Paragraph } from 'typography/Paragraph';
 
@@ -15,63 +21,63 @@ const getLabel = () => getIconCard().find(Label);
 describe('<IconCard />', () => {
   it('should render a single Semantic UI `Label` component', () => {
     const wrapper = getIconCard();
-    const actual = wrapper.find(Label);
-    expect(actual).toHaveLength(1);
+    expectComponentToBe(wrapper, Label);
   });
 
   describe('the `Label` component', () => {
     it('should get the right props', () => {
       const wrapper = getLabel();
-      const actual = wrapper.props();
-      expect(actual).toEqual(
-        expect.objectContaining({
-          basic: true,
-          className: 'icon-card',
-        })
-      );
+      expectComponentToHaveProps(wrapper, {
+        basic: true,
+        className: 'icon-card',
+      });
     });
 
     it('should render a single Lodgify UI `Icon` component', () => {
       const wrapper = getLabel();
-      const actual = wrapper.find(Icon);
-      expect(actual).toHaveLength(1);
+      expectComponentToHaveChildren(wrapper, Icon);
     });
   });
 
   describe('the `Icon` component', () => {
     it('should get the right props', () => {
       const wrapper = getIconCard().find(Icon);
-      const actual = wrapper.props();
-      expect(actual).toEqual(
-        expect.objectContaining({
-          isDisabled: false,
-          name,
-          size: 'big',
-        })
-      );
+      expectComponentToHaveProps(wrapper, {
+        isDisabled: false,
+        name,
+        size: 'big',
+      });
     });
   });
 
-  describe('if a label prop is passed', () => {
+  describe('if a single line string label prop is passed', () => {
     it('should render a single Lodgify UI `Paragraph` component', () => {
       const label = '🐘';
       const wrapper = getIconCard({ label });
-      const actual = wrapper.find(Paragraph);
-      expect(actual).toHaveLength(1);
+      expectComponentToHaveChildren(wrapper, Icon, Paragraph);
     });
   });
 
-  describe('the Lodgify UI `Paragraph` component', () => {
-    it('should get the right children prop', () => {
-      const label = '🐘';
+  describe('if a multiline string label prop is passed', () => {
+    it('should render more than one Lodgify UI `Paragraph` component', () => {
+      const label = `
+        🐘
+        🐘
+      `;
       const wrapper = getIconCard({ label });
-      const actual = wrapper.find(Paragraph).prop('children');
-      expect(actual).toBe(label);
+      expectComponentToHaveChildren(wrapper, Icon, Paragraph, Paragraph);
+    });
+  });
+
+  describe('each Lodgify UI `Paragraph` component', () => {
+    it('should have the right children', () => {
+      const label = '🐘';
+      const wrapper = getIconCard({ label }).find(Paragraph);
+      expectComponentToHaveChildren(wrapper, label);
     });
   });
 
   it('should have displayName `IconCard`', () => {
-    const actual = IconCard.displayName;
-    expect(actual).toBe('IconCard');
+    expectComponentToHaveDisplayName(IconCard, 'IconCard');
   });
 });

--- a/src/semantic/src/themes/livingstone/elements/label.overrides
+++ b/src/semantic/src/themes/livingstone/elements/label.overrides
@@ -18,19 +18,23 @@
 
   /* Icon */
   &.icon-card {
+    align-items: center;
+    display: flex;
+    flex-direction: column;
     height: @iconCardHeight;
+    justify-content: center;
     width: @iconCardWidth;
 
     & > i.icon {
-      text-align: center;
-      width: 100%;
+      margin: 0;
+    }
 
-      & + p {
-        display: block;
-        line-height: @iconCardTextLineHeight;
+    & > p {
+      line-height: @iconCardTextLineHeight;
+      white-space: nowrap;
+
+      &:nth-child(2) {
         margin: @iconCardTextMargin;
-        text-align: center;
-        white-space: nowrap;
       }
     }
   }
@@ -92,7 +96,7 @@
 
   & > i.inverted.grey.icon {
 
-    & + p {
+    & ~ p {
       color: @disabledIconCardColor;
     }
   }
@@ -100,15 +104,7 @@
   /* Left aligned */
 
   &.left.aligned.icon-card {
-
-    & > i.icon {
-      margin-right: @leftAlignedIconCardMarginRight;
-      text-align: left;
-
-      & + p {
-        text-align: left;
-      }
-    }
+    align-items: flex-start;
   }
 
   /*-------------------

--- a/src/semantic/src/themes/livingstone/elements/label.variables
+++ b/src/semantic/src/themes/livingstone/elements/label.variables
@@ -26,7 +26,7 @@
 @iconCardWidth: 8em;
 @iconCardHeight: 8.5em;
 
-@iconCardTextLineHeight: @12px;
+@iconCardTextLineHeight: @15px;
 @iconCardTextMargin: @12px 0 0;
 
 /* Image */
@@ -86,7 +86,6 @@
 @disabledIconCardColor: @lightGrey;
 
 /* Left aligned */
-@leftAlignedIconCardMarginRight: 65px;
 
 /*-------------------
         Group


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-348)

### What **one** thing does this PR do?
Changes `IconCard` to accept multiline strings as `props.label`

<img width="457" alt="screen shot 2018-04-26 at 16 33 02" src="https://user-images.githubusercontent.com/8591501/39312291-872b3584-496f-11e8-9785-945a5ce1282c.png">
