### PR TITLE
TE-470 Fix the footer social media menu

### DIFF
--- a/src/components/collections/Footer/component.js
+++ b/src/components/collections/Footer/component.js
@@ -66,7 +66,7 @@ export const Component = ({
       <Menu.Item>
         <Icon label={phoneNumber} name="phone" />
       </Menu.Item>
-      {socialMediaLinks.length && (
+      {!!socialMediaLinks.length && (
         <Menu.Menu position="right">
           {socialMediaLinks.map(({ href, iconName, iconPath }, index) => (
             <Menu.Item href={href} key={buildKeyFromStrings(href, index)} link>


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-470)

### What **one** thing does this PR do?
Stops the footer displaying a `0` when `props.socialMediaLinks.length` is equal to 0.

### Any other notes
#### Before

![image](https://user-images.githubusercontent.com/10498995/41710986-48579fce-7547-11e8-858c-5d7db3091997.png)


#### After

![image](https://user-images.githubusercontent.com/10498995/41710953-35829552-7547-11e8-8b04-977677cba51b.png)
