### PR TITLE
TE-369 Add z-index map on style guide components

### DIFF
--- a/styleguide/config/options/theme.js
+++ b/styleguide/config/options/theme.js
@@ -23,4 +23,9 @@ module.exports = {
     xlarge: '@media (min-width: 1200px)',
   },
   sidebarWidth: 210,
+  zIndices: {
+    overlay: 20,
+    banner: 10,
+    codeToggle: 5,
+  },
 };

--- a/styleguide/styleguide-components/AlphaFlag/component.js
+++ b/styleguide/styleguide-components/AlphaFlag/component.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import Styled from 'rsg-components/Styled';
 
-const styles = ({ color, fontFamily }) => ({
+const styles = ({ color, fontFamily, zIndices }) => ({
   flag: {
     alignItems: 'center',
     background: color.linkHover,
@@ -19,7 +19,7 @@ const styles = ({ color, fontFamily }) => ({
     transform: 'rotate(45deg)',
     top: 35,
     width: 350,
-    zIndex: 10,
+    zIndex: zIndices.banner,
   },
   heading: {
     fontFamily: 'inherit',

--- a/styleguide/styleguide-components/MobilePlaceholder/component.js
+++ b/styleguide/styleguide-components/MobilePlaceholder/component.js
@@ -5,7 +5,7 @@ import LogoRenderer from '../LogoRenderer';
 
 import { getMailToHref } from './getMailToHref';
 
-const styles = ({ borderRadius, color, mq, space }) => ({
+const styles = ({ borderRadius, color, mq, space, zIndices }) => ({
   screen: {
     background: color.sidebarBackground,
     display: 'none',
@@ -15,7 +15,7 @@ const styles = ({ borderRadius, color, mq, space }) => ({
     position: 'fixed',
     visibility: 'hidden',
     width: '100vw',
-    zIndex: 11,
+    zIndex: zIndices.overlay,
 
     [mq.small]: {
       display: 'block',

--- a/styleguide/styleguide-components/StyleGuideRenderer/component.js
+++ b/styleguide/styleguide-components/StyleGuideRenderer/component.js
@@ -28,7 +28,7 @@ import { AlphaFlag } from '../AlphaFlag';
 import { getIsDevelopmentServer } from './getIsDevelopmentServer';
 // Lodgify UI import end
 
-const styles = ({ color, fontFamily, fontSize, sidebarWidth, mq, space, maxWidth }) => ({
+const styles = ({ color, fontFamily, fontSize, sidebarWidth, mq, space, maxWidth, zIndices }) => ({
 	root: {
 		// Lodgify UI styles start
 		backgroundBlendMode: 'soft-light',
@@ -89,7 +89,7 @@ const styles = ({ color, fontFamily, fontSize, sidebarWidth, mq, space, maxWidth
     padding: space[2],
     color: color.white,
 		transition: 'color 0.15s ease 0.15s',
-		zIndex: 10,
+		zIndex: zIndices.codeToggle,
 	},
 	isDarkText: {
 		color: color.base,


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-369)

### What **one** thing does this PR do?
Adds two variables for z-indexing the components.

### Any other notes
After researching mixins in less and looking at the z-indices we already have in lodgify-ui/semantic it seems this is the best alternative to avoid conflicts.



