### PR TITLE
TE-343 Isolate getCheckInOrOutTimeLabel as a util

### DIFF
--- a/src/components/property-page-widgets/Rules/component.js
+++ b/src/components/property-page-widgets/Rules/component.js
@@ -9,6 +9,8 @@ import { Heading } from 'typography/Heading';
 import { Paragraph } from 'typography/Paragraph';
 import { Icon } from 'elements/Icon';
 
+import { getCheckInOrOutTimeLabel } from './utils/getCheckInOrOutTimeLabel';
+
 /**
  * The standard widget for displaying the rules of a property.
  * @returns {Object}
@@ -22,9 +24,15 @@ export const Component = ({ checkInTime, checkOutTime, rules }) => (
       <List items={rules.map(rule => <Paragraph>{rule}</Paragraph>)} />
     </GridColumn>
     <GridColumn computer={9} tablet={7}>
-      <Icon label={`Check in: ${checkInTime}`} name="question mark" />
+      <Icon
+        label={getCheckInOrOutTimeLabel(checkInTime)}
+        name="question mark"
+      />
       <Divider />
-      <Icon label={`Check out: ${checkOutTime}`} name="question mark" />
+      <Icon
+        label={getCheckInOrOutTimeLabel(checkOutTime, true)}
+        name="question mark"
+      />
     </GridColumn>
   </Grid>
 );

--- a/src/components/property-page-widgets/Rules/utils/getCheckInOrOutTimeLabel.js
+++ b/src/components/property-page-widgets/Rules/utils/getCheckInOrOutTimeLabel.js
@@ -1,0 +1,7 @@
+/**
+ * @param  {String}  time
+ * @param  {Boolean} isCheckOut
+ * @return {String}
+ */
+export const getCheckInOrOutTimeLabel = (time, isCheckOut) =>
+  `Check ${isCheckOut ? 'out' : 'in'}: ${time}`;

--- a/src/components/property-page-widgets/Rules/utils/getCheckInOurOutTimeLabel.spec.js
+++ b/src/components/property-page-widgets/Rules/utils/getCheckInOurOutTimeLabel.spec.js
@@ -1,0 +1,19 @@
+import { getCheckInOrOutTimeLabel } from './getCheckInOrOutTimeLabel';
+
+const time = '🕒';
+
+describe('getCheckInOrOutTimeLabel', () => {
+  describe('by default', () => {
+    it('should return a string for the check in time', () => {
+      const actual = getCheckInOrOutTimeLabel(time);
+      expect(actual).toBe(`Check in: ${time}`);
+    });
+  });
+
+  describe('if `isCheckOut` is true', () => {
+    it('should return a string for the check out time', () => {
+      const actual = getCheckInOrOutTimeLabel(time, true);
+      expect(actual).toBe(`Check out: ${time}`);
+    });
+  });
+});


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-343)

### What **one** thing does this PR do?
Isolate getCheckInOrOutTimeLabel as a util. Responds to comment in #122 

