### PR TITLE
TE-341 Location fixes

### DIFF
--- a/src/components/property-page-widgets/Location/component.js
+++ b/src/components/property-page-widgets/Location/component.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import { getParagraphsFromStrings } from 'lib/get-paragraphs-from-strings';
 import { getUniqueKey } from 'lib/get-unique-key';
-import { getFirstFourItems } from 'lib/get-first-four-items';
+import { withResponsive } from 'lib/with-responsive';
 import { Divider } from 'elements/Divider';
 import { GoogleMap } from 'elements/GoogleMap';
 import { Grid } from 'layout/Grid';
@@ -13,17 +13,18 @@ import { ShowOnMobile } from 'layout/ShowOnMobile';
 import { Heading } from 'typography/Heading';
 import { Paragraph } from 'typography/Paragraph';
 import { Subheading } from 'typography/Subheading';
-import { IconCard } from 'elements/IconCard';
 
-import { getTransportOptionLabel } from './utils/getTransportOptionLabel';
+import { getTransportOptionsMarkup } from './utils/getTransportOptionsMarkup';
+import { getGoogleMapHeight } from './utils/getGoogleMapHeight';
 
 /**
  * The standard widget for displaying the location of a property.
  * @returns {Object}
  */
-export const Component = ({
+const Component = ({
   isShowingApproximateLocation,
   isShowingExactLocation,
+  isUserOnMobile,
   latitude,
   locationDescription,
   locationSummary,
@@ -35,7 +36,7 @@ export const Component = ({
       <Heading>Location</Heading>
       <Subheading>{locationSummary}</Subheading>
     </GridColumn>
-    <GridColumn width={6}>
+    <GridColumn computer={6} tablet={12}>
       {getParagraphsFromStrings(locationDescription).map(
         (paragraphText, index) => (
           <Paragraph key={getUniqueKey(paragraphText, index)}>
@@ -44,51 +45,24 @@ export const Component = ({
         )
       )}
     </GridColumn>
-    <ShowOnDesktop parent={GridColumn} parentProps={{ width: 6 }}>
-      <Grid>
-        {getFirstFourItems(transportOptions).map(
-          ({ distance, iconName, label }, index) => (
-            <GridColumn key={getUniqueKey(label, index)} width={3}>
-              <IconCard
-                isFilled
-                label={getTransportOptionLabel(distance, label)}
-                name={iconName}
-              />
-            </GridColumn>
-          )
-        )}
-      </Grid>
+    <ShowOnDesktop
+      parent={GridColumn}
+      parentProps={{ computer: 6, tablet: 12 }}
+    >
+      {getTransportOptionsMarkup(transportOptions)}
     </ShowOnDesktop>
-    <ShowOnDesktop parent={GridColumn} parentProps={{ width: 12 }}>
+    <GridColumn width={12}>
       <GoogleMap
+        height={getGoogleMapHeight(isUserOnMobile)}
         isShowingExactLocation={isShowingExactLocation}
         isShowingApproximateLocation={isShowingApproximateLocation}
         latitude={latitude}
         longitude={longitude}
       />
-    </ShowOnDesktop>
+    </GridColumn>
     <ShowOnMobile parent={GridColumn} parentProps={{ width: 12 }}>
-      <GoogleMap
-        height="200px"
-        isShowingExactLocation={isShowingExactLocation}
-        isShowingApproximateLocation={isShowingApproximateLocation}
-        latitude={latitude}
-        longitude={longitude}
-      />
       <Divider />
-      <Grid>
-        {getFirstFourItems(transportOptions).map(
-          ({ distance, iconName, label }, index) => (
-            <GridColumn key={getUniqueKey(label, index)} width={3}>
-              <IconCard
-                isFilled
-                label={getTransportOptionLabel(distance, label)}
-                name={iconName}
-              />
-            </GridColumn>
-          )
-        )}
-      </Grid>
+      {getTransportOptionsMarkup(transportOptions)}
     </ShowOnMobile>
   </Grid>
 );
@@ -105,6 +79,12 @@ Component.propTypes = {
   isShowingApproximateLocation: PropTypes.bool,
   /** Is the map showing a marker for the exact location. */
   isShowingExactLocation: PropTypes.bool,
+  /**
+   * Is the user on a mobile device.
+   * Provided by `withResponsive` so ignored in the styleguide.
+   * @ignore
+   */
+  isUserOnMobile: PropTypes.bool.isRequired,
   /** The latitude coordinate for the center of the map and/or location of the marker */
   latitude: PropTypes.number.isRequired,
   /** The text description of the location. */
@@ -128,3 +108,5 @@ Component.propTypes = {
     })
   ).isRequired,
 };
+
+export const ComponentWithResponsive = withResponsive(Component);

--- a/src/components/property-page-widgets/Location/component.spec.js
+++ b/src/components/property-page-widgets/Location/component.spec.js
@@ -1,9 +1,12 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import { Label, Responsive } from 'semantic-ui-react';
 
 import {
+  expectComponentToBe,
   expectComponentToHaveChildren,
   expectComponentToHaveProps,
+  expectComponentToHaveDisplayName,
 } from 'lib/expect-helpers';
 import { getArrayOfLengthOfItem } from 'lib/get-array-of-length-of-item';
 import { getParagraphsFromStrings } from 'lib/get-paragraphs-from-strings';
@@ -15,7 +18,6 @@ import { Divider } from 'elements/Divider';
 import { Heading } from 'typography/Heading';
 import { Subheading } from 'typography/Subheading';
 import { Paragraph } from 'typography/Paragraph';
-import { IconCard } from 'elements/IconCard';
 import { GoogleMap } from 'elements/GoogleMap';
 
 import {
@@ -23,7 +25,7 @@ import {
   locationSummary,
   transportOptions,
 } from './mock-data/props';
-import { Component as Location } from './component';
+import { ComponentWithResponsive as Location } from './component';
 
 const props = {
   locationDescription,
@@ -34,17 +36,27 @@ const props = {
 };
 
 const getLocation = () => shallow(<Location {...props} />);
+const getWrappedLocation = () => {
+  const Child = getLocation().prop('as');
+  return shallow(<Child {...props} isUserOnMobile={false} />);
+};
 
 describe('<Location />', () => {
-  it('should render a single Lodgify UI `Grid` component', () => {
+  it('should be wrapped in a Semantic UI `Responsive` component', () => {
     const wrapper = getLocation();
-    const actual = wrapper.is(Grid);
-    expect(actual).toBe(true);
+    expectComponentToBe(wrapper, Responsive);
+  });
+
+  describe('the wrapped `Location` component', () => {
+    it('should be a Lodgify UI `Grid`', () => {
+      const wrapper = getWrappedLocation();
+      expectComponentToBe(wrapper, Grid);
+    });
   });
 
   describe('the first `Grid` component', () => {
     it('should render the right props', () => {
-      const wrapper = getLocation();
+      const wrapper = getWrappedLocation();
       expectComponentToHaveProps(wrapper, {
         stackable: true,
       });
@@ -53,11 +65,12 @@ describe('<Location />', () => {
 
   describe('the first `Grid` component', () => {
     it('should render the right children', () => {
-      const wrapper = getLocation();
+      const wrapper = getWrappedLocation();
       expectComponentToHaveChildren(
         wrapper,
         ...getArrayOfLengthOfItem(2, GridColumn),
-        ...getArrayOfLengthOfItem(2, ShowOnDesktop),
+        ShowOnDesktop,
+        GridColumn,
         ShowOnMobile
       );
     });
@@ -65,7 +78,7 @@ describe('<Location />', () => {
 
   describe('the first `GridColumn` component', () => {
     const getFirstGridColumn = () =>
-      getLocation()
+      getWrappedLocation()
         .find(GridColumn)
         .at(0);
 
@@ -84,14 +97,14 @@ describe('<Location />', () => {
 
   describe('the `Heading` component', () => {
     it('should render the right children', () => {
-      const wrapper = getLocation().find(Heading);
+      const wrapper = getWrappedLocation().find(Heading);
       expectComponentToHaveChildren(wrapper, 'Location');
     });
   });
 
   describe('the `Subheading` component', () => {
     it('should render the right children', () => {
-      const wrapper = getLocation()
+      const wrapper = getWrappedLocation()
         .find(Subheading)
         .at(0);
       expectComponentToHaveChildren(wrapper, locationSummary);
@@ -100,14 +113,15 @@ describe('<Location />', () => {
 
   describe('the second `GridColumn` component', () => {
     const getSecondGridColumn = () =>
-      getLocation()
+      getWrappedLocation()
         .find(GridColumn)
         .at(1);
 
     it('should have the right props', () => {
       const wrapper = getSecondGridColumn();
       expectComponentToHaveProps(wrapper, {
-        width: 6,
+        computer: 6,
+        tablet: 12,
       });
     });
 
@@ -119,7 +133,7 @@ describe('<Location />', () => {
 
   describe('each `Paragraph` in the second `GridColumn` component', () => {
     const getParagraphInSecondGridColumn = () =>
-      getLocation()
+      getWrappedLocation()
         .find(GridColumn)
         .at(1)
         .children(Paragraph);
@@ -131,107 +145,31 @@ describe('<Location />', () => {
     });
   });
 
-  describe('the first `ShowOnDesktop` component', () => {
-    const getFirstShowOnDesktop = () =>
-      getLocation()
-        .find(ShowOnDesktop)
-        .at(0);
+  describe('the `ShowOnDesktop` component', () => {
+    const getShowOnDesktop = () => getWrappedLocation().find(ShowOnDesktop);
 
     it('should have the right props', () => {
-      const wrapper = getFirstShowOnDesktop();
+      const wrapper = getShowOnDesktop();
       expectComponentToHaveProps(wrapper, {
         parent: GridColumn,
         parentProps: {
-          width: 6,
+          computer: 6,
+          tablet: 12,
         },
       });
     });
 
     it('should render the right children', () => {
-      const wrapper = getFirstShowOnDesktop();
-      expectComponentToHaveChildren(wrapper, Grid);
+      const wrapper = getShowOnDesktop();
+      expectComponentToHaveChildren(wrapper, Label.Group);
     });
   });
 
-  describe('the second `Grid` component', () => {
-    it('should render the right children', () => {
-      const wrapper = getLocation()
-        .find(Grid)
-        .at(1);
-      expectComponentToHaveChildren(
-        wrapper,
-        ...getArrayOfLengthOfItem(4, GridColumn)
-      );
-    });
-  });
-
-  describe('each `GridColumn` in the second `Grid` component', () => {
-    const getGridColumnInSecondGrid = () =>
-      getLocation()
-        .find(Grid)
-        .at(1)
-        .children(GridColumn)
-        .first();
-
+  describe('the `GoogleMap` component', () => {
     it('should have the right props', () => {
-      const wrapper = getGridColumnInSecondGrid();
+      const wrapper = getWrappedLocation().find(GoogleMap);
       expectComponentToHaveProps(wrapper, {
-        width: 3,
-      });
-    });
-
-    it('should render the right children', () => {
-      const wrapper = getGridColumnInSecondGrid();
-      expectComponentToHaveChildren(wrapper, IconCard);
-    });
-  });
-
-  describe('each `IconCard` in the second `Grid` component', () => {
-    const getIconCardInSecondGrid = () =>
-      getLocation()
-        .find(Grid)
-        .at(1)
-        .find(IconCard)
-        .first();
-
-    it('should have the right props', () => {
-      const wrapper = getIconCardInSecondGrid();
-      expectComponentToHaveProps(wrapper, {
-        isFilled: true,
-        label: expect.any(String),
-        name: transportOptions[0].iconName,
-      });
-    });
-  });
-
-  describe('the second `ShowOnDesktop` component', () => {
-    const getSecondShowOnDesktop = () =>
-      getLocation()
-        .find(ShowOnDesktop)
-        .at(1);
-
-    it('should have the right props', () => {
-      const wrapper = getSecondShowOnDesktop();
-      expectComponentToHaveProps(wrapper, {
-        parent: GridColumn,
-        parentProps: {
-          width: 12,
-        },
-      });
-    });
-
-    it('should render the right children', () => {
-      const wrapper = getSecondShowOnDesktop();
-      expectComponentToHaveChildren(wrapper, GoogleMap);
-    });
-  });
-
-  describe('the first `GoogleMap` component', () => {
-    it('should have the right props', () => {
-      const wrapper = getLocation()
-        .find(GoogleMap)
-        .at(0);
-      expectComponentToHaveProps(wrapper, {
+        height: GoogleMap.defaultProps.height,
         isShowingExactLocation: false,
         isShowingApproximateLocation: false,
         latitude: props.latitude,
@@ -240,12 +178,11 @@ describe('<Location />', () => {
     });
   });
 
-  describe('the first `ShowOnMobile` component', () => {
-    const wrapper = getLocation()
-      .find(ShowOnMobile)
-      .first();
+  describe('the `ShowOnMobile` component', () => {
+    const getShowOnMobile = () => getWrappedLocation().find(ShowOnMobile);
 
     it('should have the right props', () => {
+      const wrapper = getShowOnMobile();
       expectComponentToHaveProps(wrapper, {
         parent: GridColumn,
         parentProps: {
@@ -255,63 +192,13 @@ describe('<Location />', () => {
     });
 
     it('should render the right children', () => {
-      expectComponentToHaveChildren(wrapper, GoogleMap, Divider, Grid);
-    });
-  });
-
-  describe('the third `Grid` component', () => {
-    it('should render the right children', () => {
-      const wrapper = getLocation()
-        .find(Grid)
-        .at(2);
-      expectComponentToHaveChildren(
-        wrapper,
-        ...getArrayOfLengthOfItem(4, GridColumn)
-      );
-    });
-  });
-
-  describe('each `GridColumn` in the third `Grid` component', () => {
-    const getGridColumnInThirdGrid = () =>
-      getLocation()
-        .find(Grid)
-        .at(2)
-        .children(GridColumn)
-        .first();
-
-    it('should have the right props', () => {
-      const wrapper = getGridColumnInThirdGrid();
-      expectComponentToHaveProps(wrapper, {
-        width: 3,
-      });
-    });
-
-    it('should render the right children', () => {
-      const wrapper = getGridColumnInThirdGrid();
-      expectComponentToHaveChildren(wrapper, IconCard);
-    });
-  });
-
-  describe('each `IconCard` in the third `Grid` component', () => {
-    const getIconCardInThirdGrid = () =>
-      getLocation()
-        .find(Grid)
-        .at(2)
-        .find(IconCard)
-        .first();
-
-    it('should have the right props', () => {
-      const wrapper = getIconCardInThirdGrid();
-      expectComponentToHaveProps(wrapper, {
-        isFilled: true,
-        label: expect.any(String),
-        name: transportOptions[0].iconName,
-      });
+      const wrapper = getShowOnMobile();
+      expectComponentToHaveChildren(wrapper, Divider, Label.Group);
     });
   });
 
   it('should have `displayName` `Location`', () => {
-    const actual = Location.displayName;
-    expect(actual).toBe('Location');
+    const component = getLocation().prop('as');
+    expectComponentToHaveDisplayName(component, 'Location');
   });
 });

--- a/src/components/property-page-widgets/Location/index.js
+++ b/src/components/property-page-widgets/Location/index.js
@@ -1,1 +1,1 @@
-export { Component as Location } from './component';
+export { ComponentWithResponsive as Location } from './component';

--- a/src/components/property-page-widgets/Location/utils/getGoogleMapHeight.js
+++ b/src/components/property-page-widgets/Location/utils/getGoogleMapHeight.js
@@ -1,0 +1,6 @@
+/**
+ * @param  {Boolean} shouldBe200px
+ * @return {Number|undefined}
+ */
+export const getGoogleMapHeight = shouldBe200px =>
+  shouldBe200px ? '200px' : undefined;

--- a/src/components/property-page-widgets/Location/utils/getGoogleMapHeight.spec.js
+++ b/src/components/property-page-widgets/Location/utils/getGoogleMapHeight.spec.js
@@ -1,0 +1,13 @@
+import { getGoogleMapHeight } from './getGoogleMapHeight';
+
+describe('getGoogleMapHeight', () => {
+  it('should return `200px` if `shouldBe200px` is true', () => {
+    const actual = getGoogleMapHeight(true);
+    expect(actual).toBe('200px');
+  });
+
+  it('should return `undefined` if `shouldBe200px` is false', () => {
+    const actual = getGoogleMapHeight(false);
+    expect(actual).toBeUndefined();
+  });
+});

--- a/src/components/property-page-widgets/Location/utils/getTransportOptionLabel.js
+++ b/src/components/property-page-widgets/Location/utils/getTransportOptionLabel.js
@@ -4,5 +4,7 @@
  * @param  {String} label
  * @return {String}
  */
-export const getTransportOptionLabel = (distance, label) =>
-  `${distance} ${label}`;
+export const getTransportOptionLabel = (distance, label) => `
+  ${distance}
+  ${label}
+`;

--- a/src/components/property-page-widgets/Location/utils/getTransportOptionLabel.spec.js
+++ b/src/components/property-page-widgets/Location/utils/getTransportOptionLabel.spec.js
@@ -5,6 +5,9 @@ describe('getTransportOptionLabel', () => {
     const distance = '🚣';
     const label = 'someLabel';
     const actual = getTransportOptionLabel(distance, label);
-    expect(actual).toBe(`${distance} ${label}`);
+    expect(actual).toBe(`
+  ${distance}
+  ${label}
+`);
   });
 });

--- a/src/components/property-page-widgets/Location/utils/getTransportOptionsMarkup.js
+++ b/src/components/property-page-widgets/Location/utils/getTransportOptionsMarkup.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Label } from 'semantic-ui-react';
+
+import { getUniqueKey } from 'lib/get-unique-key';
+import { getFirstFourItems } from 'lib/get-first-four-items';
+import { IconCard } from 'elements/IconCard';
+
+import { getTransportOptionLabel } from './getTransportOptionLabel';
+
+export const getTransportOptionsMarkup = transportOptions => (
+  <Label.Group>
+    {getFirstFourItems(transportOptions).map(
+      ({ distance, iconName, label }, index) => (
+        <IconCard
+          isFilled
+          key={getUniqueKey(label, index)}
+          label={getTransportOptionLabel(distance, label)}
+          name={iconName}
+        />
+      )
+    )}
+  </Label.Group>
+);

--- a/src/components/property-page-widgets/Location/utils/getTransportOptionsMarkup.spec.js
+++ b/src/components/property-page-widgets/Location/utils/getTransportOptionsMarkup.spec.js
@@ -1,0 +1,49 @@
+import { shallow } from 'enzyme';
+
+import {
+  expectComponentToBe,
+  expectComponentToHaveChildren,
+  expectComponentToHaveProps,
+} from 'lib/expect-helpers';
+import { getArrayOfLengthOfItem } from 'lib/get-array-of-length-of-item';
+import { IconCard } from 'elements/IconCard';
+
+import { transportOptions } from '../mock-data/props';
+
+import { getTransportOptionsMarkup } from './getTransportOptionsMarkup';
+
+const getLabelGroup = () =>
+  shallow(getTransportOptionsMarkup(transportOptions));
+
+describe('getTransportOptionsMarkup', () => {
+  it('should return a Semantic UI `Label.Group`', () => {
+    const wrapper = getLabelGroup();
+    expectComponentToBe(wrapper, 'div.ui.labels');
+  });
+
+  describe('the `Label.Group`', () => {
+    it('should render the right children', () => {
+      const wrapper = getLabelGroup();
+      expectComponentToHaveChildren(
+        wrapper,
+        ...getArrayOfLengthOfItem(4, IconCard)
+      );
+    });
+  });
+
+  describe('each `IconCard` in the second `Grid` component', () => {
+    const getIconCard = () =>
+      getLabelGroup()
+        .find(IconCard)
+        .first();
+
+    it('should have the right props', () => {
+      const wrapper = getIconCard();
+      expectComponentToHaveProps(wrapper, {
+        isFilled: true,
+        label: expect.any(String),
+        name: transportOptions[0].iconName,
+      });
+    });
+  });
+});

--- a/src/semantic/src/themes/livingstone/elements/label.overrides
+++ b/src/semantic/src/themes/livingstone/elements/label.overrides
@@ -19,7 +19,7 @@
   /* Icon */
   &.icon-card {
     align-items: center;
-    display: flex;
+    display: inline-flex;
     flex-direction: column;
     height: @iconCardHeight;
     justify-content: center;


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-341)

### What **one** thing does this PR do?
Implements fixes for the Location widget.

### Any other notes
- I was able to simplify the markup a little by using `withResponsive` `isUserOnMobile` to modify the `GoogleMap` height.
- I switched to using Semantic UI `Label.Group` to wrap the `IconCards`, which is simpler and reacts more gracefully on awkward screen widths (see screenshots).

**Desktop**

<img width="950" alt="screen shot 2018-04-26 at 18 09 40" src="https://user-images.githubusercontent.com/8591501/39317945-1b0f3040-497d-11e8-8ba5-cd63e3b7b62f.png">

**Tablet**

<img width="712" alt="screen shot 2018-04-26 at 18 09 48" src="https://user-images.githubusercontent.com/8591501/39317944-1af19738-497d-11e8-9890-a6360db0d821.png">

**Mobile**

<img width="513" alt="screen shot 2018-04-26 at 18 10 01" src="https://user-images.githubusercontent.com/8591501/39317941-1aa50ef4-497d-11e8-911d-535117fc6d4e.png">

**Graceful failure**

<img width="333" alt="screen shot 2018-04-26 at 18 09 28" src="https://user-images.githubusercontent.com/8591501/39317940-1a834152-497d-11e8-9b8b-098bdb72025b.png">