### PR TITLE
Launch script to use IDE debugger in VS Code

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,30 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+    "type": "node",
+    "request": "launch",
+    "name": "Jest All",
+    "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+    "args": [
+      "--runInBand",
+      "--coverage",
+      "--config",
+      "${workspaceFolder}/tools/jest/jest.config.js"
+    ],
+    "console": "integratedTerminal",
+    "internalConsoleOptions": "neverOpen"
+  }, {
+    "type": "node",
+    "request": "launch",
+    "name": "Jest Current File",
+    "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+    "args": [
+      "${relativeFile}",
+      "--config",
+      "${workspaceFolder}/tools/jest/jest.config.js"
+    ],
+    "console": "integratedTerminal",
+    "internalConsoleOptions": "neverOpen"
+}]
+}


### PR DESCRIPTION
No ticket

### What **one** thing does this PR do?
This will add a launch config to the project so we can use the built-in VS code debugger when running Jest tests

### Any other notes
Using the VS code debugger will give us access to using breakpoints in our test code and it will allow us to easily run specs from the IDE.