### PR TITLE
TE-604 Add week day mapping to Availability calendars

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "npm-run-all": "^4.1.2",
     "prettier": "^1.12.1",
     "react-docgen": "^2.20.0",
+    "react-moment-proptypes": "^1.6.0",
     "react-styleguidist": "^7.0.5",
     "react-transition-group": "^2.3.1",
     "semantic-release": "^15.4.0",

--- a/src/components/property-page-widgets/Availability/component.js
+++ b/src/components/property-page-widgets/Availability/component.js
@@ -18,6 +18,7 @@ import { Dropdown } from 'inputs/Dropdown';
 import { getMonthsToDisplay } from './utils/getMonthsToDisplay';
 import { getNextStartDate } from './utils/getNextStartDate';
 import { getPreviousStartDate } from './utils/getPreviousStartDate';
+import { renderMonthHeader } from './utils/renderMonthHeader';
 import { BLOCKED_DAY_CLASS } from './constants';
 
 import 'react-dates/initialize';
@@ -121,6 +122,7 @@ class Component extends PureComponent {
               {getMonthsToDisplay(startDate, isUserOnMobile).map(
                 (month, index) => (
                   <GridColumn
+                    className="availability-calendar-wrapper"
                     computer={6}
                     key={buildKeyFromStrings('month-column', index)}
                     mobile={12}
@@ -130,6 +132,7 @@ class Component extends PureComponent {
                       isVisible
                       month={month}
                       renderCalendarDay={this.renderCalendarDay}
+                      renderMonthElement={renderMonthHeader}
                     />
                   </GridColumn>
                 )

--- a/src/components/property-page-widgets/Availability/constants.js
+++ b/src/components/property-page-widgets/Availability/constants.js
@@ -1,1 +1,2 @@
 export const BLOCKED_DAY_CLASS = 'blocked-calendar';
+export const WEEKDAY_LENGTH = 7;

--- a/src/components/property-page-widgets/Availability/utils/renderMonthHeader.js
+++ b/src/components/property-page-widgets/Availability/utils/renderMonthHeader.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import moment from 'moment';
+import momentPropTypes from 'react-moment-proptypes';
+
+import { WEEKDAY_LENGTH } from '../constants';
+
+const buildWeekDayMappingMarkup = () => (
+  <ul className="DayPicker_weekHeader_ul">
+    {Array(WEEKDAY_LENGTH)
+      .fill()
+      .map((_, index) => (
+        <li className="DayPicker_weekHeader_li" key={index}>
+          <small>
+            {moment()
+              .day(index)
+              .format('dd')}
+          </small>
+        </li>
+      ))}
+  </ul>
+);
+
+/**
+ * @param  {Object} header
+ * @param  {Moment} header.month
+ * @return {Object}
+ */
+export const renderMonthHeader = ({ month }) => (
+  <div className="CalendarMonth_caption">
+    <strong>{month.format('MMMM YYYY')}</strong>
+    <div className="DayPicker_weekHeaders">
+      <div className="DayPicker_weekHeader">{buildWeekDayMappingMarkup()}</div>
+    </div>
+  </div>
+);
+
+renderMonthHeader.propTypes = {
+  month: momentPropTypes.momentObj.isRequired,
+};

--- a/src/components/property-page-widgets/Availability/utils/renderMonthHeader.spec.js
+++ b/src/components/property-page-widgets/Availability/utils/renderMonthHeader.spec.js
@@ -1,0 +1,38 @@
+import moment from 'moment';
+import { shallow } from 'enzyme';
+
+import { renderMonthHeader } from './renderMonthHeader';
+
+const today = moment();
+
+describe('renderMonthHeader', () => {
+  const getMonthHeader = () =>
+    shallow(
+      renderMonthHeader({
+        month: today,
+      })
+    );
+
+  it('should correctly render 7 list items for each day', () => {
+    const wrapper = getMonthHeader().find('li');
+    expect(wrapper).toHaveLength(7);
+    expect(
+      wrapper
+        .at(0)
+        .find('small')
+        .text()
+    ).toContain('Su');
+    expect(
+      wrapper
+        .at(6)
+        .find('small')
+        .text()
+    ).toContain('Sa');
+  });
+
+  it('should correctly render the month title', () => {
+    const wrapper = getMonthHeader().find('strong');
+
+    expect(wrapper.text()).toBe(today.format('MMMM YYYY'));
+  });
+});

--- a/src/styles/semantic/definitions/third-party-components/react-dates-datepicker.less
+++ b/src/styles/semantic/definitions/third-party-components/react-dates-datepicker.less
@@ -136,6 +136,37 @@
 }
 
 /*
+  Calendar in Availability Component
+*/
+.availability-calendar-wrapper .CalendarMonth {
+
+  > .CalendarMonth_caption {
+    padding-bottom: @availabilityCaptionPadding;
+    padding-top: @availabilityCaptionPadding;
+  }
+
+  .DayPicker_weekHeader {
+    width: @availabilityWeekHeaderWidth;
+    top: @availabilityWeekHeaderTop;
+    padding: @availabilityWeekHeaderPadding;
+
+    .DayPicker_weekHeader_ul {
+      width: @availabilityWeekHeaderWidth;
+      display: flex;
+
+      .DayPicker_weekHeader_li {
+        width: @availabilityWeekHeaderWidth !important;
+
+        small {
+          text-transform: uppercase;
+          font-size: @availabilityWeekHeaderFontSize;
+        }
+      }
+    }
+  }
+}
+
+/*
   Input specific styles
 */
 

--- a/src/styles/semantic/themes/default/third-party-components/react-dates-datepicker.variables
+++ b/src/styles/semantic/themes/default/third-party-components/react-dates-datepicker.variables
@@ -59,6 +59,13 @@
 @pickerButtonFirstLeft: @20px;
 @pickerButtonLastRight: @20px;
 
+/* Availability */
+@availabilityCaptionPadding: 0;
+@availabilityWeekHeaderTop: @20px;
+@availabilityWeekHeaderPadding: 0;
+@availabilityWeekHeaderWidth: 100%;
+@availabilityWeekHeaderFontSize: 0.857rem;
+
 /*-------------------
         States
 --------------------*/


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-604)

### What **one** thing does this PR do?
Adds weekday mapping to Availability calendars

### Any other notes
I wish the dependency React Dates handled this for us, but it looks like we need to construct the weekday mapping header ourselves.

I have used the same classes they have applied in the datepicker components they provide, this will help us inherit any styles they provide to better allow the header template to sit naturally in the availability component.

I had to also introduce a new dependency to add support for the moment object in PropTypes.

<img width="788" alt="screen shot 2018-07-13 at 15 42 55" src="https://user-images.githubusercontent.com/25742275/42694728-9f2709e8-86b3-11e8-8eb0-93225870ceb1.png">