### PR TITLE
TE-812: remove mobile padding from Promotion

### DIFF
--- a/src/styles/semantic/themes/livingstone/elements/segment.overrides
+++ b/src/styles/semantic/themes/livingstone/elements/segment.overrides
@@ -84,6 +84,10 @@
     padding: 0;
   }
 
+  @media @mobileScreen {
+    padding: 0;
+  }
+
   &.display-stacked {
 
     p + .button {


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-812)

### What **one** thing does this PR do?
Removes the mobile padding from the Promotion component

### Any other notes

__before__
<img width="575" alt="screen shot 2018-08-13 at 10 29 16" src="https://user-images.githubusercontent.com/25742275/44021047-1158bd3e-9ee4-11e8-9c27-af66ec56c3d8.png">

__after__
<img width="586" alt="screen shot 2018-08-13 at 10 28 55" src="https://user-images.githubusercontent.com/25742275/44021056-15f36a6a-9ee4-11e8-8bb6-f99ededa1050.png">

