### PR TITLE
TE-461 Dropdown isDisabled

### DIFF
--- a/src/components/inputs/Dropdown/Readme.md
+++ b/src/components/inputs/Dropdown/Readme.md
@@ -10,6 +10,16 @@ const { options } = require('./mock-data/options');
 <Dropdown label="Location" options={options} />;
 ```
 
+### States
+
+#### Disabled
+
+```jsx
+const { options } = require('./mock-data/options');
+
+<Dropdown isDisabled label="Location" options={options} />
+```
+
 ### Variations
 
 #### Icon

--- a/src/components/inputs/Dropdown/component.js
+++ b/src/components/inputs/Dropdown/component.js
@@ -42,7 +42,7 @@ export class Component extends PureComponent {
 
   render() {
     const { isOpen, value } = this.state;
-    const { label, options, icon } = this.props;
+    const { icon, isDisabled, label, options } = this.props;
     const optionsWithImages = adaptOptions(options);
     const defaultValue = getDefaultValue(optionsWithImages);
     return (
@@ -56,6 +56,7 @@ export class Component extends PureComponent {
         {!optionsWithImages && icon && <Icon name={icon} />}
         <Dropdown
           defaultValue={defaultValue}
+          disabled={isDisabled}
           icon={<Icon name="caret down" />}
           onBlur={() => this.handleOpen(false)}
           onChange={this.handleChange}
@@ -74,15 +75,18 @@ export class Component extends PureComponent {
 Component.displayName = 'Dropdown';
 
 Component.defaultProps = {
+  isDisabled: false,
+  icon: null,
   label: '',
   name: '',
   onChange: Function.prototype,
-  icon: null,
 };
 
 Component.propTypes = {
   /** Icon for the dropdown. Not displayed if options have images. */
   icon: PropTypes.string,
+  /** A disabled dropdown does not allow user interaction. */
+  isDisabled: PropTypes.bool,
   /** The label for the dropdown. Not displayed if options have images. */
   label: PropTypes.string,
   /** The name for the dropdown. */

--- a/src/components/inputs/Dropdown/component.spec.js
+++ b/src/components/inputs/Dropdown/component.spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import { expectComponentToHaveProps } from '@lodgify/enzyme-jest-expect-helpers';
 import { Dropdown as SemanticDropdown } from 'semantic-ui-react';
 
 import { Icon } from 'elements/Icon';
@@ -42,6 +43,7 @@ describe('<Dropdown />', () => {
       expect(actual).toEqual(
         expect.objectContaining({
           defaultValue: null,
+          disabled: false,
           icon: <Icon name="caret down" />,
           onBlur: expect.any(Function),
           onChange: expect.any(Function),
@@ -51,6 +53,15 @@ describe('<Dropdown />', () => {
           selection: true,
         })
       );
+    });
+
+    describe('if `isDisabled` prop is passed', () => {
+      it('should have the right props', () => {
+        const wrapper = getDropdown({ isDisabled: true }).find(
+          SemanticDropdown
+        );
+        expectComponentToHaveProps(wrapper, { disabled: true });
+      });
     });
 
     it('should not render a `label` as a child', () => {


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-461)

### What **one** thing does this PR do?
Exposes the disabled prop from Semantic UI's Dropdown, adds unit tests and adds an example.

### Any other notes
![image](https://user-images.githubusercontent.com/10498995/41418498-1d92bb04-6ff0-11e8-906f-db74c8876b49.png)
