### PR TITLE
TE-389 Remove the babel dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   },
   "homepage": "https://lodgify.github.io/lodgify-ui/",
   "devDependencies": {
-    "babel": "^6.23.0",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-eslint": "^8.2.3",


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-389)

### What **one** thing does this PR do?
Removes an unnecessary dependency (babel) because we are using babel-cli

### Any other notes
If you get the `babel: command not found` error message then you'll need to delete node modules