### PR TITLE
TE-442 Revert PlaygroundRenderer overflow commit

### DIFF
--- a/styleguide/styleguide-components/PlaygroundRenderer/component.js
+++ b/styleguide/styleguide-components/PlaygroundRenderer/component.js
@@ -38,7 +38,6 @@ export const styles = ({ space, color, borderRadius, mq }) => ({
 		// the next 2 lines are required to contain floated components
 	  width: '100%',
 	  display: 'inline-block',
-		overflowX: 'auto',
 	  // Lodgify UI styles start
 	  [mq.xlarge]: {
 		  marginRight: space[4],


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-442)

### What **one** thing does this PR do?
This reverts commit e90442c6d88ffdfee26c5c800b7f485285f94dc7.

### Any other notes
The e90442c commit introduced other overflow issues that went unnoticed at the point of merging the commit into staging.