### PR TITLE
TE-408 Implement new typography to rates widget

### DIFF
--- a/src/components/property-page-widgets/Rates/utils/getRateCategoryHeadingMarkup.js
+++ b/src/components/property-page-widgets/Rates/utils/getRateCategoryHeadingMarkup.js
@@ -1,33 +1,35 @@
 import React from 'react';
 
 import { Icon } from 'elements/Icon';
+import { Paragraph } from 'typography/Paragraph';
 
 import { buildPricePerExtraGuestString } from './buildPricePerExtraGuestString';
 
 /**
  * @param {Object} rateCategory
- * @param {String} rateCategory.name
- * @param {String} rateCategory.dateRange
- * @param {String} rateCategory.numberOfGuests
  * @param {String} rateCategory.costPerExtraGuest
+ * @param {String} rateCategory.dateRange
+ * @param {String} rateCategory.name
+ * @param {String} rateCategory.numberOfGuests
  * @return {Object}
  */
 export const getRateCategoryHeadingMarkup = ({
   /* eslint-disable react/prop-types */
-  name,
-  dateRange,
-  numberOfGuests,
   costPerExtraGuest,
+  dateRange,
+  name,
+  numberOfGuests,
   /* eslint-enable react/prop-types */
 }) => (
   <div>
-    <strong>{name}</strong>
-    <br />
-    {dateRange}
-    <br />
-    <Icon name="users" />
-    {numberOfGuests}
-    <br />
-    {buildPricePerExtraGuestString(costPerExtraGuest)}
+    <Paragraph weight="heavy">{name}</Paragraph>
+    <Paragraph weight="light">
+      {dateRange}
+      <br />
+      <Icon name="guests" />
+      {numberOfGuests}
+      <br />
+      {buildPricePerExtraGuestString(costPerExtraGuest)}
+    </Paragraph>
   </div>
 );

--- a/src/components/property-page-widgets/Rates/utils/getRateCategoryHeadingMarkup.spec.js
+++ b/src/components/property-page-widgets/Rates/utils/getRateCategoryHeadingMarkup.spec.js
@@ -6,6 +6,7 @@ import {
 } from '@lodgify/enzyme-jest-expect-helpers';
 
 import { Icon } from 'elements/Icon';
+import { Paragraph } from 'typography/Paragraph';
 
 import { getRateCategoryHeadingMarkup } from './getRateCategoryHeadingMarkup';
 import { buildPricePerExtraGuestString } from './buildPricePerExtraGuestString';
@@ -27,12 +28,42 @@ describe('getRateCategoryHeadingMarkup', () => {
 
   describe('the single `div` element', () => {
     it('should render the right children', () => {
-      const { dateRange, numberOfGuests, costPerExtraGuest } = rate;
       const wrapper = getRateHeading();
+      expectComponentToHaveChildren(wrapper, Paragraph, Paragraph);
+    });
+  });
+
+  describe('the first `Paragraph`', () => {
+    const getFirstParagraph = () =>
+      getRateHeading()
+        .find(Paragraph)
+        .first();
+    it('should have the right props', () => {
+      const wrapper = getFirstParagraph();
+      expectComponentToHaveProps(wrapper, { weight: 'heavy' });
+    });
+
+    it('should render the right children', () => {
+      const wrapper = getFirstParagraph();
+      expectComponentToHaveChildren(wrapper, rate.name);
+    });
+  });
+
+  describe('the second `Paragraph`', () => {
+    const getSecondParagraph = () =>
+      getRateHeading()
+        .find(Paragraph)
+        .at(1);
+    it('should have the right props', () => {
+      const wrapper = getSecondParagraph();
+      expectComponentToHaveProps(wrapper, { weight: 'light' });
+    });
+
+    it('should render the right children', () => {
+      const { dateRange, numberOfGuests, costPerExtraGuest } = rate;
+      const wrapper = getSecondParagraph();
       expectComponentToHaveChildren(
         wrapper,
-        'strong',
-        'br',
         dateRange,
         'br',
         Icon,
@@ -43,17 +74,10 @@ describe('getRateCategoryHeadingMarkup', () => {
     });
   });
 
-  describe('the `strong` element', () => {
-    it('should render the right children', () => {
-      const wrapper = getRateHeading().find('strong');
-      expectComponentToHaveChildren(wrapper, rate.name);
-    });
-  });
-
   describe('the `Icon` component', () => {
     it('should have the right props', () => {
       const wrapper = getRateHeading().find(Icon);
-      expectComponentToHaveProps(wrapper, { name: 'users' });
+      expectComponentToHaveProps(wrapper, { name: 'guests' });
     });
   });
 });

--- a/src/components/property-page-widgets/Rates/utils/getRoomTypeDropdownMarkup.js
+++ b/src/components/property-page-widgets/Rates/utils/getRoomTypeDropdownMarkup.js
@@ -4,6 +4,7 @@ import { Dropdown } from 'inputs/Dropdown';
 import { Grid } from 'layout/Grid';
 import { GridColumn } from 'layout/GridColumn';
 import { GridRow } from 'layout/GridRow';
+import { Paragraph } from 'typography/Paragraph';
 
 /**
  * @param {Object[]} options
@@ -13,7 +14,9 @@ import { GridRow } from 'layout/GridRow';
 export const getRoomTypeDropdownMarkup = (options, onChange) => (
   <Grid stackable verticalAlign="middle">
     <GridRow columns={2}>
-      <GridColumn width={4}>View Rate Information for:</GridColumn>
+      <GridColumn width={4}>
+        <Paragraph weight="heavy">View Rate Information for:</Paragraph>
+      </GridColumn>
       <GridColumn width={4}>
         <Dropdown options={options} onChange={onChange} />
       </GridColumn>

--- a/src/components/property-page-widgets/Rates/utils/getRoomTypeDropdownMarkup.spec.js
+++ b/src/components/property-page-widgets/Rates/utils/getRoomTypeDropdownMarkup.spec.js
@@ -8,6 +8,7 @@ import {
 import { Dropdown } from 'inputs/Dropdown';
 import { GridColumn } from 'layout/GridColumn';
 import { GridRow } from 'layout/GridRow';
+import { Paragraph } from 'typography/Paragraph';
 
 import { getRoomTypeDropdownMarkup } from './getRoomTypeDropdownMarkup';
 
@@ -82,6 +83,22 @@ describe('getTransportOptionsMarkup', () => {
 
     it('should render the right children', () => {
       const wrapper = getFirstGridColumn();
+      expectComponentToHaveChildren(wrapper, Paragraph);
+    });
+  });
+
+  describe('the `Paragraph`', () => {
+    const getParagraph = () =>
+      getRoomTypeDropdown()
+        .find(Paragraph)
+        .first();
+    it('should have the right props', () => {
+      const wrapper = getParagraph();
+      expectComponentToHaveProps(wrapper, { weight: 'heavy' });
+    });
+
+    it('should render the right children', () => {
+      const wrapper = getParagraph();
       expectComponentToHaveChildren(wrapper, 'View Rate Information for:');
     });
   });

--- a/src/components/typography/Paragraph/component.js
+++ b/src/components/typography/Paragraph/component.js
@@ -21,8 +21,11 @@ Component.defaultProps = {
 };
 
 Component.propTypes = {
-  /** The paragraph text. */
-  children: PropTypes.string.isRequired,
+  /** The paragraph content. */
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]).isRequired,
   /** The size of the paragraph. */
   size: PropTypes.oneOf([MEDIUM, TINY]),
   /** The weight of the paragraph. */

--- a/src/components/typography/Paragraph/component.spec.js
+++ b/src/components/typography/Paragraph/component.spec.js
@@ -5,7 +5,7 @@ import { Component as Paragraph } from './component';
 
 const getParagraph = props => shallow(<Paragraph {...props} />);
 
-const children = '🚸';
+const children = ['🚸', 2];
 
 describe('<Paragraph />', () => {
   it('should default render a single `p`', () => {


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-408)

### What **one** thing does this PR do?
Implements the new typography into the Rates component

### Any other notes
- Updates Paragraph to accept a node or an array of nodes
- Changes the Icon in the Rates header from `users` to `guests`

![kapture 2018-06-06 at 11 51 33](https://user-images.githubusercontent.com/10498995/41031042-fe670b34-697f-11e8-99b6-03ac11b6053f.gif)
