### PR TITLE
TE-609 Make the search bar responsive

### DIFF
--- a/src/components/general-widgets/SearchBar/Readme.md
+++ b/src/components/general-widgets/SearchBar/Readme.md
@@ -54,3 +54,29 @@ const { guestsOptions, locationOptions } = require('./mock-data/options');
   isSticky
 />
 ```
+
+#### Display search bar in a modal
+
+```jsx
+const { guestsOptions, locationOptions } = require('./mock-data/options');
+
+<SearchBar
+  guestsOptions={guestsOptions}
+  locationOptions={locationOptions}
+  isDisplayedAsModal
+/>
+```
+
+#### Custom modal trigger
+
+```jsx
+const { Button } = require('../../elements/Button');
+const { guestsOptions, locationOptions } = require('./mock-data/options');
+
+<SearchBar
+  guestsOptions={guestsOptions}
+  locationOptions={locationOptions}
+  modalTrigger={<Button>Show Search bar</Button>}
+  isDisplayedAsModal
+/>
+```

--- a/src/components/general-widgets/SearchBar/component.js
+++ b/src/components/general-widgets/SearchBar/component.js
@@ -1,12 +1,14 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import { Form } from 'semantic-ui-react';
+import { Form, Modal as SemanticModal } from 'semantic-ui-react';
 
 import { Icon } from 'elements/Icon';
-import { Dropdown } from 'inputs/Dropdown';
-import { DateRangePicker } from 'inputs/DateRangePicker';
+import { Heading } from 'typography/Heading';
+import { Modal } from 'elements/Modal';
 import { Button } from 'elements/Button';
+
+import { getFormFieldMarkup } from './utils/getFormFieldMarkup';
 
 /**
  * The standard widget for property search.
@@ -24,55 +26,26 @@ export class Component extends PureComponent {
   };
 
   render = () => {
-    const {
-      getIsDayBlocked,
-      guestsOptions,
-      locationOptions,
-      isShowingLocationDropdown,
-      isShowingSummary,
-      searchButton,
-      isSticky,
-    } = this.props;
+    const { isDisplayedAsModal, isSticky, modalTrigger } = this.props;
+
+    if (isDisplayedAsModal) {
+      return (
+        <Modal trigger={modalTrigger}>
+          <SemanticModal.Content>
+            <Heading size="small">Check our availability</Heading>
+            <Form onSubmit={this.handleSubmit}>
+              {getFormFieldMarkup(this.props, this.persistInputChange, true)}
+            </Form>
+          </SemanticModal.Content>
+        </Modal>
+      );
+    }
 
     return (
       <div className={cx({ 'is-sticky': isSticky })}>
         <Form onSubmit={this.handleSubmit}>
           <Form.Group>
-            {!!isShowingSummary && (
-              <Form.Field width="three">
-                <Icon isDisabled labelText="Property Summary" name="home" />
-              </Form.Field>
-            )}
-            {!!isShowingLocationDropdown && (
-              <Form.Field width="three">
-                <Dropdown
-                  icon="map pin"
-                  label="Location"
-                  name="location"
-                  onChange={this.persistInputChange}
-                  options={locationOptions}
-                />
-              </Form.Field>
-            )}
-            <Form.Field width="seven">
-              <DateRangePicker
-                endDatePlaceholderText="Check-out"
-                getIsDayBlocked={getIsDayBlocked}
-                name="dates"
-                onChange={this.persistInputChange}
-                startDatePlaceholderText="Check-in"
-              />
-            </Form.Field>
-            <Form.Field width="three">
-              <Dropdown
-                icon="users"
-                label="Guests"
-                name="guests"
-                onChange={this.persistInputChange}
-                options={guestsOptions}
-              />
-            </Form.Field>
-            <Form.Field width="three">{searchButton}</Form.Field>
+            {getFormFieldMarkup(this.props, this.persistInputChange, false)}
           </Form.Group>
         </Form>
       </div>
@@ -84,17 +57,19 @@ Component.displayName = 'SearchBar';
 
 Component.defaultProps = {
   getIsDayBlocked: Function.prototype,
+  modalTrigger: <Icon name="search" />,
   onSubmit: Function.prototype,
+  isDisplayedAsModal: false,
   isShowingSummary: false,
   isShowingLocationDropdown: true,
   isSticky: false,
   searchButton: (
-    <Button icon="search" isRounded>
+    <Button icon="search" isPositionedRight isRounded>
       Search
     </Button>
   ),
 };
-
+/* eslint react/no-unused-prop-types: 0 */
 Component.propTypes = {
   /**
    * A function called for each day to be displayed in the DateRangePicker. Returning true blocks that day in the date range picker.
@@ -115,6 +90,8 @@ Component.propTypes = {
       ]),
     })
   ).isRequired,
+  /** Is the Search Bar displayed in a modal*/
+  isDisplayedAsModal: PropTypes.bool,
   /** Is Search Bar showing the Location Dropdown. */
   isShowingLocationDropdown: PropTypes.bool,
   /** Is Search Bar showing the Property Summary info. */
@@ -134,6 +111,8 @@ Component.propTypes = {
       ]),
     })
   ).isRequired,
+  /** The element to be clicked to display the modal. */
+  modalTrigger: PropTypes.node,
   /** The function to call when the search bar is submitted.
    *  @param {Object} values - The values of the inputs in the search bar.
    *  @param {Object} values.dates

--- a/src/components/general-widgets/SearchBar/utils/getFormFieldMarkup.js
+++ b/src/components/general-widgets/SearchBar/utils/getFormFieldMarkup.js
@@ -1,0 +1,75 @@
+/* eslint react/prop-types: 0 */
+import React, { Fragment } from 'react';
+import { Form } from 'semantic-ui-react';
+
+import { Icon } from 'elements/Icon';
+import { Dropdown } from 'inputs/Dropdown';
+import { DateRangePicker } from 'inputs/DateRangePicker';
+
+/**
+ * @param  {Object}   props
+ * @param  {Boolean}  props.isShowingSummary
+ * @param  {Boolean}  props.isShowingLocationDropdown
+ * @param  {Function} props.getIsDayBlocked
+ * @param  {Object[]} props.locationOptions
+ * @param  {Object[]} props.guestsOptions
+ * @param  {Node}     props.searchButton
+ * @param  {Function} onDatePickerChange
+ * @param  {Boolean}  areColumnsStacked
+ * @return {Object}
+ */
+export const getFormFieldMarkup = (
+  {
+    isShowingSummary,
+    isShowingLocationDropdown,
+    getIsDayBlocked,
+    locationOptions,
+    guestsOptions,
+    searchButton,
+  },
+  onDatePickerChange,
+  areColumnsStacked
+) => {
+  const defaultColumnWidth = areColumnsStacked ? 'twelve' : 'three';
+  const datePickerColumnWidth = areColumnsStacked ? 'twelve' : 'seven';
+
+  return (
+    <Fragment>
+      {!!isShowingSummary && (
+        <Form.Field width={defaultColumnWidth}>
+          <Icon isDisabled labelText="Property Summary" name="home" />
+        </Form.Field>
+      )}
+      {!!isShowingLocationDropdown && (
+        <Form.Field width={defaultColumnWidth}>
+          <Dropdown
+            icon="map pin"
+            label="Location"
+            name="location"
+            onChange={onDatePickerChange}
+            options={locationOptions}
+          />
+        </Form.Field>
+      )}
+      <Form.Field width={datePickerColumnWidth}>
+        <DateRangePicker
+          endDatePlaceholderText="Check-out"
+          getIsDayBlocked={getIsDayBlocked}
+          name="dates"
+          onChange={onDatePickerChange}
+          startDatePlaceholderText="Check-in"
+        />
+      </Form.Field>
+      <Form.Field width={defaultColumnWidth}>
+        <Dropdown
+          icon="users"
+          label="Guests"
+          name="guests"
+          onChange={onDatePickerChange}
+          options={guestsOptions}
+        />
+      </Form.Field>
+      <Form.Field width={defaultColumnWidth}>{searchButton}</Form.Field>
+    </Fragment>
+  );
+};

--- a/src/components/general-widgets/SearchBar/utils/getFormFieldMarkup.spec.js
+++ b/src/components/general-widgets/SearchBar/utils/getFormFieldMarkup.spec.js
@@ -1,0 +1,179 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import {
+  expectComponentToHaveChildren,
+  expectComponentToHaveProps,
+} from '@lodgify/enzyme-jest-expect-helpers';
+import { Form } from 'semantic-ui-react';
+
+import { Icon } from 'elements/Icon';
+import { Dropdown } from 'inputs/Dropdown';
+import { DateRangePicker } from 'inputs/DateRangePicker';
+
+import { getFormFieldMarkup } from './getFormFieldMarkup';
+
+const componentProps = {
+  isShowingSummary: true,
+  isShowingLocationDropdown: true,
+  getIsDayBlocked: Function.prototype,
+  locationOptions: [],
+  guestsOptions: [],
+  searchButton: <div />,
+};
+
+const getMarkup = overrideProps =>
+  shallow(
+    <div>
+      {getFormFieldMarkup(
+        {
+          ...componentProps,
+          ...overrideProps,
+        },
+        Function.prototype,
+        false
+      )}
+    </div>
+  );
+
+describe('getFormFieldMarkup', () => {
+  it('should return 5 `Form.Field`', () => {
+    const wrapper = getMarkup().find(Form.Field);
+    expect(wrapper).toHaveLength(5);
+  });
+
+  describe('first `Form.Field`', () => {
+    const getField = () =>
+      getMarkup()
+        .find(Form.Field)
+        .at(0);
+
+    it('should have the right props', () => {
+      const wrapper = getField();
+      expectComponentToHaveProps(wrapper, {
+        width: 'three',
+      });
+    });
+    it('should have the correct children', () => {
+      const wrapper = getField();
+      expectComponentToHaveChildren(wrapper, Icon);
+    });
+  });
+
+  describe('first `Icon`', () => {
+    it('should have the right props', () => {
+      const wrapper = getMarkup()
+        .find(Icon)
+        .at(0);
+      expectComponentToHaveProps(wrapper, {
+        name: 'home',
+        labelText: 'Property Summary',
+      });
+    });
+  });
+
+  describe('second `Form.Field`', () => {
+    const getField = () =>
+      getMarkup()
+        .find(Form.Field)
+        .at(1);
+
+    it('should have the right props', () => {
+      const wrapper = getField();
+      expectComponentToHaveProps(wrapper, {
+        width: 'three',
+      });
+    });
+    it('should have the correct children', () => {
+      const wrapper = getField();
+      expectComponentToHaveChildren(wrapper, Dropdown);
+    });
+  });
+  describe('first `Dropdown`', () => {
+    it('should have the right props', () => {
+      const wrapper = getMarkup()
+        .find(Dropdown)
+        .at(0);
+
+      expectComponentToHaveProps(wrapper, {
+        icon: 'map pin',
+        label: 'Location',
+        onChange: expect.any(Function),
+      });
+    });
+  });
+
+  describe('third `Form.Field`', () => {
+    const getField = () =>
+      getMarkup()
+        .find(Form.Field)
+        .at(2);
+    it('should have the right props', () => {
+      const wrapper = getField();
+      expectComponentToHaveProps(wrapper, {
+        width: 'seven',
+      });
+    });
+    it('should have the correct children', () => {
+      const wrapper = getField();
+      expectComponentToHaveChildren(wrapper, DateRangePicker);
+    });
+  });
+  describe('first `DateRangePicker`', () => {
+    it('should have the right props', () => {
+      const wrapper = getMarkup()
+        .find(DateRangePicker)
+        .at(0);
+
+      expectComponentToHaveProps(wrapper, {
+        name: 'dates',
+        getIsDayBlocked: expect.any(Function),
+        onChange: expect.any(Function),
+      });
+    });
+  });
+  describe('fourth `Form.Field`', () => {
+    const getField = () =>
+      getMarkup()
+        .find(Form.Field)
+        .at(3);
+    it('should have the right props', () => {
+      const wrapper = getField();
+      expectComponentToHaveProps(wrapper, {
+        width: 'three',
+      });
+    });
+    it('should have the correct children', () => {
+      const wrapper = getField();
+      expectComponentToHaveChildren(wrapper, Dropdown);
+    });
+  });
+  describe('second `DateRangePicker`', () => {
+    it('should have the right props', () => {
+      const wrapper = getMarkup()
+        .find(Dropdown)
+        .at(1);
+
+      expectComponentToHaveProps(wrapper, {
+        name: 'guests',
+        icon: 'users',
+        label: 'Guests',
+      });
+    });
+  });
+  describe('fifth `Form.Field`', () => {
+    const getField = () =>
+      getMarkup()
+        .find(Form.Field)
+        .at(4);
+    it('should have the right props', () => {
+      const wrapper = getField();
+      expectComponentToHaveProps(wrapper, {
+        width: 'three',
+      });
+    });
+    it('should have the correct children', () => {
+      const wrapper = getField();
+      expectComponentToHaveChildren(wrapper, 'div');
+    });
+  });
+});

--- a/src/styles/semantic/themes/livingstone/modules/modal.overrides
+++ b/src/styles/semantic/themes/livingstone/modules/modal.overrides
@@ -27,6 +27,12 @@
   margin-top: 0;
 }
 
+.ui.modal .content:after {
+  clear: both;
+  display: block;
+  content: "";
+}
+
 /* Image / Description */
 
 /* Modal Actions */


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-609)

### What **one** thing does this PR do?
Updates the search bar to appear in a modal when on mobile.

### Any other notes
![kapture 2018-07-19 at 9 55 40](https://user-images.githubusercontent.com/25742275/42929289-f196bf68-8b39-11e8-817e-54772b3ded14.gif)

The mock-up can be found here zpl.io/awYNvBg

This update includes:
1. Placeing the search bar in a modal and stacks the fields
2. Adding a prop to determine if the search bar should be in a modal
3. Adding a prop to set the modal trigger element, a default is set in case this prop is not set
4. Adding a clear fix to all content containers in the Modal component


