### PR TITLE
TE-601 Update ReactDates to v17

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "libphonenumber-js": "^1.1.9",
     "lodash": "^4.17.5",
     "moment": "^2.22.1",
-    "react-dates": "^16.6.1",
+    "react-dates": "^17.0.0",
     "react-google-maps": "^9.4.5",
     "react-image-gallery": "^0.8.7",
     "react-player": "^1.4.0",

--- a/src/styles/semantic/definitions/third-party-components/react-dates-datepicker.less
+++ b/src/styles/semantic/definitions/third-party-components/react-dates-datepicker.less
@@ -33,6 +33,23 @@
       top: @pickerNavigationButtonTopSpace;
     }
 
+    // add styling for buttons
+    .DayPickerNavigation button:not(.DayPickerNavigation_button__horizontalDefault) {
+      position: absolute;
+      top: @pickerButtonTop;
+      line-height: @pickerButtonLineHeight;
+      border-radius: @pickerButtonBorderRadius;
+      padding: @pickerButtonPadding;
+
+      &:first-child {
+        left: @pickerButtonFirstLeft;
+      }
+
+      &:last-child {
+        right: @pickerButtonLastRight;
+      }
+    }
+
     .DayPicker_weekHeader {
       color: inherit;
       padding: @pickerTablePadding;

--- a/src/styles/semantic/themes/default/third-party-components/react-dates-datepicker.variables
+++ b/src/styles/semantic/themes/default/third-party-components/react-dates-datepicker.variables
@@ -43,13 +43,21 @@
 
 @pickerTablePadding: 0 @15px;
 @pickerTableCellBorder: @4px solid @pureWhite;
-@pickerTableCellHeight: 38px !important;
+@pickerTableCellHeight: 48px !important;
 @pickerTableCellWidth: 48px !important;
 
 @pickerDayHoveredBackground: @lightPrimaryColor;
 @pickerDaySelectedBackground: @primaryColor;
 @pickerDayBlockedBackground: @greyTwo;
 @pickerDayBlockedFontColor: @greyFive;
+
+/* Buttons */
+@pickerButtonTop: 1.7rem;
+@pickerButtonLineHeight: 0.78em;
+@pickerButtonBorderRadius: @3px;
+@pickerButtonPadding: @6px @9px;
+@pickerButtonFirstLeft: @20px;
+@pickerButtonLastRight: @20px;
 
 /*-------------------
         States


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-601)

### What **one** thing does this PR do?
Upgrades the dependency, `react-dates`, from v16 to v17

### Any other notes
A number of breaking changes have been introduced in this upgrade.
1. Default styling has been removed from custom navigation buttons, because of this we need to add our own CSS to resolve this issue
2. The datepicker height is now computed using the number of weeks rather than the computed height, so the datepicker assumes the height of the cells will always be the same and due to our custom stying, a white space will appear after the dates. So the fix is to expand the height of the table cells to respect this assumption.

__Preview of the datepickers with the new version__

<img width="854" alt="screen shot 2018-07-12 at 11 06 26" src="https://user-images.githubusercontent.com/25742275/42623637-a774bb22-85c3-11e8-8bd0-b799b6f6f135.png">
<img width="479" alt="screen shot 2018-07-12 at 11 06 13" src="https://user-images.githubusercontent.com/25742275/42623638-a79194cc-85c3-11e8-9b74-29dc765d9b08.png">
