### PR TITLE
TE-573 Add `expectComponentToBe` to all component unit tests

### DIFF
--- a/src/components/elements/Divider/component.spec.js
+++ b/src/components/elements/Divider/component.spec.js
@@ -1,7 +1,10 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { Divider as SemanticDivider } from 'semantic-ui-react';
-import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
+import {
+  expectComponentToBe,
+  expectComponentToHaveDisplayName,
+} from '@lodgify/enzyme-jest-expect-helpers';
 
 import { Component as Divider } from './component';
 
@@ -10,8 +13,7 @@ const getDivider = props => shallow(<Divider {...props} />);
 describe('<Divider />', () => {
   it('should render a single Semantic UI `Divider` component', () => {
     const wrapper = getDivider();
-    const actual = wrapper.find(SemanticDivider).length;
-    expect(actual).toBe(1);
+    expectComponentToBe(wrapper, SemanticDivider);
   });
 
   describe('the Semantic UI `Divider` component', () => {

--- a/src/components/elements/GoogleMap/component.spec.js
+++ b/src/components/elements/GoogleMap/component.spec.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { Card } from 'semantic-ui-react';
 import {
+  expectComponentToBe,
   expectComponentToHaveDisplayName,
   expectComponentToHaveProps,
 } from '@lodgify/enzyme-jest-expect-helpers';
@@ -21,8 +22,7 @@ const getGoogleMap = () => shallow(<GoogleMap {...props} />);
 describe('<GoogleMap />', () => {
   it('should render a single `ReactGoogleMap` component', () => {
     const wrapper = getGoogleMap();
-    const actual = wrapper.is(ReactGoogleMap);
-    expect(actual).toBe(true);
+    expectComponentToBe(wrapper, ReactGoogleMap);
   });
 
   describe('the `ReactGoogleMap` component', () => {

--- a/src/components/elements/Icon/component.spec.js
+++ b/src/components/elements/Icon/component.spec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import {
+  expectComponentToBe,
   expectComponentToHaveChildren,
   expectComponentToHaveDisplayName,
   expectComponentToHaveProps,
@@ -24,8 +25,7 @@ const getIcon = extraProps => shallow(<Icon {...props} {...extraProps} />);
 describe('<Icon />', () => {
   it('should render a `i.icon` element', () => {
     const wrapper = getIcon();
-    const actual = wrapper.is('i.icon');
-    expect(actual).toBe(true);
+    expectComponentToBe(wrapper, 'i.icon');
   });
 
   describe('the `i.icon` element', () => {

--- a/src/components/elements/Link/component.spec.js
+++ b/src/components/elements/Link/component.spec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { Button } from 'semantic-ui-react';
+import { expectComponentToBe } from '@lodgify/enzyme-jest-expect-helpers';
 
 import { Component as Link } from './component';
 
@@ -14,8 +15,8 @@ const getLink = props =>
 
 describe('<Link />', () => {
   it('should render a single Semantic UI `Button` component', () => {
-    const actual = getLink().find(Button).length;
-    expect(actual).toBe(1);
+    const wrapper = getLink();
+    expectComponentToBe(wrapper, Button);
   });
 
   it('should pass the `Button` component the right props', () => {

--- a/src/components/elements/Modal/component.spec.js
+++ b/src/components/elements/Modal/component.spec.js
@@ -1,7 +1,10 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { Modal as SemanticModal } from 'semantic-ui-react';
-import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
+import {
+  expectComponentToBe,
+  expectComponentToHaveDisplayName,
+} from '@lodgify/enzyme-jest-expect-helpers';
 
 import { Icon } from 'elements/Icon';
 
@@ -15,8 +18,7 @@ const getModal = () => shallow(<Modal trigger={trigger}>{content}</Modal>);
 describe('<Modal />', () => {
   it('should render a single Semantic UI `Modal` component', () => {
     const wrapper = getModal();
-    const actual = wrapper.find(SemanticModal).length;
-    expect(actual).toBe(1);
+    expectComponentToBe(wrapper, SemanticModal);
   });
 
   describe('the Semantic UI `Modal` component', () => {

--- a/src/components/elements/Pagination/component.spec.js
+++ b/src/components/elements/Pagination/component.spec.js
@@ -1,20 +1,25 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
+import { Pagination as SemanticPagination } from 'semantic-ui-react';
+import {
+  expectComponentToBe,
+  expectComponentToHaveDisplayName,
+} from '@lodgify/enzyme-jest-expect-helpers';
 
 import { nextItem, pageItem, prevItem } from './navigationMarkup';
 import { Component as Pagination } from './component';
 
+const getPagination = () => shallow(<Pagination totalPages={5} />);
+
 describe('<Pagination />', () => {
   it('should render a single Semantic UI `Pagination` component', () => {
-    const pagination = shallow(<Pagination totalPages={5} />);
-    const actual = pagination.find('Pagination');
-    expect(actual).toHaveLength(1);
+    const wrapper = getPagination();
+    expectComponentToBe(wrapper, SemanticPagination);
   });
 
   it('should pass the right props to the Semantic UI `Pagination` component', () => {
-    const pagination = shallow(<Pagination totalPages={5} />);
-    const actual = pagination.find('Pagination').props();
+    const wrapper = getPagination();
+    const actual = wrapper.find('Pagination').props();
     expect(actual).toEqual(
       expect.objectContaining({
         boundaryRange: 10,

--- a/src/components/elements/Quote/component.spec.js
+++ b/src/components/elements/Quote/component.spec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import {
+  expectComponentToBe,
   expectComponentToHaveChildren,
   expectComponentToHaveDisplayName,
   expectComponentToHaveProps,
@@ -29,8 +30,7 @@ const getQuote = () => shallow(<Quote {...props} />);
 describe('<Quote />', () => {
   it('should render a single `blockquote`', () => {
     const wrapper = getQuote();
-    const actual = wrapper.is('blockquote');
-    expect(actual).toBe(true);
+    expectComponentToBe(wrapper, 'blockquote');
   });
 
   describe('the `blockquote` element', () => {

--- a/src/components/elements/Submenu/component.spec.js
+++ b/src/components/elements/Submenu/component.spec.js
@@ -1,6 +1,10 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
+import { Dropdown } from 'semantic-ui-react';
+import {
+  expectComponentToBe,
+  expectComponentToHaveDisplayName,
+} from '@lodgify/enzyme-jest-expect-helpers';
 
 import { Icon } from 'elements/Icon';
 
@@ -11,9 +15,8 @@ const items = [{ text: 'someText', href: 'someHref' }];
 
 describe('<Submenu />', () => {
   it('should render a single Semantic UI `Dropdown` component', () => {
-    const submenu = shallow(<Submenu items={items}>{children}</Submenu>);
-    const actual = submenu.find('Dropdown');
-    expect(actual).toHaveLength(1);
+    const wrapper = shallow(<Submenu items={items}>{children}</Submenu>);
+    expectComponentToBe(wrapper, Dropdown);
   });
 
   describe('the `Dropdown` component', () => {

--- a/src/components/elements/Tooltip/component.spec.js
+++ b/src/components/elements/Tooltip/component.spec.js
@@ -1,6 +1,10 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
+import { Popup } from 'semantic-ui-react';
+import {
+  expectComponentToBe,
+  expectComponentToHaveDisplayName,
+} from '@lodgify/enzyme-jest-expect-helpers';
 
 import { Icon } from 'elements/Icon';
 
@@ -10,9 +14,8 @@ const content = 'Extra berenjena';
 
 describe('<Tooltip />', () => {
   it('should render a single Semantic UI `Popup` component', () => {
-    const tooltip = shallow(<Tooltip content={content} />);
-    const actual = tooltip.find('Popup').length;
-    expect(actual).toBe(1);
+    const wrapper = shallow(<Tooltip content={content} />);
+    expectComponentToBe(wrapper, Popup);
   });
 
   it('should pass the `Popup` component the right props', () => {

--- a/src/components/inputs/CaptchaInput/component.spec.js
+++ b/src/components/inputs/CaptchaInput/component.spec.js
@@ -1,7 +1,10 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { Form, Image } from 'semantic-ui-react';
-import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
+import {
+  expectComponentToBe,
+  expectComponentToHaveDisplayName,
+} from '@lodgify/enzyme-jest-expect-helpers';
 
 import { TextInput } from 'inputs/TextInput';
 
@@ -13,8 +16,8 @@ const getFormGroup = () => getCaptchaInput().find(Form.Group);
 
 describe('<CaptchaInput />', () => {
   it('should render a single Semantic UI `Form.Group` component', () => {
-    const actual = getFormGroup();
-    expect(actual).toHaveLength(1);
+    const wrapper = getCaptchaInput();
+    expectComponentToBe(wrapper, Form.Group);
   });
 
   describe('the `Form.Group` component', () => {

--- a/src/components/inputs/Checkbox/component.spec.js
+++ b/src/components/inputs/Checkbox/component.spec.js
@@ -1,15 +1,17 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { Checkbox as SemanticCheckbox } from 'semantic-ui-react';
-import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
+import {
+  expectComponentToBe,
+  expectComponentToHaveDisplayName,
+} from '@lodgify/enzyme-jest-expect-helpers';
 
 import { Component as Checkbox } from './component';
 
 describe('<Checkbox />', () => {
   it('should render a single Semantic UI Checkbox component', () => {
-    const component = shallow(<Checkbox />);
-    const checkbox = component.find(SemanticCheckbox);
-    expect(checkbox).toHaveLength(1);
+    const wrapper = shallow(<Checkbox />);
+    expectComponentToBe(wrapper, SemanticCheckbox);
   });
 
   it('should pass the right props to child component', () => {

--- a/src/components/inputs/Dropdown/component.spec.js
+++ b/src/components/inputs/Dropdown/component.spec.js
@@ -2,7 +2,10 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { expectComponentToHaveProps } from '@lodgify/enzyme-jest-expect-helpers';
 import { Dropdown as SemanticDropdown } from 'semantic-ui-react';
-import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
+import {
+  expectComponentToBe,
+  expectComponentToHaveDisplayName,
+} from '@lodgify/enzyme-jest-expect-helpers';
 
 import { Icon } from 'elements/Icon';
 
@@ -20,8 +23,7 @@ const getDropdownContainer = extraProps =>
 describe('<Dropdown />', () => {
   it('should render a single `div` with class `.dropdown-container`', () => {
     const wrapper = getDropdown();
-    const actual = wrapper.find('div.dropdown-container');
-    expect(actual).toHaveLength(1);
+    expectComponentToBe(wrapper, 'div.dropdown-container');
   });
 
   describe('the `div.dropdown-container`', () => {

--- a/src/components/inputs/ErrorMessage/component.spec.js
+++ b/src/components/inputs/ErrorMessage/component.spec.js
@@ -1,6 +1,10 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
+import { Label } from 'semantic-ui-react';
+import {
+  expectComponentToBe,
+  expectComponentToHaveDisplayName,
+} from '@lodgify/enzyme-jest-expect-helpers';
 
 import { Component as ErrorMessage } from './component';
 
@@ -8,9 +12,8 @@ const errorMessage = '🔥';
 
 describe('<ErrorMessage />', () => {
   it('should render a single Semantic UI `Label` component', () => {
-    const textInput = shallow(<ErrorMessage errorMessage={errorMessage} />);
-    const actual = textInput.find('Label').length;
-    expect(actual).toBe(1);
+    const wrapper = shallow(<ErrorMessage errorMessage={errorMessage} />);
+    expectComponentToBe(wrapper, Label);
   });
 
   it('should pass the right props to `Label`', () => {

--- a/src/components/inputs/InputController/component.spec.js
+++ b/src/components/inputs/InputController/component.spec.js
@@ -1,6 +1,10 @@
 import React from 'react';
 import { shallow, mount } from 'enzyme';
-import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
+import { Input } from 'semantic-ui-react';
+import {
+  expectComponentToBe,
+  expectComponentToHaveDisplayName,
+} from '@lodgify/enzyme-jest-expect-helpers';
 
 import { Icon } from 'elements/Icon';
 
@@ -24,9 +28,8 @@ const getInputController = extraProps =>
 describe('<InputController />', () => {
   describe('default behaviour', () => {
     it('should render a single Semantic UI `Input` component', () => {
-      const inputController = getInputController();
-      const actual = inputController.find('Input').length;
-      expect(actual).toBe(1);
+      const wrapper = getInputController();
+      expectComponentToBe(wrapper, Input);
     });
 
     it('should default to no classNames on `Input`', () => {

--- a/src/components/inputs/PhoneInput/component.spec.js
+++ b/src/components/inputs/PhoneInput/component.spec.js
@@ -1,6 +1,11 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
+import {
+  expectComponentToBe,
+  expectComponentToHaveDisplayName,
+} from '@lodgify/enzyme-jest-expect-helpers';
+
+import { InputController } from '../InputController';
 
 import { Component as PhoneInput } from './component';
 
@@ -11,8 +16,7 @@ const getInputController = () => getPhoneInput().find('InputController');
 describe('<PhoneInput />', () => {
   it('should render a single `InputController` component', () => {
     const wrapper = getPhoneInput();
-    const actual = wrapper.find('InputController').length;
-    expect(actual).toBe(1);
+    expectComponentToBe(wrapper, InputController);
   });
 
   it('should pass the right `props` to `InputController`', () => {

--- a/src/components/inputs/RadioButton/component.spec.js
+++ b/src/components/inputs/RadioButton/component.spec.js
@@ -1,6 +1,9 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
+import {
+  expectComponentToBe,
+  expectComponentToHaveDisplayName,
+} from '@lodgify/enzyme-jest-expect-helpers';
 
 import { Component as Checkbox } from '../Checkbox/component';
 
@@ -8,10 +11,8 @@ import { Component as RadioButton } from './component';
 
 describe('<RadioButton />', () => {
   it('should render a single UI Checkbox component', () => {
-    const component = shallow(<RadioButton />);
-    // Reminder: <RadioButton/> is based on <Checkbox>
-    const checkbox = component.find(Checkbox);
-    expect(checkbox).toHaveLength(1);
+    const wrapper = shallow(<RadioButton />);
+    expectComponentToBe(wrapper, Checkbox);
   });
 
   it('should pass the right props to child component', () => {

--- a/src/components/inputs/TextArea/component.spec.js
+++ b/src/components/inputs/TextArea/component.spec.js
@@ -1,6 +1,11 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
+import {
+  expectComponentToBe,
+  expectComponentToHaveDisplayName,
+} from '@lodgify/enzyme-jest-expect-helpers';
+
+import { InputController } from '../InputController';
 
 import { Component as TextArea } from './component';
 
@@ -8,9 +13,8 @@ const getTextArea = () => shallow(<TextArea />);
 
 describe('<TextArea />', () => {
   it('should render a single `InputController` component', () => {
-    const textArea = getTextArea();
-    const actual = textArea.find('InputController').length;
-    expect(actual).toBe(1);
+    const wrapper = getTextArea();
+    expectComponentToBe(wrapper, InputController);
   });
 
   it('should pass the right `props` to `InputController`', () => {

--- a/src/components/inputs/TextInput/component.spec.js
+++ b/src/components/inputs/TextInput/component.spec.js
@@ -1,6 +1,11 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
+import {
+  expectComponentToBe,
+  expectComponentToHaveDisplayName,
+} from '@lodgify/enzyme-jest-expect-helpers';
+
+import { InputController } from '../InputController';
 
 import { Component as TextInput } from './component';
 
@@ -8,9 +13,8 @@ const getTextInput = () => shallow(<TextInput />);
 
 describe('<TextInput />', () => {
   it('should render a single `InputController` component', () => {
-    const textInput = getTextInput();
-    const actual = textInput.find('InputController').length;
-    expect(actual).toBe(1);
+    const wrapper = getTextInput();
+    expectComponentToBe(wrapper, InputController);
   });
 
   it('should pass the right `props` to `InputController`', () => {

--- a/src/components/inputs/Toggle/component.spec.js
+++ b/src/components/inputs/Toggle/component.spec.js
@@ -1,21 +1,18 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
+import {
+  expectComponentToBe,
+  expectComponentToHaveDisplayName,
+} from '@lodgify/enzyme-jest-expect-helpers';
 
 import { Component as Checkbox } from '../Checkbox/component';
 
 import { Component as Toggle } from './component';
 
 describe('<Toggle />', () => {
-  it('should have displayName "Toggle"', () => {
-    expectComponentToHaveDisplayName(Toggle, 'Toggle');
-  });
-
   it('should render a single UI Checkbox component', () => {
-    const component = shallow(<Toggle />);
-    // Reminder: <Toggle> is based on <Checkbox>
-    const checkboxComponent = component.find(Checkbox);
-    expect(checkboxComponent).toHaveLength(1);
+    const wrapper = shallow(<Toggle />);
+    expectComponentToBe(wrapper, Checkbox);
   });
 
   it('should pass the right props to child component', () => {
@@ -33,5 +30,9 @@ describe('<Toggle />', () => {
         ...PROPS,
       })
     );
+  });
+
+  it('should have displayName "Toggle"', () => {
+    expectComponentToHaveDisplayName(Toggle, 'Toggle');
   });
 });

--- a/src/components/media/FullBleed/component.spec.js
+++ b/src/components/media/FullBleed/component.spec.js
@@ -1,7 +1,10 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { Segment } from 'semantic-ui-react';
-import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
+import {
+  expectComponentToBe,
+  expectComponentToHaveDisplayName,
+} from '@lodgify/enzyme-jest-expect-helpers';
 
 import { Component as FullBleed } from './component';
 
@@ -16,8 +19,7 @@ const getSegment = () => getFullBleed().find(Segment);
 describe('<FullBleed />', () => {
   it('should render a single Semantic UI `Segment` component', () => {
     const wrapper = getFullBleed();
-    const actual = wrapper.find(Segment);
-    expect(actual).toHaveLength(1);
+    expectComponentToBe(wrapper, Segment);
   });
 
   describe('the `Segment` component', () => {

--- a/src/components/media/ResponsiveImage/component.spec.js
+++ b/src/components/media/ResponsiveImage/component.spec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { Image as SemanticImage, Label } from 'semantic-ui-react';
+import { expectComponentToBe } from '@lodgify/enzyme-jest-expect-helpers';
 
 import { Paragraph } from 'typography/Paragraph';
 
@@ -9,9 +10,9 @@ import { Component as ResponsiveImage } from './component';
 const getResponsiveImage = props => shallow(<ResponsiveImage {...props} />);
 
 describe('<ResponsiveImage />', () => {
-  it('should render a single Lodgify UI `ResponsiveImage` component', () => {
-    const image = getResponsiveImage();
-    expect(image).toHaveLength(1);
+  it('should render a single `picture` element', () => {
+    const wrapper = getResponsiveImage();
+    expectComponentToBe(wrapper, 'picture');
   });
 
   describe('the `ResponsiveImage` component', () => {

--- a/src/components/media/Slideshow/component.spec.js
+++ b/src/components/media/Slideshow/component.spec.js
@@ -1,7 +1,10 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import ImageGallery from 'react-image-gallery';
-import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
+import {
+  expectComponentToBe,
+  expectComponentToHaveDisplayName,
+} from '@lodgify/enzyme-jest-expect-helpers';
 
 import { Component as Slideshow } from './component';
 import { images } from './mock-data/images';
@@ -11,8 +14,7 @@ const getSlideshow = () => shallow(<Slideshow images={images} />);
 describe('<Slideshow />', () => {
   it('should render a single react-image-gallery `ImageGallery` component', () => {
     const wrapper = getSlideshow();
-    const actual = wrapper.find(ImageGallery);
-    expect(actual).toHaveLength(1);
+    expectComponentToBe(wrapper, ImageGallery);
   });
 
   describe('the `ImageGallery` component', () => {

--- a/src/components/media/Video/component.spec.js
+++ b/src/components/media/Video/component.spec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import ReactPlayer from 'react-player';
+import { expectComponentToBe } from '@lodgify/enzyme-jest-expect-helpers';
 
 import { Component as Video } from './component';
 
@@ -11,25 +12,22 @@ describe('<Video />', () => {
     expect(() => shallow(getVideo())).toThrow();
   });
 
-  it('should render a single `div` children component', () => {
-    const video = shallow(getVideo({ videoSource: '<iframe></iframe>' }));
-    const actual = video.find('div');
-    expect(actual).toHaveLength(1);
+  it('should render a single `div.video` element', () => {
+    const wrapper = shallow(getVideo({ videoSource: '<iframe></iframe>' }));
+    expectComponentToBe(wrapper, 'div.video');
   });
 
   describe('the `Video` component', () => {
-    it('should render a div.is-url if an url is provided', () => {
+    it('should render a `div.video.is-url` element if an url is provided', () => {
       const props = { videoSource: 'https://lodgify.com' };
-      const video = shallow(getVideo(props));
-
-      expect(video.find('.video.is-url')).toHaveLength(1);
+      const wrapper = shallow(getVideo(props));
+      expectComponentToBe(wrapper, 'div.video.is-url');
     });
 
-    it('should render a div.is-html if an HTML snippet is provided', () => {
+    it('should render a `div.video.is-html` if an HTML snippet is provided', () => {
       const props = { videoSource: '<iframe></iframe>' };
-      const video = shallow(getVideo(props));
-
-      expect(video.find('.video.is-html')).toHaveLength(1);
+      const wrapper = shallow(getVideo(props));
+      expectComponentToBe(wrapper, 'div.video.is-html');
     });
 
     it('should render a <ReactPlayer> if HTML is provided', () => {

--- a/src/components/property-page-widgets/Description/component.spec.js
+++ b/src/components/property-page-widgets/Description/component.spec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import {
+  expectComponentToBe,
   expectComponentToHaveChildren,
   expectComponentToHaveDisplayName,
   expectComponentToHaveProps,
@@ -35,8 +36,7 @@ const getDescription = extraProps =>
 describe('<Description />', () => {
   it('should render a single Lodgify UI `Grid` component', () => {
     const wrapper = getDescription();
-    const actual = wrapper.is(Grid);
-    expect(actual).toBe(true);
+    expectComponentToBe(wrapper, Grid);
   });
 
   describe('the first `Grid` component', () => {

--- a/src/components/property-page-widgets/PaymentInformation/component.spec.js
+++ b/src/components/property-page-widgets/PaymentInformation/component.spec.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { Statistic } from 'semantic-ui-react';
 import {
+  expectComponentToBe,
   expectComponentToHaveChildren,
   expectComponentToHaveDisplayName,
   expectComponentToHaveProps,
@@ -48,8 +49,7 @@ const getPaymentInformation = extraProps =>
 describe('<PaymentInformation />', () => {
   it('should render a single Lodgify UI `Grid` component', () => {
     const wrapper = getPaymentInformation();
-    const actual = wrapper.is(Grid);
-    expect(actual).toBe(true);
+    expectComponentToBe(wrapper, Grid);
   });
 
   describe('the first `Grid` component', () => {

--- a/src/components/property-page-widgets/Pictures/component.spec.js
+++ b/src/components/property-page-widgets/Pictures/component.spec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import {
+  expectComponentToBe,
   expectComponentToHaveChildren,
   expectComponentToHaveDisplayName,
   expectComponentToHaveProps,
@@ -23,8 +24,7 @@ const getPictures = () => shallow(<Pictures pictures={pictures} />);
 describe('<Pictures />', () => {
   it('should render a single Lodgify UI `Grid` component', () => {
     const wrapper = getPictures();
-    const actual = wrapper.is(Grid);
-    expect(actual).toBe(true);
+    expectComponentToBe(wrapper, Grid);
   });
 
   describe('the `Grid` component', () => {

--- a/src/components/property-page-widgets/PropertySearchBar/component.spec.js
+++ b/src/components/property-page-widgets/PropertySearchBar/component.spec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow, mount } from 'enzyme';
 import { Form } from 'semantic-ui-react';
+import { expectComponentToBe } from '@lodgify/enzyme-jest-expect-helpers';
 
 import { Button } from 'elements/Button';
 import { SearchBar } from 'general-widgets/SearchBar';
@@ -20,8 +21,8 @@ const getSearchBar = props => getPropertySearchBar(props).find(SearchBar);
 
 describe('<PropertySearchBar />', () => {
   it('should render a single Lodgify UI `SearchBar` component', () => {
-    const actual = getSearchBar();
-    expect(actual).toHaveLength(1);
+    const wrapper = getPropertySearchBar();
+    expectComponentToBe(wrapper, SearchBar);
   });
 
   describe('the `SearchBar` component', () => {

--- a/src/components/property-page-widgets/Reviews/component.spec.js
+++ b/src/components/property-page-widgets/Reviews/component.spec.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { Rating } from 'semantic-ui-react';
 import {
+  expectComponentToBe,
   expectComponentToHaveChildren,
   expectComponentToHaveDisplayName,
   expectComponentToHaveProps,
@@ -59,8 +60,7 @@ const getReviews = additionalProps =>
 describe('<Reviews />', () => {
   it('should render a single Lodgify UI `Grid` component', () => {
     const wrapper = getReviews();
-    const actual = wrapper.is(Grid);
-    expect(actual).toBeTruthy();
+    expectComponentToBe(wrapper, Grid);
   });
 
   describe('the first `GridRow` component', () => {

--- a/src/components/property-page-widgets/SleepingArrangements/component.spec.js
+++ b/src/components/property-page-widgets/SleepingArrangements/component.spec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import {
+  expectComponentToBe,
   expectComponentToHaveChildren,
   expectComponentToHaveDisplayName,
   expectComponentToHaveProps,
@@ -25,8 +26,7 @@ const getSleepingArrangements = () =>
 describe('<SleepingArrangements />', () => {
   it('should render a single `div` element', () => {
     const wrapper = getSleepingArrangements();
-    const actual = wrapper.is('div');
-    expect(actual).toBe(true);
+    expectComponentToBe(wrapper, 'div');
   });
 
   describe('the `div` element', () => {

--- a/src/components/property-page-widgets/Summary/component.spec.js
+++ b/src/components/property-page-widgets/Summary/component.spec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { Segment, Rating } from 'semantic-ui-react';
+import { expectComponentToBe } from '@lodgify/enzyme-jest-expect-helpers';
 
 import { Icon } from 'elements/Icon';
 import { Heading } from 'typography/Heading';
@@ -19,8 +20,7 @@ const getSummary = () => shallow(<Summary {...props} />);
 describe('<Summary />', () => {
   it('should render a single Semantic UI `Segment.Group` component', () => {
     const wrapper = getSummary();
-    const actual = wrapper.is(Segment.Group);
-    expect(actual).toBe(true);
+    expectComponentToBe(wrapper, Segment.Group);
   });
 
   describe('the first `Segment.Group` component', () => {

--- a/src/components/typography/Heading/component.spec.js
+++ b/src/components/typography/Heading/component.spec.js
@@ -1,6 +1,10 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
+import { Header } from 'semantic-ui-react';
+import {
+  expectComponentToBe,
+  expectComponentToHaveDisplayName,
+} from '@lodgify/enzyme-jest-expect-helpers';
 
 import { Component as Heading } from './component';
 
@@ -8,9 +12,8 @@ const children = '🚸';
 
 describe('<Heading />', () => {
   it('should render a single Semantic UI `Header` component', () => {
-    const heading = shallow(<Heading>{children}</Heading>);
-    const actual = heading.find('Header');
-    expect(actual).toHaveLength(1);
+    const wrapper = shallow(<Heading>{children}</Heading>);
+    expectComponentToBe(wrapper, Header);
   });
 
   it('should default to setting `props.as` as `h3`', () => {

--- a/src/components/typography/Paragraph/component.spec.js
+++ b/src/components/typography/Paragraph/component.spec.js
@@ -1,6 +1,9 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
+import {
+  expectComponentToBe,
+  expectComponentToHaveDisplayName,
+} from '@lodgify/enzyme-jest-expect-helpers';
 
 import { Component as Paragraph } from './component';
 
@@ -9,10 +12,9 @@ const getParagraph = props => shallow(<Paragraph {...props} />);
 const children = ['🚸', 2];
 
 describe('<Paragraph />', () => {
-  it('should default render a single `p`', () => {
-    const header = getParagraph({ children });
-    const actual = header.find('p');
-    expect(actual).toHaveLength(1);
+  it('should default render a single `p` element', () => {
+    const wrapper = getParagraph({ children });
+    expectComponentToBe(wrapper, 'p');
   });
 
   it('should default to adding no className', () => {


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-573)

### What **one** thing does this PR do?
Add `expectComponentToBe` to all component unit tests

