### PR TITLE
TE-574 Use displayName expect helpers

### DIFF
--- a/src/components/collections/Form/component.spec.js
+++ b/src/components/collections/Form/component.spec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow, mount } from 'enzyme';
 import { Card as SemanticCard } from 'semantic-ui-react';
+import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
 
 import { TextInput } from 'inputs/TextInput';
 
@@ -156,7 +157,6 @@ describe('<Form />', () => {
   });
 
   it('should have `displayName` Form', () => {
-    const actual = Form.displayName;
-    expect(actual).toBe('Form');
+    expectComponentToHaveDisplayName(Form, 'Form');
   });
 });

--- a/src/components/collections/Header/component.spec.js
+++ b/src/components/collections/Header/component.spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
 
 import { Component as Header } from './component';
 import { navigationItems } from './mock-data/navigationItems';
@@ -264,7 +265,6 @@ describe('<Header />', () => {
   });
 
   it('should have `displayName` Header', () => {
-    const actual = Header.displayName;
-    expect(actual).toBe('Header');
+    expectComponentToHaveDisplayName(Header, 'Header');
   });
 });

--- a/src/components/elements/Divider/component.spec.js
+++ b/src/components/elements/Divider/component.spec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { Divider as SemanticDivider } from 'semantic-ui-react';
+import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
 
 import { Component as Divider } from './component';
 
@@ -36,7 +37,6 @@ describe('<Divider />', () => {
   });
 
   it('should have `displayName` Divider', () => {
-    const actual = Divider.displayName;
-    expect(actual).toBe('Divider');
+    expectComponentToHaveDisplayName(Divider, 'Divider');
   });
 });

--- a/src/components/elements/GoogleMap/component.spec.js
+++ b/src/components/elements/GoogleMap/component.spec.js
@@ -1,7 +1,10 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { Card } from 'semantic-ui-react';
-import { expectComponentToHaveProps } from '@lodgify/enzyme-jest-expect-helpers';
+import {
+  expectComponentToHaveDisplayName,
+  expectComponentToHaveProps,
+} from '@lodgify/enzyme-jest-expect-helpers';
 
 import { ReactGoogleMap } from 'utils/react-google-maps';
 
@@ -37,7 +40,6 @@ describe('<GoogleMap />', () => {
   });
 
   it('should have `displayName` GoogleMap', () => {
-    const actual = GoogleMap.displayName;
-    expect(actual).toBe('GoogleMap');
+    expectComponentToHaveDisplayName(GoogleMap, 'GoogleMap');
   });
 });

--- a/src/components/elements/Icon/component.spec.js
+++ b/src/components/elements/Icon/component.spec.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import {
-  expectComponentToHaveProps,
   expectComponentToHaveChildren,
+  expectComponentToHaveDisplayName,
+  expectComponentToHaveProps,
 } from '@lodgify/enzyme-jest-expect-helpers';
 
 import { Paragraph } from 'typography/Paragraph';
@@ -84,7 +85,6 @@ describe('<Icon />', () => {
   });
 
   it('should have displayName `Icon`', () => {
-    const actual = Icon.displayName;
-    expect(actual).toBe('Icon');
+    expectComponentToHaveDisplayName(Icon, 'Icon');
   });
 });

--- a/src/components/elements/Modal/component.spec.js
+++ b/src/components/elements/Modal/component.spec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { Modal as SemanticModal } from 'semantic-ui-react';
+import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
 
 import { Icon } from 'elements/Icon';
 
@@ -35,7 +36,6 @@ describe('<Modal />', () => {
   });
 
   it('should have `displayName` Modal', () => {
-    const actual = Modal.displayName;
-    expect(actual).toBe('Modal');
+    expectComponentToHaveDisplayName(Modal, 'Modal');
   });
 });

--- a/src/components/elements/Pagination/component.spec.js
+++ b/src/components/elements/Pagination/component.spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
 
 import { nextItem, pageItem, prevItem } from './navigationMarkup';
 import { Component as Pagination } from './component';
@@ -31,7 +32,6 @@ describe('<Pagination />', () => {
   });
 
   it('should have displayName `Pagination`', () => {
-    const actual = Pagination.displayName;
-    expect(actual).toBe('Pagination');
+    expectComponentToHaveDisplayName(Pagination, 'Pagination');
   });
 });

--- a/src/components/elements/Quote/component.spec.js
+++ b/src/components/elements/Quote/component.spec.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import {
   expectComponentToHaveChildren,
+  expectComponentToHaveDisplayName,
   expectComponentToHaveProps,
 } from '@lodgify/enzyme-jest-expect-helpers';
 
@@ -131,7 +132,6 @@ describe('<Quote />', () => {
   });
 
   it('should have displayName `Quote`', () => {
-    const actual = Quote.displayName;
-    expect(actual).toBe('Quote');
+    expectComponentToHaveDisplayName(Quote, 'Quote');
   });
 });

--- a/src/components/elements/Submenu/component.spec.js
+++ b/src/components/elements/Submenu/component.spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
 
 import { Icon } from 'elements/Icon';
 
@@ -68,7 +69,6 @@ describe('<Submenu />', () => {
   });
 
   it('should have displayName `Submenu`', () => {
-    const actual = Submenu.displayName;
-    expect(actual).toBe('Submenu');
+    expectComponentToHaveDisplayName(Submenu, 'Submenu');
   });
 });

--- a/src/components/elements/Tooltip/component.spec.js
+++ b/src/components/elements/Tooltip/component.spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
 
 import { Icon } from 'elements/Icon';
 
@@ -38,7 +39,6 @@ describe('<Tooltip />', () => {
   });
 
   it('should have `displayName` Tooltip', () => {
-    const actual = Tooltip.displayName;
-    expect(actual).toBe('Tooltip');
+    expectComponentToHaveDisplayName(Tooltip, 'Tooltip');
   });
 });

--- a/src/components/inputs/CaptchaInput/component.spec.js
+++ b/src/components/inputs/CaptchaInput/component.spec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { Form, Image } from 'semantic-ui-react';
+import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
 
 import { TextInput } from 'inputs/TextInput';
 
@@ -83,7 +84,6 @@ describe('<CaptchaInput />', () => {
   });
 
   it('should have displayName `CaptchaInput`', () => {
-    const actual = CaptchaInput.displayName;
-    expect(actual).toBe('CaptchaInput');
+    expectComponentToHaveDisplayName(CaptchaInput, 'CaptchaInput');
   });
 });

--- a/src/components/inputs/Checkbox/component.spec.js
+++ b/src/components/inputs/Checkbox/component.spec.js
@@ -1,15 +1,11 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { Checkbox as SemanticCheckbox } from 'semantic-ui-react';
+import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
 
 import { Component as Checkbox } from './component';
 
 describe('<Checkbox />', () => {
-  it('should have displayName "Checkbox"', () => {
-    const displayName = Checkbox.displayName;
-    expect(displayName).toBe('Checkbox');
-  });
-
   it('should render a single Semantic UI Checkbox component', () => {
     const component = shallow(<Checkbox />);
     const checkbox = component.find(SemanticCheckbox);
@@ -46,5 +42,9 @@ describe('<Checkbox />', () => {
       checkbox.simulate('change', undefined, { checked: true });
       expect(handleChange).toHaveBeenCalledWith(name, true);
     });
+  });
+
+  it('should have displayName "Checkbox"', () => {
+    expectComponentToHaveDisplayName(Checkbox, 'Checkbox');
   });
 });

--- a/src/components/inputs/Dropdown/component.spec.js
+++ b/src/components/inputs/Dropdown/component.spec.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { expectComponentToHaveProps } from '@lodgify/enzyme-jest-expect-helpers';
 import { Dropdown as SemanticDropdown } from 'semantic-ui-react';
+import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
 
 import { Icon } from 'elements/Icon';
 
@@ -217,7 +218,6 @@ describe('<Dropdown />', () => {
   });
 
   it('should have displayName `Dropdown`', () => {
-    const actual = Dropdown.displayName;
-    expect(actual).toBe('Dropdown');
+    expectComponentToHaveDisplayName(Dropdown, 'Dropdown');
   });
 });

--- a/src/components/inputs/ErrorMessage/component.spec.js
+++ b/src/components/inputs/ErrorMessage/component.spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
 
 import { Component as ErrorMessage } from './component';
 
@@ -27,7 +28,6 @@ describe('<ErrorMessage />', () => {
   });
 
   it('should have displayName `ErrorMessage`', () => {
-    const actual = ErrorMessage.displayName;
-    expect(actual).toBe('ErrorMessage');
+    expectComponentToHaveDisplayName(ErrorMessage, 'ErrorMessage');
   });
 });

--- a/src/components/inputs/InputController/component.spec.js
+++ b/src/components/inputs/InputController/component.spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { shallow, mount } from 'enzyme';
+import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
 
 import { Icon } from 'elements/Icon';
 
@@ -76,11 +77,6 @@ describe('<InputController />', () => {
       const semanticInput = getInputController().find('Input');
       const actual = semanticInput.find('Icon').length;
       expect(actual).toBe(0);
-    });
-
-    it('should have displayName `InputController`', () => {
-      const actual = InputController.displayName;
-      expect(actual).toBe('InputController');
     });
   });
 
@@ -234,5 +230,9 @@ describe('<InputController />', () => {
       htmlLabel.simulate('click');
       expect(htmlInput).toBe(document.activeElement);
     });
+  });
+
+  it('should have displayName `InputController`', () => {
+    expectComponentToHaveDisplayName(InputController, 'InputController');
   });
 });

--- a/src/components/inputs/PhoneInput/component.spec.js
+++ b/src/components/inputs/PhoneInput/component.spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
 
 import { Component as PhoneInput } from './component';
 
@@ -70,7 +71,6 @@ describe('<PhoneInput />', () => {
   });
 
   it('should have displayName `PhoneInput`', () => {
-    const actual = PhoneInput.displayName;
-    expect(actual).toBe('PhoneInput');
+    expectComponentToHaveDisplayName(PhoneInput, 'PhoneInput');
   });
 });

--- a/src/components/inputs/RadioButton/component.spec.js
+++ b/src/components/inputs/RadioButton/component.spec.js
@@ -1,16 +1,12 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
 
 import { Component as Checkbox } from '../Checkbox/component';
 
 import { Component as RadioButton } from './component';
 
 describe('<RadioButton />', () => {
-  it('should have displayName "RadioButton"', () => {
-    const displayName = RadioButton.displayName;
-    expect(displayName).toBe('RadioButton');
-  });
-
   it('should render a single UI Checkbox component', () => {
     const component = shallow(<RadioButton />);
     // Reminder: <RadioButton/> is based on <Checkbox>
@@ -34,5 +30,9 @@ describe('<RadioButton />', () => {
         ...PROPS,
       })
     );
+  });
+
+  it('should have displayName `RadioButton`', () => {
+    expectComponentToHaveDisplayName(RadioButton, 'RadioButton');
   });
 });

--- a/src/components/inputs/TextArea/component.spec.js
+++ b/src/components/inputs/TextArea/component.spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
 
 import { Component as TextArea } from './component';
 
@@ -41,7 +42,6 @@ describe('<TextArea />', () => {
   });
 
   it('should have displayName `TextArea`', () => {
-    const actual = TextArea.displayName;
-    expect(actual).toBe('TextArea');
+    expectComponentToHaveDisplayName(TextArea, 'TextArea');
   });
 });

--- a/src/components/inputs/TextInput/component.spec.js
+++ b/src/components/inputs/TextInput/component.spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
 
 import { Component as TextInput } from './component';
 
@@ -41,7 +42,6 @@ describe('<TextInput />', () => {
   });
 
   it('should have displayName `TextInput`', () => {
-    const actual = TextInput.displayName;
-    expect(actual).toBe('TextInput');
+    expectComponentToHaveDisplayName(TextInput, 'TextInput');
   });
 });

--- a/src/components/inputs/Toggle/component.spec.js
+++ b/src/components/inputs/Toggle/component.spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
 
 import { Component as Checkbox } from '../Checkbox/component';
 
@@ -7,8 +8,7 @@ import { Component as Toggle } from './component';
 
 describe('<Toggle />', () => {
   it('should have displayName "Toggle"', () => {
-    const displayName = Toggle.displayName;
-    expect(displayName).toBe('Toggle');
+    expectComponentToHaveDisplayName(Toggle, 'Toggle');
   });
 
   it('should render a single UI Checkbox component', () => {

--- a/src/components/media/FullBleed/component.spec.js
+++ b/src/components/media/FullBleed/component.spec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { Segment } from 'semantic-ui-react';
+import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
 
 import { Component as FullBleed } from './component';
 
@@ -35,7 +36,6 @@ describe('<FullBleed />', () => {
   });
 
   it('should have `displayName` `FullBleed`', () => {
-    const actual = FullBleed.displayName;
-    expect(actual).toBe('FullBleed');
+    expectComponentToHaveDisplayName(FullBleed, 'FullBleed');
   });
 });

--- a/src/components/media/Slideshow/component.spec.js
+++ b/src/components/media/Slideshow/component.spec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import ImageGallery from 'react-image-gallery';
+import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
 
 import { Component as Slideshow } from './component';
 import { images } from './mock-data/images';
@@ -34,7 +35,6 @@ describe('<Slideshow />', () => {
   });
 
   it('should have displayName `Slideshow`', () => {
-    const actual = Slideshow.displayName;
-    expect(actual).toBe('Slideshow');
+    expectComponentToHaveDisplayName(Slideshow, 'Slideshow');
   });
 });

--- a/src/components/property-page-widgets/Description/component.spec.js
+++ b/src/components/property-page-widgets/Description/component.spec.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import {
   expectComponentToHaveChildren,
+  expectComponentToHaveDisplayName,
   expectComponentToHaveProps,
 } from '@lodgify/enzyme-jest-expect-helpers';
 
@@ -190,7 +191,6 @@ describe('<Description />', () => {
   });
 
   it('should have `displayName` `Description`', () => {
-    const actual = Description.displayName;
-    expect(actual).toBe('Description');
+    expectComponentToHaveDisplayName(Description, 'Description');
   });
 });

--- a/src/components/property-page-widgets/PaymentInformation/component.spec.js
+++ b/src/components/property-page-widgets/PaymentInformation/component.spec.js
@@ -3,6 +3,7 @@ import { shallow } from 'enzyme';
 import { Statistic } from 'semantic-ui-react';
 import {
   expectComponentToHaveChildren,
+  expectComponentToHaveDisplayName,
   expectComponentToHaveProps,
 } from '@lodgify/enzyme-jest-expect-helpers';
 
@@ -582,7 +583,6 @@ describe('<PaymentInformation />', () => {
   });
 
   it('should have `displayName` `PaymentInformation`', () => {
-    const actual = PaymentInformation.displayName;
-    expect(actual).toBe('PaymentInformation');
+    expectComponentToHaveDisplayName(PaymentInformation, 'PaymentInformation');
   });
 });

--- a/src/components/property-page-widgets/Pictures/component.spec.js
+++ b/src/components/property-page-widgets/Pictures/component.spec.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import {
   expectComponentToHaveChildren,
+  expectComponentToHaveDisplayName,
   expectComponentToHaveProps,
 } from '@lodgify/enzyme-jest-expect-helpers';
 
@@ -160,7 +161,6 @@ describe('<Pictures />', () => {
   });
 
   it('should have `displayName` `Pictures`', () => {
-    const actual = Pictures.displayName;
-    expect(actual).toBe('Pictures');
+    expectComponentToHaveDisplayName(Pictures, 'Pictures');
   });
 });

--- a/src/components/property-page-widgets/Reviews/component.spec.js
+++ b/src/components/property-page-widgets/Reviews/component.spec.js
@@ -3,6 +3,7 @@ import { shallow } from 'enzyme';
 import { Rating } from 'semantic-ui-react';
 import {
   expectComponentToHaveChildren,
+  expectComponentToHaveDisplayName,
   expectComponentToHaveProps,
 } from '@lodgify/enzyme-jest-expect-helpers';
 
@@ -246,7 +247,6 @@ describe('<Reviews />', () => {
   });
 
   it('should have displayName `Reviews`', () => {
-    const actual = Reviews.displayName;
-    expect(actual).toBe('Reviews');
+    expectComponentToHaveDisplayName(Reviews, 'Reviews');
   });
 });

--- a/src/components/property-page-widgets/SleepingArrangements/component.spec.js
+++ b/src/components/property-page-widgets/SleepingArrangements/component.spec.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import {
   expectComponentToHaveChildren,
+  expectComponentToHaveDisplayName,
   expectComponentToHaveProps,
 } from '@lodgify/enzyme-jest-expect-helpers';
 
@@ -66,7 +67,9 @@ describe('<SleepingArrangements />', () => {
   });
 
   it('should have `displayName` `SleepingArrangements`', () => {
-    const actual = SleepingArrangements.displayName;
-    expect(actual).toBe('SleepingArrangements');
+    expectComponentToHaveDisplayName(
+      SleepingArrangements,
+      'SleepingArrangements'
+    );
   });
 });

--- a/src/components/typography/Heading/component.spec.js
+++ b/src/components/typography/Heading/component.spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
 
 import { Component as Heading } from './component';
 
@@ -38,7 +39,6 @@ describe('<Heading />', () => {
   });
 
   it('should have displayName `Heading`', () => {
-    const actual = Heading.displayName;
-    expect(actual).toBe('Heading');
+    expectComponentToHaveDisplayName('Heading');
   });
 });

--- a/src/components/typography/Paragraph/component.spec.js
+++ b/src/components/typography/Paragraph/component.spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
 
 import { Component as Paragraph } from './component';
 
@@ -39,7 +40,6 @@ describe('<Paragraph />', () => {
   });
 
   it('should have displayName `Paragraph`', () => {
-    const actual = Paragraph.displayName;
-    expect(actual).toBe('Paragraph');
+    expectComponentToHaveDisplayName(Paragraph, 'Paragraph');
   });
 });

--- a/src/utils/react-google-maps/component.spec.js
+++ b/src/utils/react-google-maps/component.spec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { GoogleMap, Marker, Circle } from 'react-google-maps';
+import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
 
 import { Component as ReactGoogleMap } from './component';
 
@@ -94,7 +95,6 @@ describe('<ReactGoogleMaps />', () => {
   });
 
   it('should have `displayName` ReactGoogleMap', () => {
-    const actual = ReactGoogleMap.displayName;
-    expect(actual).toBe('ReactGoogleMap');
+    expectComponentToHaveDisplayName(ReactGoogleMap, 'ReactGoogleMap');
   });
 });


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-574)

### What **one** thing does this PR do?
Replaces all the displayName unit tests that were using `.toBe` with `expectComponentToHaveDisplayName`
