### PR TITLE
TE-777: clean up fullscreen version of Modal

### DIFF
--- a/src/styles/semantic/themes/livingstone/modules/modal.overrides
+++ b/src/styles/semantic/themes/livingstone/modules/modal.overrides
@@ -48,6 +48,10 @@
   position: absolute;
   top: 0;
 
+  &.scrolling.modal {
+    margin: 0 !important;
+  }
+
   .content {
     height: 100%;
     overflow: auto;

--- a/src/styles/semantic/themes/livingstone/modules/modal.variables
+++ b/src/styles/semantic/themes/livingstone/modules/modal.variables
@@ -26,8 +26,7 @@
 
 /* Responsive Widths */
 @fullScreenWidth: 100%;
-// Fixes the bug I describe at https://stackoverflow.com/questions/41453780/semantic-react-modal-weird-height-behavior/51426377#51426377
-@fullScreenHeight: ~"calc(100% - 1px)";
+@fullScreenHeight: 100%;
 
 /* Coupling */
 


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-777)

### What **one** thing does this PR do?
Removes the height `100% - 1px` CSS to fix the fullscreen bug

### Any other notes
- Also had to remove the margin from the fullscreen modal to ensure it is 100% fullscreen.

__The `margin: 0 !important` fixes:__
<img width="809" alt="screen shot 2018-08-08 at 12 56 06" src="https://user-images.githubusercontent.com/25742275/43833248-7190698c-9b0a-11e8-892c-cd0160d07f61.png">

__Preview of fullscreen modal with device toolbar open in Chrome devtools__
<img width="831" alt="screen shot 2018-08-08 at 12 54 42" src="https://user-images.githubusercontent.com/25742275/43833187-41dcf372-9b0a-11e8-897b-5be50d5a30e8.png">
