### PR TITLE
TE-615 Remove `.isRequired` from `bedroomsNumber` on `FeaturedProperty`

### DIFF
--- a/src/components/general-widgets/FeaturedProperty/component.js
+++ b/src/components/general-widgets/FeaturedProperty/component.js
@@ -51,12 +51,13 @@ export const Component = ({
 Component.displayName = 'FeaturedProperty';
 
 Component.defaultProps = {
+  bedroomsNumber: null,
   imageAlternativeText: '',
 };
 
 Component.propTypes = {
   /** The number of available bedrooms at the property. */
-  bedroomsNumber: PropTypes.number.isRequired,
+  bedroomsNumber: PropTypes.number,
   /** The number of guests the property can accommodate. */
   guestsNumber: PropTypes.number.isRequired,
   /** The alternative text for the image to display. */

--- a/src/components/general-widgets/FeaturedProperty/utils/getPropertyDescription.js
+++ b/src/components/general-widgets/FeaturedProperty/utils/getPropertyDescription.js
@@ -4,4 +4,6 @@
  *  @returns {String}
  */
 export const getPropertyDescription = (guestsNumber, bedroomsNumber) =>
-  `Guests: ${guestsNumber} | Bedrooms: ${bedroomsNumber}`;
+  `Guests: ${guestsNumber}${
+    bedroomsNumber ? ` | Bedrooms: ${bedroomsNumber}` : ''
+  }`;

--- a/src/components/general-widgets/FeaturedProperty/utils/getPropertyDescription.spec.js
+++ b/src/components/general-widgets/FeaturedProperty/utils/getPropertyDescription.spec.js
@@ -9,4 +9,13 @@ describe('getPropertyDescription', () => {
       `Guests: ${guestsNumber} | Bedrooms: ${bedroomsNumber}`
     );
   });
+
+  describe('if `bedroomsNumber` is falsy', () => {
+    it('should return a string composed from the `guestsNumber` only', () => {
+      const guestsNumber = 10;
+      const bedroomsNumber = null;
+      const actual = getPropertyDescription(guestsNumber, bedroomsNumber);
+      expect(actual).toBe(`Guests: ${guestsNumber}`);
+    });
+  });
 });


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-615)

### What **one** thing does this PR do?
Remove `.isRequired` from `bedroomsNumber` on `FeaturedProperty`

Note that the ticket says remove the prop altogether. I don't think this is necessary - we can leave it on here as we/others may or may not consume the prop later.