### PR TITLE
TE-461 Dropdown options

### DIFF
--- a/src/components/inputs/Dropdown/component.js
+++ b/src/components/inputs/Dropdown/component.js
@@ -56,7 +56,7 @@ export class Component extends PureComponent {
         {!optionsWithImages && icon && <Icon name={icon} />}
         <Dropdown
           defaultValue={defaultValue}
-          disabled={isDisabled}
+          disabled={isDisabled || !options.length}
           icon={<Icon name="caret down" />}
           onBlur={() => this.handleOpen(false)}
           onChange={this.handleChange}
@@ -80,6 +80,7 @@ Component.defaultProps = {
   label: '',
   name: '',
   onChange: Function.prototype,
+  options: [],
 };
 
 Component.propTypes = {
@@ -93,7 +94,7 @@ Component.propTypes = {
   name: PropTypes.string,
   /** A function called when the dropdown value changes. */
   onChange: PropTypes.func,
-  /** The options which the user can select. */
+  /** The options which the user can select. Dropdown is disabled if options is an empty array. */
   options: PropTypes.arrayOf(
     PropTypes.shape({
       /** The source url for the image to display with the option. */
@@ -103,5 +104,5 @@ Component.propTypes = {
       /** The underlying value for the option. */
       value: PropTypes.any,
     })
-  ).isRequired,
+  ),
 };

--- a/src/components/inputs/Dropdown/component.spec.js
+++ b/src/components/inputs/Dropdown/component.spec.js
@@ -12,8 +12,7 @@ const OPTIONS_WITH_IMAGES = [
   { text: 'someText', value: 'someValue', image: 'someImage' },
 ];
 
-const getDropdown = extraProps =>
-  shallow(<Dropdown options={OPTIONS} {...extraProps} />);
+const getDropdown = extraProps => shallow(<Dropdown {...extraProps} />);
 const getDropdownContainer = extraProps =>
   getDropdown(extraProps).find('div.dropdown-container');
 
@@ -25,6 +24,9 @@ describe('<Dropdown />', () => {
   });
 
   describe('the `div.dropdown-container`', () => {
+    const getSemanticDropdown = extraProps =>
+      getDropdown(extraProps).find(SemanticDropdown);
+
     it('should not render an `Icon`', () => {
       const wrapper = getDropdownContainer();
       const actual = wrapper.children(Icon);
@@ -38,28 +40,45 @@ describe('<Dropdown />', () => {
     });
 
     it('should pass the right props to `Dropdown`', () => {
-      const wrapper = getDropdownContainer();
-      const actual = wrapper.children(SemanticDropdown).props();
-      expect(actual).toEqual(
-        expect.objectContaining({
-          defaultValue: null,
+      const wrapper = getSemanticDropdown(SemanticDropdown);
+      expectComponentToHaveProps(wrapper, {
+        defaultValue: null,
+        icon: <Icon name="caret down" />,
+        onBlur: expect.any(Function),
+        onChange: expect.any(Function),
+        onClick: expect.any(Function),
+        open: false,
+        options: expect.any(Array),
+        selection: true,
+      });
+    });
+
+    describe('if `options` prop is passed and has a length', () => {
+      it('should have the right props', () => {
+        const wrapper = getSemanticDropdown({
+          options: OPTIONS,
+        });
+        expectComponentToHaveProps(wrapper, {
           disabled: false,
-          icon: <Icon name="caret down" />,
-          onBlur: expect.any(Function),
-          onChange: expect.any(Function),
-          onClick: expect.any(Function),
-          open: false,
-          options: expect.arrayContaining([expect.any(Object)]),
-          selection: true,
-        })
-      );
+        });
+      });
+    });
+
+    describe('if `options` and `isDisabled` props are passed', () => {
+      it('should have the right props', () => {
+        const wrapper = getSemanticDropdown({
+          isDisabled: true,
+          options: OPTIONS,
+        });
+        expectComponentToHaveProps(wrapper, { disabled: true });
+      });
     });
 
     describe('if `isDisabled` prop is passed', () => {
       it('should have the right props', () => {
-        const wrapper = getDropdown({ isDisabled: true }).find(
-          SemanticDropdown
-        );
+        const wrapper = getSemanticDropdown({
+          isDisabled: true,
+        });
         expectComponentToHaveProps(wrapper, { disabled: true });
       });
     });


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-461)

### What **one** thing does this PR do?
Removes the isRequired from the `options` prop

### Any other notes
`disabled` prop is now also controlled by whether the `options` prop is an empty array 
![kapture 2018-06-15 at 12 16 30](https://user-images.githubusercontent.com/10498995/41463225-fbf50942-7095-11e8-89f8-19a1846669b5.gif)
