### PR TITLE
TE-839 Expose strings props on `Contact`

### DIFF
--- a/src/components/collections/Form/utils/getFormChild.js
+++ b/src/components/collections/Form/utils/getFormChild.js
@@ -18,7 +18,7 @@ export const getFormChild = (child, parent) => {
   if (child.type === Form.Group) {
     return React.cloneElement(child, {
       children: Children.map(child.props.children, nestedChild =>
-        getClonedInput(nestedChild, parent)
+        getFormChild(nestedChild, parent)
       ),
       widths: 'equal',
     });

--- a/src/components/general-widgets/Contact/Readme.md
+++ b/src/components/general-widgets/Contact/Readme.md
@@ -61,3 +61,31 @@ const {
   roomOptions={roomOptions}
 />
 ```
+
+#### Strings
+
+```jsx
+const mockCaptcha = require('./mock-data/signupcode.jpeg');
+const {
+  propertyOptions,
+  roomOptions,
+} = require('./mock-data/options');
+
+<Contact
+  arrivalDateInputLabel="Check-in"
+  captchaInputImage={mockCaptcha}
+  captchaInputLabel="Enter Code"
+  commentsInputLabel="Other notes"
+  departureDateInputLabel="Check-out"
+  emailInputLabel="Your email"
+  guestsInputLabel="Visitors"
+  headingText="Get in touch"
+  nameInputLabel="Your name"
+  phoneInputLabel="Your phone"
+  propertyInputLabel="Chalet"
+  propertyOptions={propertyOptions}
+  roomInputLabel="Salon"
+  roomOptions={roomOptions}
+  submitButtonText="Submit"
+/>
+```

--- a/src/components/general-widgets/Contact/component.js
+++ b/src/components/general-widgets/Contact/component.js
@@ -9,52 +9,87 @@ import { DateRangePicker } from 'inputs/DateRangePicker';
 import { TextArea } from 'inputs/TextArea';
 import { CaptchaInput } from 'inputs/CaptchaInput';
 import { Dropdown } from 'inputs/Dropdown';
+import {
+  ARRIVAL,
+  CONTACT,
+  COMMENTS,
+  DEPARTURE,
+  EMAIL,
+  GUESTS,
+  NAME,
+  PHONE,
+  PROPERTY,
+  ROOM,
+  SECURITY_CODE,
+  SEND,
+} from 'utils/default-strings';
 
 /**
  * The standard widget for a user contact an owner.
  * @returns {Object}
  */
 export const Component = ({
+  arrivalDateInputLabel,
   captchaInputImage,
+  captchaInputLabel,
+  commentsInputLabel,
+  departureDateInputLabel,
+  emailInputLabel,
+  guestsInputLabel,
+  headingText,
+  nameInputLabel,
   onChangeProperty,
   onSubmit,
+  phoneInputLabel,
+  propertyInputLabel,
   propertyOptions,
+  roomInputLabel,
   roomOptions,
+  submitButtonText,
 }) => (
-  <Form headingText="Contact" onSubmit={onSubmit} submitButtonText="Send">
+  <Form
+    headingText={headingText}
+    onSubmit={onSubmit}
+    submitButtonText={submitButtonText}
+  >
     <InputGroup>
-      <TextInput label="Name" name="name" />
-      <PhoneInput label="Phone" name="phone" />
+      <TextInput label={nameInputLabel} name="name" />
+      <PhoneInput label={phoneInputLabel} name="phone" />
     </InputGroup>
-    <TextInput label="Email" name="email" />
+    <TextInput label={emailInputLabel} name="email" />
     <InputGroup>
       <DateRangePicker
-        endDatePlaceholderText="Departure"
+        endDatePlaceholderText={departureDateInputLabel}
         name="dates"
-        startDatePlaceholderText="Arrival"
+        startDatePlaceholderText={arrivalDateInputLabel}
         width="eight"
       />
-      <TextInput label="Guests" name="guests" type="number" width="four" />
+      <TextInput
+        label={guestsInputLabel}
+        name="guests"
+        type="number"
+        width="four"
+      />
     </InputGroup>
-    <TextArea label="Comments" name="comments" />
+    <TextArea label={commentsInputLabel} name="comments" />
     {(roomOptions || propertyOptions) && (
       <InputGroup>
         {propertyOptions && (
           <Dropdown
-            label="Property"
+            label={propertyInputLabel}
             name="property"
             onChange={onChangeProperty}
             options={propertyOptions}
           />
         )}
         {roomOptions && (
-          <Dropdown label="Room" name="room" options={roomOptions} />
+          <Dropdown label={roomInputLabel} name="room" options={roomOptions} />
         )}
       </InputGroup>
     )}
     <CaptchaInput
       image={captchaInputImage}
-      label="Security Code"
+      label={captchaInputLabel}
       name="captcha"
     />
   </Form>
@@ -63,15 +98,43 @@ export const Component = ({
 Component.displayName = 'Contact';
 
 Component.defaultProps = {
+  arrivalDateInputLabel: ARRIVAL,
+  captchaInputLabel: SECURITY_CODE,
+  commentsInputLabel: COMMENTS,
+  departureDateInputLabel: DEPARTURE,
+  emailInputLabel: EMAIL,
+  guestsInputLabel: GUESTS,
+  headingText: CONTACT,
+  nameInputLabel: NAME,
   onChangeProperty: Function.prototype,
   onSubmit: Function.prototype,
+  phoneInputLabel: PHONE,
+  propertyInputLabel: PROPERTY,
   propertyOptions: null,
+  roomInputLabel: ROOM,
   roomOptions: null,
+  submitButtonText: SEND,
 };
 
 Component.propTypes = {
+  /** The label for the arrival date input.*/
+  arrivalDateInputLabel: PropTypes.string,
   /** The source url for the image to display. */
   captchaInputImage: PropTypes.string.isRequired,
+  /** The label for the captcha input.*/
+  captchaInputLabel: PropTypes.string,
+  /** The label for the comments input.*/
+  commentsInputLabel: PropTypes.string,
+  /** The label for the departure date input.*/
+  departureDateInputLabel: PropTypes.string,
+  /** The label for the email input.*/
+  emailInputLabel: PropTypes.string,
+  /** The label for the guests input.*/
+  guestsInputLabel: PropTypes.string,
+  /** The text to display as a heading at the top of the form. */
+  headingText: PropTypes.string,
+  /** The label for the name input.*/
+  nameInputLabel: PropTypes.string,
   /** The function called when the property dropdown is changed.
    *  @param {String}        name - The name of the property dropdown field.
    *  @param {String|Number} value - The value of the property dropdown after the change
@@ -81,6 +144,11 @@ Component.propTypes = {
    *  @param {Object} values - The values of the inputs in the form.
    */
   onSubmit: PropTypes.func,
+
+  /** The label for the phone input.*/
+  phoneInputLabel: PropTypes.string,
+  /** The label for the property input.*/
+  propertyInputLabel: PropTypes.string,
   /** The options which the user can select for the property field. */
   propertyOptions: PropTypes.arrayOf(
     PropTypes.shape({
@@ -94,6 +162,8 @@ Component.propTypes = {
       ]),
     })
   ),
+  /** The label for the room input.*/
+  roomInputLabel: PropTypes.string,
   /** The options which the user can select for the room field. */
   roomOptions: PropTypes.arrayOf(
     PropTypes.shape({
@@ -107,4 +177,6 @@ Component.propTypes = {
       ]),
     })
   ),
+  /** The text to display on the submit button. */
+  submitButtonText: PropTypes.string,
 };

--- a/src/components/general-widgets/Contact/component.spec.js
+++ b/src/components/general-widgets/Contact/component.spec.js
@@ -15,6 +15,20 @@ import { InputGroup } from 'collections/InputGroup';
 import { PhoneInput } from 'inputs/PhoneInput';
 import { TextArea } from 'inputs/TextArea';
 import { TextInput } from 'inputs/TextInput';
+import {
+  ARRIVAL,
+  CONTACT,
+  COMMENTS,
+  DEPARTURE,
+  EMAIL,
+  GUESTS,
+  NAME,
+  PHONE,
+  PROPERTY,
+  ROOM,
+  SECURITY_CODE,
+  SEND,
+} from 'utils/default-strings';
 
 import { roomOptions, propertyOptions } from './mock-data/options';
 import { Component as Contact } from './component';
@@ -37,9 +51,9 @@ describe('<Contact />', () => {
       const wrapper = getForm();
 
       expectComponentToHaveProps(wrapper, {
-        headingText: 'Contact',
+        headingText: CONTACT,
         onSubmit: Function.prototype,
-        submitButtonText: 'Send',
+        submitButtonText: SEND,
       });
     });
 
@@ -74,7 +88,7 @@ describe('<Contact />', () => {
         .at(0);
 
       expectComponentToHaveProps(wrapper, {
-        label: 'Name',
+        label: NAME,
         name: 'name',
       });
     });
@@ -85,7 +99,7 @@ describe('<Contact />', () => {
       const wrapper = getForm().find(PhoneInput);
 
       expectComponentToHaveProps(wrapper, {
-        label: 'Phone',
+        label: PHONE,
         name: 'phone',
       });
     });
@@ -98,7 +112,7 @@ describe('<Contact />', () => {
         .at(1);
 
       expectComponentToHaveProps(wrapper, {
-        label: 'Email',
+        label: EMAIL,
         name: 'email',
       });
     });
@@ -119,9 +133,9 @@ describe('<Contact />', () => {
       const wrapper = getForm().find(DateRangePicker);
 
       expectComponentToHaveProps(wrapper, {
-        endDatePlaceholderText: 'Departure',
+        endDatePlaceholderText: DEPARTURE,
         name: 'dates',
-        startDatePlaceholderText: 'Arrival',
+        startDatePlaceholderText: ARRIVAL,
         width: 'eight',
       });
     });
@@ -135,7 +149,7 @@ describe('<Contact />', () => {
         .find(TextInput);
 
       expectComponentToHaveProps(wrapper, {
-        label: 'Guests',
+        label: GUESTS,
         name: 'guests',
         type: 'number',
         width: 'four',
@@ -148,7 +162,7 @@ describe('<Contact />', () => {
       const wrapper = getForm().find(TextArea);
 
       expectComponentToHaveProps(wrapper, {
-        label: 'Comments',
+        label: COMMENTS,
         name: 'comments',
       });
     });
@@ -186,7 +200,7 @@ describe('<Contact />', () => {
         const wrapper = getFormWithPropertyOptions().find(Dropdown);
 
         expectComponentToHaveProps(wrapper, {
-          label: 'Property',
+          label: PROPERTY,
           name: 'property',
           onChange: expect.any(Function),
           options: propertyOptions,
@@ -227,7 +241,7 @@ describe('<Contact />', () => {
         const wrapper = getFormWithRoomOptions().find(Dropdown);
 
         expectComponentToHaveProps(wrapper, {
-          label: 'Room',
+          label: ROOM,
           name: 'room',
           onChange: expect.any(Function),
           options: roomOptions,
@@ -254,7 +268,7 @@ describe('<Contact />', () => {
 
       expectComponentToHaveProps(wrapper, {
         image: captchaInputImage,
-        label: 'Security Code',
+        label: SECURITY_CODE,
         name: 'captcha',
       });
     });

--- a/src/utils/default-strings/constants.js
+++ b/src/utils/default-strings/constants.js
@@ -1,0 +1,12 @@
+export const ARRIVAL = 'Arrival';
+export const CONTACT = 'Contact';
+export const COMMENTS = 'Comments';
+export const DEPARTURE = 'Departure';
+export const EMAIL = 'Email';
+export const GUESTS = 'Guests';
+export const NAME = 'Name';
+export const PHONE = 'Phone';
+export const PROPERTY = 'Property';
+export const ROOM = 'Room';
+export const SECURITY_CODE = 'Security code';
+export const SEND = 'Send';

--- a/src/utils/default-strings/index.js
+++ b/src/utils/default-strings/index.js
@@ -1,0 +1,1 @@
+export * from './constants';


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-839)

### What **one** thing does this PR do?
Exposes strings props on `Contact`.

### Any other notes

Please review this carefully as the agreed solution will be followed across all components.

I considered two approaches for exposing strings props...

1. Expose a single `strings` prop, being an object containing each of the necessary strings; and
1. Expose a single prop for each of the necessary strings.

I opted for 2., for the following reasons...

- Flat string props are great for rerendering on update. There are no complications associated with object identity.
- It makes use of the top level React `defaultProps` API with no intermediate steps. This is great both for simplicity of code and for props documentation in Styleguidist. 
- It is the simplest solution, requiring the minimum change.

One contentious point is the isolation of default strings as a module at `src/utils/default-strings`. This is good for the code - we avoid duplication and spelling mistakes - but it looks a bit wonky in the documentation... 

<img width="788" alt="screen shot 2018-08-17 at 12 23 34" src="https://user-images.githubusercontent.com/8591501/44261583-67409280-a218-11e8-8d94-7228fc5c1c6d.png">

I'm comfortable with the trade off. Considering our primary audience for the documentation is developers, I think the UPPERCASED identifiers are easily understood as constants.

I am merging this without review in order to unblock myself on [TE-833](https://youtrack.lodgify.net/issue/TE-833) but I am open to comments and amendments.





