### PR TITLE
TE-621 Fixes the modal in the RoomType component

### DIFF
--- a/src/components/property-page-widgets/Amenities/component.js
+++ b/src/components/property-page-widgets/Amenities/component.js
@@ -48,7 +48,7 @@ Component.propTypes = {
       /** The name of the icon to display for the category. */
       iconName: PropTypes.string.isRequired,
       /** The list of amenities */
-      items: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
+      items: PropTypes.arrayOf(PropTypes.string.isRequired),
       /** The category name */
       name: PropTypes.string.isRequired,
     })

--- a/src/components/property-page-widgets/Amenities/utils/getCategoryMarkup.js
+++ b/src/components/property-page-widgets/Amenities/utils/getCategoryMarkup.js
@@ -24,6 +24,8 @@ export const getCategoryMarkup = (category, index, isFullWidth = false) => (
       labelWeight="heavy"
       name={category.iconName}
     />
-    <Paragraph>{getFormattedAmenityItems(category.items)}</Paragraph>
+    {category.items ? (
+      <Paragraph>{getFormattedAmenityItems(category.items)}</Paragraph>
+    ) : null}
   </GridColumn>
 );

--- a/src/components/property-page-widgets/RoomType/Readme.md
+++ b/src/components/property-page-widgets/RoomType/Readme.md
@@ -1,14 +1,14 @@
 ```jsx
 const availableAmenities = [
-  { iconName: 'wheelchair', labelText: 'Elevator' },
-  { iconName: 'coffee', labelText: 'Free Coffee', isDisabled: true, },
-  { iconName: 'bus', labelText: 'Bus Routes' },
-  { iconName: 'sun', labelText: 'Sunny Terrace' },
-  { iconName: 'leaf', labelText: 'Tea Cutlery' },
-  { iconName: 'paw', labelText: 'Pets Allowed' },
-  { iconName: 'users', labelText: 'Family Friendly' },
-  { iconName: 'placeholder', labelText: 'Great View' },
-  { iconName: 'plane', labelText: 'Airport Pickup' },
+  { iconName: 'wheelchair', name: 'Elevator' },
+  { iconName: 'coffee', name: 'Free Coffee', isDisabled: true, },
+  { iconName: 'bus', name: 'Bus Routes' },
+  { iconName: 'sun', name: 'Sunny Terrace' },
+  { iconName: 'leaf', name: 'Tea Cutlery' },
+  { iconName: 'paw', name: 'Pets Allowed' },
+  { iconName: 'users', name: 'Family Friendly' },
+  { iconName: 'placeholder', name: 'Great View' },
+  { iconName: 'plane', name: 'Airport Pickup' },
 ];
 
 const description = "There are not many cities that have experienced such social and political extremes in recent history as Amsterdam. In the 20th century alone, Amsterdam faced the atrocities of war for the first time in 400 years, became the radical center of 1960s social movements and witnessed a complete about-face in its core economy.";

--- a/src/components/property-page-widgets/RoomType/component.js
+++ b/src/components/property-page-widgets/RoomType/component.js
@@ -153,7 +153,7 @@ Component.propTypes = {
       /** Is the amenity disabled. */
       isDisabled: PropTypes.bool,
       /** A visible label to display for the amenity. */
-      labelText: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired,
     })
   ).isRequired,
   /** A description to be displayed in the modal */

--- a/src/components/property-page-widgets/RoomType/component.spec.js
+++ b/src/components/property-page-widgets/RoomType/component.spec.js
@@ -23,7 +23,7 @@ import { Slideshow } from 'media/Slideshow';
 import { ComponentWithResponsive as RoomType } from './component';
 
 const props = {
-  amenities: [{ iconName: 'wheelchair', labelText: 'Elevator' }],
+  amenities: [{ iconName: 'wheelchair', name: 'Elevator' }],
   description: 'yayayay',
   imageUrl: '🐱🐱',
   locationName: 'Catania',


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-621)

### What **one** thing does this PR do?
Fixes the modal in the RoomType component

### Any other notes
Make items optional in Amenities so it works in the RoomType component and updates the RoomType props to be compatible with the Amenities component.

One of the bugs was introduced when the items prop was made a requirement in the Amenities component.
The existing component, RoomType, will pass in an array of items without the required sub-array, even though this is a requirement in the Amenities component. The fix was to make this sub array optional in the Amenities component.

The other bug includes the prop `labelText` in the RoomType component, it will pass this in the amenities array into the Amenities component, which the RoomType consumes. This is not valid since the Amenities component expects the `labelText` value to be defined as `name`.

This change will fix those two bugs.

#### Steps to reproduce bug
1. navigate to https://lodgify.github.io/lodgify-ui/#/Property%20page%20widgets/RoomType
2. Click on the "More Info" link
3. Observe the result

It is expected to see the modal rendered with additional information

__Broken version__
![kapture 2018-07-17 at 17 18 59](https://user-images.githubusercontent.com/25742275/42826868-bc9c0d54-89e5-11e8-8c20-72aaf08a72e1.gif)

__Working version after fix__
![kapture 2018-07-17 at 17 20 25](https://user-images.githubusercontent.com/25742275/42826902-cb42fe3a-89e5-11e8-932c-66f6b31bb573.gif)

