### PR TITLE
TE-703: Video, Width and height props should be type number

### DIFF
--- a/src/components/media/Video/component.js
+++ b/src/components/media/Video/component.js
@@ -72,15 +72,15 @@ export class Component extends PureComponent {
 Component.displayName = 'Video';
 
 Component.defaultProps = {
-  height: '315',
+  height: 315,
   isResponsive: false,
   videoSource: null,
-  width: '560',
+  width: 560,
 };
 
 Component.propTypes = {
   /** The height of the video to determine the aspect ratio of the video */
-  height: PropTypes.string,
+  height: PropTypes.number,
   /** Should the video be responsive */
   isResponsive: PropTypes.bool,
   /** The string that will be used to build the video player.
@@ -90,5 +90,5 @@ Component.propTypes = {
    */
   videoSource: PropTypes.string,
   /** The width of the component to determine aspect ratio */
-  width: PropTypes.string,
+  width: PropTypes.number,
 };

--- a/src/components/media/Video/utils/getPlayerCss.js
+++ b/src/components/media/Video/utils/getPlayerCss.js
@@ -7,6 +7,6 @@
 export const getPlayerCss = (isResponsive, width, height) =>
   width && height && isResponsive
     ? {
-        paddingTop: `${100 / (parseInt(width, 10) / parseInt(height, 10))}%`,
+        paddingTop: `${100 / (width / height)}%`,
       }
     : {};

--- a/src/components/media/Video/utils/getPlayerCss.spec.js
+++ b/src/components/media/Video/utils/getPlayerCss.spec.js
@@ -2,14 +2,14 @@ import { getPlayerCss } from './getPlayerCss';
 
 describe('getPlayerCss', () => {
   it('should correctly set the right padding top value with 300 by 300', () => {
-    const componentCss = getPlayerCss(true, '300', '300');
+    const componentCss = getPlayerCss(true, 300, 300);
     expect(componentCss).toEqual({
       paddingTop: '100%',
     });
   });
 
   it('should correctly set the right padding top value with 600 by 450', () => {
-    const componentCss = getPlayerCss(true, '600', '450');
+    const componentCss = getPlayerCss(true, 600, 450);
     expect(componentCss).toEqual({
       paddingTop: '75%',
     });


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-703)

### What **one** thing does this PR do?
Convert props, Width and Height, to type number