### PR TITLE
TE-351 Refer to webpackHotUpdate as a property of the global object.

### DIFF
--- a/styleguide/styleguide-components/StyleGuideRenderer/getIsDevelopmentServer.js
+++ b/styleguide/styleguide-components/StyleGuideRenderer/getIsDevelopmentServer.js
@@ -1,1 +1,1 @@
-export const getIsDevelopmentServer = () => !!webpackHotUpdate;
+export const getIsDevelopmentServer = () => !!global.webpackHotUpdate;


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-351)

### What **one** thing does this PR do?
Fix. Refer to webpackHotUpdate as a property of the global object.

