### PR TITLE
TE-362 Update heading size of the getting started documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,4 +70,3 @@ lib/
 
 # OS generated files
 .DS_Store
-.DS_Store?

--- a/styleguide/docs/getStarted.md
+++ b/styleguide/docs/getStarted.md
@@ -1,10 +1,10 @@
-## Install
+### Install
 
 ```bash
 $ npm install @lodgify/lodgify-ui
 ```
 
-## Import components
+### Import components
 
 ```jsx static
 import { Heading } from '@lodgify/lodgify-ui';
@@ -12,7 +12,7 @@ import { Heading } from '@lodgify/lodgify-ui';
 <Heading>Easy, right?</Heading>
 ```
 
-## Import Styles
+### Import Styles
 
 ```jsx static
 import '@lodgify/lodgify-ui/lib/styles/lodgify-ui.css';


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-362)

### What **one** thing does this PR do?
Update the heading sizes on the Get Started section in the documentation 

### Any other notes
Removed the second `DS_Store` on the `.gitignore`

![image](https://user-images.githubusercontent.com/10498995/39763251-e4c26368-52dc-11e8-9853-a1095429d21f.png)
