### PR TITLE
TE-357 Alpha ribbin z-index fix

### DIFF
--- a/styleguide/styleguide-components/AlphaFlag/component.js
+++ b/styleguide/styleguide-components/AlphaFlag/component.js
@@ -19,7 +19,7 @@ const styles = ({ color, fontFamily }) => ({
     transform: 'rotate(45deg)',
     top: 35,
     width: 350,
-    zIndex: 1000,
+    zIndex: 10,
   },
   heading: {
     fontFamily: 'inherit',

--- a/styleguide/styleguide-components/MobilePlaceholder/component.js
+++ b/styleguide/styleguide-components/MobilePlaceholder/component.js
@@ -15,7 +15,7 @@ const styles = ({ borderRadius, color, mq, space }) => ({
     position: 'fixed',
     visibility: 'hidden',
     width: '100vw',
-    zIndex: 2,
+    zIndex: 11,
 
     [mq.small]: {
       display: 'block',


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-357)

### What **one** thing does this PR do?
It puts the alpha ribbon behind the mobile placeholder screen but still in front of the code blocks.

### Any other notes
![image](https://user-images.githubusercontent.com/10498995/39513915-134c5f18-4df6-11e8-80f0-c690360e3dc9.png)

![image](https://user-images.githubusercontent.com/10498995/39513963-330671ea-4df6-11e8-8749-d02250dd3d61.png)
