### PR TITLE
TE-617 Extend Contact component

### DIFF
--- a/src/components/collections/Form/component.js
+++ b/src/components/collections/Form/component.js
@@ -23,12 +23,14 @@ export class Component extends PureComponent {
   };
 
   cloneFormGroup = formGroup =>
+    formGroup &&
     React.cloneElement(formGroup, {
       children: Children.map(formGroup.props.children, this.cloneInput),
       widths: 'equal',
     });
 
   cloneInput = input =>
+    input &&
     React.createElement(Form.Field, {
       children: React.cloneElement(input, {
         onChange: (name, value) => {
@@ -53,7 +55,7 @@ export class Component extends PureComponent {
             {Children.map(
               children,
               child =>
-                child.type === Form.Group
+                child && child.type === Form.Group
                   ? this.cloneFormGroup(child)
                   : this.cloneInput(child)
             )}

--- a/src/components/general-widgets/Contact/Readme.md
+++ b/src/components/general-widgets/Contact/Readme.md
@@ -2,10 +2,62 @@
 const mockCaptcha = require('./mock-data/signupcode.jpeg');
 const {
   propertyOptions,
+  roomOptions,
 } = require('./mock-data/options');
 
 <Contact
   captchaInputImage={mockCaptcha}
   propertyOptions={propertyOptions}
+  roomOptions={roomOptions}
+/>
+```
+
+### Content
+
+
+#### Dropdowns
+
+No dropdown will be rendered if there is no options prop.
+
+```jsx
+const mockCaptcha = require('./mock-data/signupcode.jpeg');
+const {
+  roomOptions,
+} = require('./mock-data/options');
+
+<Contact
+  captchaInputImage={mockCaptcha}
+  roomOptions={roomOptions}
+/>
+```
+
+A disabled dropdown will be rendered if the options array is empty.
+
+```jsx
+const mockCaptcha = require('./mock-data/signupcode.jpeg');
+const {
+  roomOptions,
+} = require('./mock-data/options');
+
+<Contact
+  captchaInputImage={mockCaptcha}
+  propertyOptions={[]}
+  roomOptions={roomOptions}
+/>
+```
+
+A dropdown will be rendered if the options array is populated.
+
+```jsx
+const mockCaptcha = require('./mock-data/signupcode.jpeg');
+const {
+  propertyOptions,
+  roomOptions,
+} = require('./mock-data/options');
+
+<Contact
+  captchaInputImage={mockCaptcha}
+  propertyOptions={propertyOptions}
+  roomOptions={roomOptions}
 />
 ```

--- a/src/components/general-widgets/Contact/component.js
+++ b/src/components/general-widgets/Contact/component.js
@@ -5,10 +5,10 @@ import { Form } from 'collections/Form';
 import { InputGroup } from 'collections/InputGroup';
 import { TextInput } from 'inputs/TextInput';
 import { PhoneInput } from 'inputs/PhoneInput';
-import { Dropdown } from 'inputs/Dropdown';
 import { DateRangePicker } from 'inputs/DateRangePicker';
 import { TextArea } from 'inputs/TextArea';
 import { CaptchaInput } from 'inputs/CaptchaInput';
+import { Dropdown } from 'inputs/Dropdown';
 
 /**
  * The standard widget for a user contact an owner.
@@ -37,15 +37,21 @@ export const Component = ({
       <TextInput label="Guests" name="guests" type="number" width="four" />
     </InputGroup>
     <TextArea label="Comments" name="comments" />
-    <InputGroup>
-      <Dropdown
-        label="Property"
-        name="property"
-        onChange={onChangeProperty}
-        options={propertyOptions}
-      />
-      <Dropdown label="Room" name="room" options={roomOptions} />
-    </InputGroup>
+    {(roomOptions || propertyOptions) && (
+      <InputGroup>
+        {propertyOptions && (
+          <Dropdown
+            label="Property"
+            name="property"
+            onChange={onChangeProperty}
+            options={propertyOptions}
+          />
+        )}
+        {roomOptions && (
+          <Dropdown label="Room" name="room" options={roomOptions} />
+        )}
+      </InputGroup>
+    )}
     <CaptchaInput
       image={captchaInputImage}
       label="Security Code"
@@ -59,7 +65,8 @@ Component.displayName = 'Contact';
 Component.defaultProps = {
   onChangeProperty: Function.prototype,
   onSubmit: Function.prototype,
-  roomOptions: undefined,
+  propertyOptions: null,
+  roomOptions: null,
 };
 
 Component.propTypes = {
@@ -86,7 +93,7 @@ Component.propTypes = {
         PropTypes.string,
       ]),
     })
-  ).isRequired,
+  ),
   /** The options which the user can select for the room field. */
   roomOptions: PropTypes.arrayOf(
     PropTypes.shape({

--- a/src/components/general-widgets/Contact/component.spec.js
+++ b/src/components/general-widgets/Contact/component.spec.js
@@ -16,14 +16,14 @@ import { PhoneInput } from 'inputs/PhoneInput';
 import { TextArea } from 'inputs/TextArea';
 import { TextInput } from 'inputs/TextInput';
 
-import * as options from './mock-data/options';
+import { roomOptions, propertyOptions } from './mock-data/options';
 import { Component as Contact } from './component';
 
 const captchaInputImage = 'someImage';
 
-const getContact = () =>
-  shallow(<Contact captchaInputImage={captchaInputImage} {...options} />);
-const getForm = () => getContact().find(Form);
+const getContact = extraProps =>
+  shallow(<Contact captchaInputImage={captchaInputImage} {...extraProps} />);
+const getForm = extraProps => getContact(extraProps).find(Form);
 
 describe('<Contact />', () => {
   it('should render a single Lodgify UI `Form` component', () => {
@@ -49,7 +49,6 @@ describe('<Contact />', () => {
         TextInput,
         InputGroup,
         TextArea,
-        InputGroup,
         CaptchaInput
       );
     });
@@ -144,39 +143,89 @@ describe('<Contact />', () => {
     });
   });
 
-  describe('the third `InputGroup`', () => {
-    it('should render two `Dropdown`s', () => {
-      const wrapper = getForm()
-        .find(InputGroup)
-        .at(2);
-      expectComponentToHaveChildren(wrapper, Dropdown, Dropdown);
-    });
-  });
+  describe('if `props.propertyOptions` is passed', () => {
+    const getFormWithPropertyOptions = () => getForm({ propertyOptions });
 
-  describe('the Property `Dropdown`', () => {
-    it('should have the right props', () => {
-      const wrapper = getForm()
-        .find(InputGroup)
-        .at(2)
-        .childAt(0);
-      expectComponentToHaveProps(wrapper, {
-        label: 'Property',
-        name: 'property',
-        options: options.propertyOptions,
+    it('should render the right children', () => {
+      const wrapper = getFormWithPropertyOptions();
+      expectComponentToHaveChildren(
+        wrapper,
+        InputGroup,
+        TextInput,
+        InputGroup,
+        TextArea,
+        InputGroup,
+        CaptchaInput
+      );
+    });
+
+    describe('the third `InputGroup`', () => {
+      it('should render the right children', () => {
+        const wrapper = getFormWithPropertyOptions()
+          .find(InputGroup)
+          .at(2);
+        expectComponentToHaveChildren(wrapper, Dropdown);
+      });
+    });
+
+    describe('the `Dropdown`', () => {
+      it('should have the right props', () => {
+        const wrapper = getFormWithPropertyOptions().find(Dropdown);
+        expectComponentToHaveProps(wrapper, {
+          label: 'Property',
+          name: 'property',
+          onChange: expect.any(Function),
+          options: propertyOptions,
+        });
       });
     });
   });
 
-  describe('the Room `Dropdown`', () => {
-    it('should have the right props', () => {
-      const wrapper = getForm()
-        .find(InputGroup)
-        .at(2)
-        .childAt(1);
-      expectComponentToHaveProps(wrapper, {
-        label: 'Room',
-        name: 'room',
-        options: options.roomOptions,
+  describe('if `props.roomOptions` is passed', () => {
+    const getFormWithRoomOptions = () => getForm({ roomOptions });
+
+    it('should render the right children', () => {
+      const wrapper = getFormWithRoomOptions();
+      expectComponentToHaveChildren(
+        wrapper,
+        InputGroup,
+        TextInput,
+        InputGroup,
+        TextArea,
+        InputGroup,
+        CaptchaInput
+      );
+    });
+
+    describe('the third `InputGroup`', () => {
+      it('should render the right children', () => {
+        const wrapper = getFormWithRoomOptions()
+          .find(InputGroup)
+          .at(2);
+        expectComponentToHaveChildren(wrapper, Dropdown);
+      });
+    });
+
+    describe('the `Dropdown`', () => {
+      it('should have the right props', () => {
+        const wrapper = getFormWithRoomOptions().find(Dropdown);
+        expectComponentToHaveProps(wrapper, {
+          label: 'Room',
+          name: 'room',
+          onChange: expect.any(Function),
+          options: roomOptions,
+        });
+      });
+    });
+  });
+
+  describe('if `propertyOptions` and `roomOptions` are passed', () => {
+    describe('the third `InputGroup`', () => {
+      it('should render the right children', () => {
+        const wrapper = getForm({ propertyOptions, roomOptions })
+          .find(InputGroup)
+          .at(2);
+        expectComponentToHaveChildren(wrapper, Dropdown, Dropdown);
       });
     });
   });


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-617)

### What **one** thing does this PR do?
Extends the Contact component to have the ability to only show the necessary dropdowns

### Any other notes
- Fixed a issue in the Form component when `React.createElement` and `React.cloneElement` was trying to clone or create `null` or `undefined`. 

![kapture 2018-07-18 at 11 43 06](https://user-images.githubusercontent.com/10498995/42873631-c60e6450-8a7f-11e8-890d-6203e5cc2a7c.gif)
