### PR TITLE
TE-920 Tweaks for string prop naming

### DIFF
--- a/src/components/general-widgets/CallMeBack/Readme.md
+++ b/src/components/general-widgets/CallMeBack/Readme.md
@@ -35,18 +35,18 @@ const timeZoneOptions = [
 
 ```jsx
 <CallMeBack
-  datePlaceholderText="The Date"
+  dateInputPlaceholder="The Date"
   emailInputLabel="Your email address"
   headingText="Can you call me back?"
   nameInputLabel="Your name"
-  noteTextareaLabel="Some notes?"
+  notesInputLabel="Some notes?"
   phoneInputLabel="Your phone number"
-  propertyDropdownLabel="What property?"
+  propertyInputLabel="What property?"
   propertyOptions={[]}
   submitButtonText="Submit form"
-  timeDropdownLabel="Choose an ideal time"
+  timeInputLabel="Choose an ideal time"
   timeOptions={[]}
-  timezoneDropdownLabel="What is your time zone"
+  timeZoneInputLabel="What is your time zone"
   timeZoneOptions={[]}
 />
 ```

--- a/src/components/general-widgets/CallMeBack/component.js
+++ b/src/components/general-widgets/CallMeBack/component.js
@@ -27,19 +27,19 @@ import { ICON_NAMES } from 'elements/Icon';
  * @returns {Object}
  */
 export const Component = ({
-  datePlaceholderText,
+  dateInputPlaceholder,
   emailInputLabel,
   headingText,
   nameInputLabel,
-  noteTextareaLabel,
+  notesInputLabel,
   onSubmit,
   phoneInputLabel,
-  propertyDropdownLabel,
+  propertyInputLabel,
   propertyOptions,
   submitButtonText,
-  timeDropdownLabel,
+  timeInputLabel,
   timeOptions,
-  timezoneDropdownLabel,
+  timeZoneInputLabel,
   timeZoneOptions,
 }) => (
   <Form
@@ -53,65 +53,65 @@ export const Component = ({
     </InputGroup>
     <TextInput label={emailInputLabel} name="email" />
     <InputGroup>
-      <SingleDatePicker name="date" placeholderText={datePlaceholderText} />
+      <SingleDatePicker name="date" placeholderText={dateInputPlaceholder} />
       <Dropdown
         icon={ICON_NAMES.CLOCK}
-        label={timeDropdownLabel}
+        label={timeInputLabel}
         name="time"
         options={timeOptions}
       />
     </InputGroup>
     <InputGroup>
       <Dropdown
-        label={timezoneDropdownLabel}
+        label={timeZoneInputLabel}
         name="timeZone"
         options={timeZoneOptions}
       />
       <Dropdown
-        label={propertyDropdownLabel}
+        label={propertyInputLabel}
         name="property"
         options={propertyOptions}
       />
     </InputGroup>
-    <TextArea label={noteTextareaLabel} name="notes" />
+    <TextArea label={notesInputLabel} name="notes" />
   </Form>
 );
 
 Component.displayName = 'CallMeBack';
 
 Component.defaultProps = {
-  datePlaceholderText: DATE,
+  dateInputPlaceholder: DATE,
   emailInputLabel: EMAIL,
   headingText: CALL_ME_BACK,
   nameInputLabel: NAME,
-  noteTextareaLabel: NOTES,
+  notesInputLabel: NOTES,
   onSubmit: Function.prototype,
   phoneInputLabel: PHONE,
-  propertyDropdownLabel: PROPERTY,
+  propertyInputLabel: PROPERTY,
   submitButtonText: SEND,
-  timeDropdownLabel: TIME,
-  timezoneDropdownLabel: TIME_ZONE,
+  timeInputLabel: TIME,
+  timeZoneInputLabel: TIME_ZONE,
 };
 
 Component.propTypes = {
-  /** The placeholder text for the date input */
-  datePlaceholderText: PropTypes.string,
-  /** The label for the email input */
+  /** The placeholder for the date input. */
+  dateInputPlaceholder: PropTypes.string,
+  /** The label for the email input. */
   emailInputLabel: PropTypes.string,
-  /** The text for the heading displayed above the call me back form */
+  /** The text to display as a heading at the top of the widget. */
   headingText: PropTypes.string,
-  /** The label for the name input */
+  /** The label for the name input. */
   nameInputLabel: PropTypes.string,
-  /** The label for the note text area */
-  noteTextareaLabel: PropTypes.string,
+  /** The label for the notes input. */
+  notesInputLabel: PropTypes.string,
   /** The function to call when the form is submitted
    *  @param {Object} values - The values of the inputs in the form.
    */
   onSubmit: PropTypes.func,
   /** The label for the phone input */
   phoneInputLabel: PropTypes.string,
-  /** The label for the property dropdown */
-  propertyDropdownLabel: PropTypes.string,
+  /** The label for the property input. */
+  propertyInputLabel: PropTypes.string,
   /** The options which the user can select for the property field. */
   propertyOptions: PropTypes.arrayOf(
     PropTypes.shape({
@@ -127,8 +127,8 @@ Component.propTypes = {
   ).isRequired,
   /** The form submit button text */
   submitButtonText: PropTypes.string,
-  /** The label for the time dropdown */
-  timeDropdownLabel: PropTypes.string,
+  /** The label for the time input. */
+  timeInputLabel: PropTypes.string,
   /** The options which the user can select for the time field. */
   timeOptions: PropTypes.arrayOf(
     PropTypes.shape({
@@ -142,6 +142,8 @@ Component.propTypes = {
       ]),
     })
   ).isRequired,
+  /** The label for the time zone input. */
+  timeZoneInputLabel: PropTypes.string,
   /** The options which the user can select for the time zone field. */
   timeZoneOptions: PropTypes.arrayOf(
     PropTypes.shape({
@@ -155,6 +157,4 @@ Component.propTypes = {
       ]),
     })
   ).isRequired,
-  /** The label for the time zone dropdown */
-  timezoneDropdownLabel: PropTypes.string,
 };

--- a/src/components/general-widgets/Contact/component.js
+++ b/src/components/general-widgets/Contact/component.js
@@ -131,7 +131,7 @@ Component.propTypes = {
   emailInputLabel: PropTypes.string,
   /** The label for the guests input.*/
   guestsInputLabel: PropTypes.string,
-  /** The text to display as a heading at the top of the form. */
+  /** The text to display as a heading at the top of the widget. */
   headingText: PropTypes.string,
   /** The label for the name input.*/
   nameInputLabel: PropTypes.string,

--- a/src/components/general-widgets/OwnerLogin/Readme.md
+++ b/src/components/general-widgets/OwnerLogin/Readme.md
@@ -8,13 +8,13 @@
 
 ```jsx
 <OwnerLogin
-  emailLabel="Email Address"
-  forgotPasswordButtonText="Reset Password"
+  emailInputLabel="Email Address"
+  forgotPasswordEmailInputLabel="Enter email to reset"
   forgotPasswordHeadingText="Forgot the password"
-  forgotPasswordEmailLabel="Enter email to reset"
-  forgotPasswordModelTriggerText="Click to reset password"
-  loginFormButtonText="Log into website"
-  loginFormHeadingText="Login to the site"
-  passwordLabel="Your Password"
+  forgotPasswordModalTriggerText="Click to reset password"
+  forgotPasswordSubmitButtonText="Reset Password"
+  headingText="Log in to the site"
+  passwordInputLabel="Your Password"
+  submitButtonText="Log in to website"
 />
 ```

--- a/src/components/general-widgets/OwnerLogin/component.js
+++ b/src/components/general-widgets/OwnerLogin/component.js
@@ -19,66 +19,64 @@ import { getForgotPasswordFormMarkup } from './utils/getForgotPasswordFormMarkup
  * @returns {Object}
  */
 export const Component = ({
-  emailLabel,
-  forgotPasswordButtonText,
-  forgotPasswordEmailLabel,
+  emailInputLabel,
+  forgotPasswordEmailInputLabel,
   forgotPasswordHeadingText,
-  forgotPasswordModelTriggerText,
-  loginFormButtonText,
-  loginFormHeadingText,
+  forgotPasswordModalTriggerText,
+  forgotPasswordSubmitButtonText,
+  submitButtonText,
+  headingText,
   onForgotPasswordSubmit,
   onSubmit,
-  passwordLabel,
+  passwordInputLabel,
 }) => (
   <Form
     actionLink={{
       text: getForgotPasswordFormMarkup(
         onForgotPasswordSubmit,
-        forgotPasswordButtonText,
-        forgotPasswordEmailLabel,
+        forgotPasswordSubmitButtonText,
+        forgotPasswordEmailInputLabel,
         forgotPasswordHeadingText,
-        forgotPasswordModelTriggerText
+        forgotPasswordModalTriggerText
       ),
     }}
-    headingText={loginFormHeadingText}
+    headingText={headingText}
     onSubmit={onSubmit}
-    submitButtonText={loginFormButtonText}
+    submitButtonText={submitButtonText}
   >
-    <TextInput label={emailLabel} name="email" />
-    <TextInput label={passwordLabel} name="password" type="password" />
+    <TextInput label={emailInputLabel} name="email" />
+    <TextInput label={passwordInputLabel} name="password" type="password" />
   </Form>
 );
 
 Component.displayName = 'OwnerLogin';
 
 Component.defaultProps = {
-  emailLabel: EMAIL,
-  forgotPasswordButtonText: SEND_RESET,
+  emailInputLabel: EMAIL,
+  forgotPasswordEmailInputLabel: EMAIL,
   forgotPasswordHeadingText: FORGOT_PASSWORD,
-  forgotPasswordEmailLabel: EMAIL,
-  forgotPasswordModelTriggerText: FORGOT_PASSWORD,
-  loginFormButtonText: LOGIN,
-  loginFormHeadingText: OWNER_LOGIN,
+  forgotPasswordModalTriggerText: FORGOT_PASSWORD,
+  forgotPasswordSubmitButtonText: SEND_RESET,
+  submitButtonText: LOGIN,
+  headingText: OWNER_LOGIN,
   onForgotPasswordSubmit: Function.prototype,
   onSubmit: Function.prototype,
-  passwordLabel: PASSWORD,
+  passwordInputLabel: PASSWORD,
 };
 
 Component.propTypes = {
-  /** The login form heading text */
-  emailLabel: PropTypes.string,
-  /** The forgot password button text */
-  forgotPasswordButtonText: PropTypes.string,
-  /** The email label for forgot password */
-  forgotPasswordEmailLabel: PropTypes.string,
-  /** The forgot password heading text */
+  /** The label for the email input. */
+  emailInputLabel: PropTypes.string,
+  /** The label for the email input on the forgot password form. */
+  forgotPasswordEmailInputLabel: PropTypes.string,
+  /** The text to display as a heading at the top of the forgot password form. */
   forgotPasswordHeadingText: PropTypes.string,
-  /** The trigger forgot password model text */
-  forgotPasswordModelTriggerText: PropTypes.string,
-  /** The login form button text */
-  loginFormButtonText: PropTypes.string,
-  /** The login form heading text */
-  loginFormHeadingText: PropTypes.string,
+  /** The text for the forgot password form modal trigger. */
+  forgotPasswordModalTriggerText: PropTypes.string,
+  /** The text to display on the submit button on the forgot password form.. */
+  forgotPasswordSubmitButtonText: PropTypes.string,
+  /** The text to display as a heading at the top of the widget. */
+  headingText: PropTypes.string,
   /** The function to call when the forgot password form is submitted
    *  @param {Object} values - The values of the inputs in the form.
    */
@@ -87,6 +85,8 @@ Component.propTypes = {
    *  @param {Object} values - The values of the inputs in the form.
    */
   onSubmit: PropTypes.func,
-  /** The password label */
-  passwordLabel: PropTypes.string,
+  /** The label for the password input. */
+  passwordInputLabel: PropTypes.string,
+  /** The text to display on the submit button. */
+  submitButtonText: PropTypes.string,
 };

--- a/src/components/general-widgets/OwnerLogin/component.spec.js
+++ b/src/components/general-widgets/OwnerLogin/component.spec.js
@@ -12,7 +12,6 @@ import { Form } from 'collections/Form';
 import { TextInput } from 'inputs/TextInput';
 
 import { Component as OwnerLogin } from './component';
-import { getForgotPasswordFormMarkup } from './utils/getForgotPasswordFormMarkup';
 
 const getOwnerLogin = () => shallow(<OwnerLogin />);
 
@@ -35,7 +34,7 @@ describe('<OwnerLogin />', () => {
 
       expectComponentToHaveProps(wrapper, {
         actionLink: {
-          text: getForgotPasswordFormMarkup(Function.prototype),
+          text: expect.any(Object),
         },
         headingText: OWNER_LOGIN,
         onSubmit: Function.prototype,

--- a/src/components/general-widgets/OwnerLogin/utils/getForgotPasswordFormMarkup.js
+++ b/src/components/general-widgets/OwnerLogin/utils/getForgotPasswordFormMarkup.js
@@ -1,32 +1,31 @@
 import React from 'react';
 
-import { FORGOT_PASSWORD, SEND_RESET, EMAIL } from 'utils/default-strings';
 import { Form } from 'collections/Form';
 import { Modal } from 'elements/Modal';
 import { TextInput } from 'inputs/TextInput';
 
 /**
  * @param {Function}  onForgotPasswordSubmit
- * @param {String}    forgotPasswordButtonText
- * @param {String}    forgotPasswordEmailLabel
+ * @param {String}    forgotPasswordSubmitButtonText
+ * @param {String}    forgotPasswordEmailInputLabel
  * @param {String}    forgotPasswordHeadingText
- * @param {String}    forgotPasswordModelTriggerText
+ * @param {String}    forgotPasswordModalTriggerText
  * @return {Object}
  */
 export const getForgotPasswordFormMarkup = (
   onForgotPasswordSubmit,
-  forgotPasswordButtonText = SEND_RESET,
-  forgotPasswordEmailLabel = EMAIL,
-  forgotPasswordHeadingText = FORGOT_PASSWORD,
-  forgotPasswordModelTriggerText = FORGOT_PASSWORD
+  forgotPasswordSubmitButtonText,
+  forgotPasswordEmailInputLabel,
+  forgotPasswordHeadingText,
+  forgotPasswordModalTriggerText
 ) => (
-  <Modal trigger={<span>{forgotPasswordModelTriggerText}</span>}>
+  <Modal trigger={<span>{forgotPasswordModalTriggerText}</span>}>
     <Form
       headingText={forgotPasswordHeadingText}
       onSubmit={onForgotPasswordSubmit}
-      submitButtonText={forgotPasswordButtonText}
+      submitButtonText={forgotPasswordSubmitButtonText}
     >
-      <TextInput label={forgotPasswordEmailLabel} name="email" />
+      <TextInput label={forgotPasswordEmailInputLabel} name="email" />
     </Form>
   </Modal>
 );

--- a/src/components/general-widgets/OwnerLogin/utils/getForgotPasswordFormMarkup.spec.js
+++ b/src/components/general-widgets/OwnerLogin/utils/getForgotPasswordFormMarkup.spec.js
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import { FORGOT_PASSWORD, SEND_RESET, EMAIL } from 'utils/default-strings';
 import { Form } from 'collections/Form';
 import { Modal } from 'elements/Modal';
 import { TextInput } from 'inputs/TextInput';
@@ -10,16 +9,26 @@ import { getForgotPasswordFormMarkup } from './getForgotPasswordFormMarkup';
 describe('getForgotPasswordFormMarkup', () => {
   it('should return the right markup ', () => {
     const someFunction = () => {};
-    const actual = getForgotPasswordFormMarkup(someFunction);
+    const forgotPasswordSubmitButtonText = 'A';
+    const forgotPasswordEmailInputLabel = 'B';
+    const forgotPasswordHeadingText = 'C';
+    const forgotPasswordModalTriggerText = 'D';
+    const actual = getForgotPasswordFormMarkup(
+      someFunction,
+      forgotPasswordSubmitButtonText,
+      forgotPasswordEmailInputLabel,
+      forgotPasswordHeadingText,
+      forgotPasswordModalTriggerText
+    );
 
     expect(actual).toEqual(
-      <Modal trigger={<span>{FORGOT_PASSWORD}</span>}>
+      <Modal trigger={<span>{forgotPasswordModalTriggerText}</span>}>
         <Form
-          headingText={FORGOT_PASSWORD}
+          headingText={forgotPasswordHeadingText}
           onSubmit={someFunction}
-          submitButtonText={SEND_RESET}
+          submitButtonText={forgotPasswordSubmitButtonText}
         >
-          <TextInput label={EMAIL} name="email" />
+          <TextInput label={forgotPasswordEmailInputLabel} name="email" />
         </Form>
       </Modal>
     );

--- a/src/components/general-widgets/OwnerSignUp/Readme.md
+++ b/src/components/general-widgets/OwnerSignUp/Readme.md
@@ -8,10 +8,10 @@
 
 ```jsx
 <OwnerSignUp
-  emailLabel="Enter email"
-  firstNameLabel="Your first name"
-  formButtonText="Submit here"
-  formHeadingText="Sign up today!"
-  lastNameLabel="Your last name"
+  emailInputLabel="Enter email"
+  firstNameInputLabel="Your first name"
+  headingText="Sign up today!"
+  lastNameInutLabel="Your last name"
+  submitButtonText="Submit here"
 />
 ```

--- a/src/components/general-widgets/OwnerSignUp/component.js
+++ b/src/components/general-widgets/OwnerSignUp/component.js
@@ -16,48 +16,48 @@ import { TextInput } from 'inputs/TextInput';
  * @returns {Object}
  */
 export const Component = ({
-  emailLabel,
-  firstNameLabel,
-  formButtonText,
-  formHeadingText,
-  lastNameLabel,
+  emailInputLabel,
+  firstNameInputLabel,
+  headingText,
+  lastNameInputLabel,
   onSubmit,
+  submitButtonText,
 }) => (
   <Form
-    headingText={formHeadingText}
+    headingText={headingText}
     onSubmit={onSubmit}
-    submitButtonText={formButtonText}
+    submitButtonText={submitButtonText}
   >
-    <TextInput label={firstNameLabel} name="firstName" />
-    <TextInput label={lastNameLabel} name="lastName" />
-    <TextInput label={emailLabel} name="email" />
+    <TextInput label={firstNameInputLabel} name="firstName" />
+    <TextInput label={lastNameInputLabel} name="lastName" />
+    <TextInput label={emailInputLabel} name="email" />
   </Form>
 );
 
 Component.displayName = 'OwnerSignUp';
 
 Component.defaultProps = {
-  emailLabel: EMAIL,
-  firstNameLabel: FIRST_NAME,
-  formButtonText: SIGN_UP,
-  formHeadingText: OWNER_SIGNUP,
-  lastNameLabel: LAST_NAME,
+  emailInputLabel: EMAIL,
+  firstNameInputLabel: FIRST_NAME,
+  headingText: OWNER_SIGNUP,
+  lastNameInputLabel: LAST_NAME,
   onSubmit: Function.prototype,
+  submitButtonText: SIGN_UP,
 };
 
 Component.propTypes = {
-  /** The label for the email input */
-  emailLabel: PropTypes.string,
-  /** The label for the first name input */
-  firstNameLabel: PropTypes.string,
-  /** The text displayed inside the form submit button */
-  formButtonText: PropTypes.string,
-  /** The text displayed at the top of the form */
-  formHeadingText: PropTypes.string,
+  /** The label for the email input. */
+  emailInputLabel: PropTypes.string,
+  /** The label for the first name input. */
+  firstNameInputLabel: PropTypes.string,
+  /** The text to display as a heading at the top of the widget. */
+  headingText: PropTypes.string,
   /** The label for the last name input */
-  lastNameLabel: PropTypes.string,
+  lastNameInputLabel: PropTypes.string,
   /** The function to call when the form is submitted
    *  @param {Object} values - The values of the inputs in the form.
    */
   onSubmit: PropTypes.func,
+  /** The text to display on the submit button. */
+  submitButtonText: PropTypes.string,
 };

--- a/src/components/general-widgets/Promotion/component.js
+++ b/src/components/general-widgets/Promotion/component.js
@@ -117,7 +117,7 @@ Component.propTypes = {
   discountCodeParagraphText: PropTypes.string,
   /** The text for the button that shows on hover */
   discountHoverButtonText: PropTypes.string,
-  /** The heading text */
+  /** The text to display as a heading at the top of the widget. */
   headingText: PropTypes.string.isRequired,
   /** Is the component displayed with each item above one another */
   isDisplayedStacked: PropTypes.bool,

--- a/src/components/property-page-widgets/HostProfile/Readme.md
+++ b/src/components/property-page-widgets/HostProfile/Readme.md
@@ -22,7 +22,8 @@ const languages = ['English', 'Italian', 'German', 'Spanish'];
   description={description}
   email={email}
   phone={phone}
-  languages={languages} />
+  languages={languages}
+/>
 ```
 
 ### Content
@@ -34,11 +35,10 @@ const name = 'Mitjons & Kira';
 const description = `Cats have keen vision; they can see much more detail than dogs.
 Concentrated in the center of the retina of the eye, a specific type of cell called a cone gives cats
 excellent visual acuity and binocular vision.`;
-
 const contactInformationHeadingText = 'Contact details';
 const email = 'welovecats@lodgify.com';
 const emailLabel = 'Email Address';
-const hostProfileHeadingText = 'Profile';
+const headingText = 'Profile';
 const languages = ['English', 'Italian', 'German', 'Spanish'];
 const languagesLabel = 'Spoken languages';
 const phone = '+34932206524';
@@ -50,11 +50,11 @@ const phoneLabel = 'Tel';
   description={description}
   email={email}
   emailLabel={emailLabel}
-  hostProfileHeadingText={hostProfileHeadingText}
+  headingText={headingText}
   languages={languages}
   languagesLabel={languagesLabel}
   name={name}
   phone={phone}
   phoneLabel={phoneLabel}
-  />
+/>
 ```

--- a/src/components/property-page-widgets/HostProfile/component.js
+++ b/src/components/property-page-widgets/HostProfile/component.js
@@ -15,6 +15,8 @@ import { GridRow } from 'layout/GridRow';
 import { GridColumn } from 'layout/GridColumn';
 import { Paragraph } from 'typography/Paragraph';
 
+import { getStringWithColonSuffix } from './utils/getStringWithColonSuffix';
+
 /**
  * The standard widget for displaying the property host information.
  * @returns {Object}
@@ -25,7 +27,7 @@ export const Component = ({
   description,
   email,
   emailLabel,
-  hostProfileHeadingText,
+  headingText,
   languages,
   languagesLabel,
   name,
@@ -35,7 +37,7 @@ export const Component = ({
   <Grid textAlign="left">
     <GridRow>
       <GridColumn width={12}>
-        <Heading>{hostProfileHeadingText}</Heading>
+        <Heading>{headingText}</Heading>
       </GridColumn>
     </GridRow>
     <GridRow>
@@ -59,19 +61,19 @@ export const Component = ({
         <List relaxed size="medium">
           {!!email && (
             <List.Item>
-              <span>{`${emailLabel}: `}</span>
+              <span>{getStringWithColonSuffix(emailLabel)}</span>
               <span>{email}</span>
             </List.Item>
           )}
           {!!phone && (
             <List.Item>
-              <span>{`${phoneLabel}: `}</span>
+              <span>{getStringWithColonSuffix(phoneLabel)}</span>
               <span>{phone}</span>
             </List.Item>
           )}
           {!!languages && (
             <List.Item>
-              <span>{`${languagesLabel}: `}</span>
+              <span>{getStringWithColonSuffix(languagesLabel)}</span>
               <span>{languages.join(', ')}</span>
             </List.Item>
           )}
@@ -88,7 +90,7 @@ Component.defaultProps = {
   contactInformationHeadingText: CONTACT_INFORMATION,
   email: null,
   emailLabel: EMAIL,
-  hostProfileHeadingText: YOUR_HOST,
+  headingText: YOUR_HOST,
   languages: null,
   languagesLabel: LANGUAGES,
   phone: null,
@@ -106,8 +108,8 @@ Component.propTypes = {
   email: PropTypes.string,
   /** The label for the contact email address. */
   emailLabel: PropTypes.string,
-  /** The text for the host profile heading. */
-  hostProfileHeadingText: PropTypes.string,
+  /** The text to display as a heading at the top of the widget. */
+  headingText: PropTypes.string,
   /** The languages the property host speaks. */
   languages: PropTypes.arrayOf(PropTypes.string),
   /** The label for the contact languages. */

--- a/src/components/property-page-widgets/HostProfile/utils/getStringWithColonSuffix.js
+++ b/src/components/property-page-widgets/HostProfile/utils/getStringWithColonSuffix.js
@@ -1,0 +1,5 @@
+/**
+ * @param  {String} string
+ * @return {String}
+ */
+export const getStringWithColonSuffix = string => `${string}: `;

--- a/src/components/property-page-widgets/HostProfile/utils/getStringWithColonSuffix.spec.js
+++ b/src/components/property-page-widgets/HostProfile/utils/getStringWithColonSuffix.spec.js
@@ -1,0 +1,10 @@
+import { getStringWithColonSuffix } from './getStringWithColonSuffix';
+
+describe('`getStringWithColonSuffix`', () => {
+  it('should return the right string', () => {
+    const string = '🏰';
+    const actual = getStringWithColonSuffix(string);
+
+    expect(actual).toBe(`${string}: `);
+  });
+});

--- a/src/components/property-page-widgets/KeyFacts/Readme.md
+++ b/src/components/property-page-widgets/KeyFacts/Readme.md
@@ -4,10 +4,12 @@ const { keyFacts } = require('./mock-data/keyFacts');
 <KeyFacts keyFacts={keyFacts} />
 ```
 
+### Content
+
 #### Strings
 
 ```jsx
 const { keyFacts } = require('./mock-data/keyFacts');
 
-<KeyFacts keyFacts={keyFacts} keyFactsHeadingText="My title" />
+<KeyFacts keyFacts={keyFacts} headingText="What to expect" />
 ```

--- a/src/components/property-page-widgets/KeyFacts/component.js
+++ b/src/components/property-page-widgets/KeyFacts/component.js
@@ -13,10 +13,10 @@ import { IconCard } from 'elements/IconCard';
  * The standard widget for displaying key facts about a property.
  * @returns {Object}
  */
-export const Component = ({ keyFacts, keyFactsHeadingText }) => (
+export const Component = ({ keyFacts, headingText }) => (
   <Grid>
     <GridColumn width={12}>
-      <Heading>{keyFactsHeadingText}</Heading>
+      <Heading>{headingText}</Heading>
     </GridColumn>
     <GridColumn width={12}>
       <Label.Group>
@@ -37,10 +37,12 @@ export const Component = ({ keyFacts, keyFactsHeadingText }) => (
 Component.displayName = 'KeyFacts';
 
 Component.defaultProps = {
-  keyFactsHeadingText: KEY_FACTS,
+  headingText: KEY_FACTS,
 };
 
 Component.propTypes = {
+  /** The text to display as a heading at the top of the widget. */
+  headingText: PropTypes.string,
   /** The key facts to display as icon cards. */
   keyFacts: PropTypes.arrayOf(
     PropTypes.shape({
@@ -55,6 +57,4 @@ Component.propTypes = {
       label: PropTypes.string.isRequired,
     })
   ).isRequired,
-  /** The key facts heading text */
-  keyFactsHeadingText: PropTypes.string,
 };

--- a/src/components/property-page-widgets/Location/Readme.md
+++ b/src/components/property-page-widgets/Location/Readme.md
@@ -27,10 +27,10 @@ const {
 } = require('./mock-data/props');
 
 <Location
+  headingText="Where to find us"
   isShowingExactLocation
   latitude={41.387863}
   locationDescription={locationDescription}
-  locationHeadingText="heading text"
   locationSummary={locationSummary}
   longitude={2.158105}
   transportOptions={transportOptions}

--- a/src/components/property-page-widgets/Location/component.js
+++ b/src/components/property-page-widgets/Location/component.js
@@ -23,19 +23,19 @@ import { getGoogleMapHeight } from './utils/getGoogleMapHeight';
  * @returns {Object}
  */
 const Component = ({
+  headingText,
   isShowingApproximateLocation,
   isShowingExactLocation,
   isUserOnMobile,
   latitude,
   locationDescription,
-  locationHeadingText,
   locationSummary,
   longitude,
   transportOptions,
 }) => (
   <Grid stackable>
     <GridColumn width={12}>
-      <Heading>{locationHeadingText}</Heading>
+      <Heading>{headingText}</Heading>
       <Subheading>{locationSummary}</Subheading>
     </GridColumn>
     <GridColumn computer={6} tablet={12}>
@@ -72,12 +72,14 @@ const Component = ({
 Component.displayName = 'Location';
 
 Component.defaultProps = {
-  locationHeadingText: LOCATION,
+  headingText: LOCATION,
   isShowingApproximateLocation: false,
   isShowingExactLocation: false,
 };
 
 Component.propTypes = {
+  /** The text to display as a heading at the top of the widget. */
+  headingText: PropTypes.string,
   /** Is the map showing a marker for the approximate location. */
   isShowingApproximateLocation: PropTypes.bool,
   /** Is the map showing a marker for the exact location. */
@@ -92,8 +94,6 @@ Component.propTypes = {
   latitude: PropTypes.number.isRequired,
   /** The text description of the location. */
   locationDescription: PropTypes.string.isRequired,
-  /** The location heading text */
-  locationHeadingText: PropTypes.string,
   /** The summary of the location. */
   locationSummary: PropTypes.string.isRequired,
   /** The longitude coordinate for the center of the map and/or location of the marker */

--- a/src/components/property-page-widgets/PaymentInformation/Readme.md
+++ b/src/components/property-page-widgets/PaymentInformation/Readme.md
@@ -68,20 +68,20 @@ const damageDepositText = `A refundable damage deposit of 200.00 € (EUR) is du
 const notesText = null;
 
 <PaymentInformation
-  paymentScheduleText={paymentScheduleText}
-  cleaningCharge={cleaningCharge}
-  cancellationPolicyText={cancellationPolicyText}
-  taxesText={taxesText}
-  taxesDescriptionText={taxesDescriptionText}
-  damageDepositText={damageDepositText}
-  notesText={notesText}
   cancellationPolicyHeadingText="Cancel"
+  cancellationPolicyText={cancellationPolicyText}
+  cleaningCharge={cleaningCharge}
   cleaningChargeHeadingText="Cleaning"
   damageDepositHeadingText="Damage"
-  paymentInformationHeadingText="Heading"
+  damageDepositText={damageDepositText}
+  headingText="How we charge"
+  modalTriggerText="See more"
   notesHeadingText="Notes"
+  notesText={notesText}
   paymentScheduleHeadingText="Payment"
+  paymentScheduleText={paymentScheduleText}
+  taxesDescriptionText={taxesDescriptionText}
   taxesHeadingText="Taxes info"
-  modalViewMoreTriggerText="See more"
+  taxesText={taxesText}
 />
 ```

--- a/src/components/property-page-widgets/PaymentInformation/component.js
+++ b/src/components/property-page-widgets/PaymentInformation/component.js
@@ -34,10 +34,10 @@ export const Component = ({
   damageDepositHeadingText,
   damageDepositText,
   extraNotesText,
-  modalViewMoreTriggerText,
+  modalTriggerText,
   notesHeadingText,
   notesText,
-  paymentInformationHeadingText,
+  headingText,
   paymentScheduleHeadingText,
   paymentScheduleText,
   taxesDescriptionText,
@@ -47,7 +47,7 @@ export const Component = ({
   <Grid stackable>
     <GridRow>
       <GridColumn width={12}>
-        <Heading>{paymentInformationHeadingText}</Heading>
+        <Heading>{headingText}</Heading>
       </GridColumn>
     </GridRow>
     <GridRow>
@@ -103,7 +103,7 @@ export const Component = ({
     {!!extraNotesText && (
       <GridRow>
         <GridColumn width={12}>
-          <Modal trigger={<Link>{modalViewMoreTriggerText}</Link>}>
+          <Modal trigger={<Link>{modalTriggerText}</Link>}>
             {getParagraphsFromStrings(extraNotesText).map(
               (paragraphText, index) => (
                 <Paragraph key={buildKeyFromStrings(paragraphText, index)}>
@@ -128,10 +128,10 @@ Component.defaultProps = {
   damageDepositHeadingText: DAMAGE_DEPOSIT,
   damageDepositText: null,
   extraNotesText: null,
-  modalViewMoreTriggerText: VIEW_MORE,
+  modalTriggerText: VIEW_MORE,
   notesHeadingText: NOTES,
   notesText: null,
-  paymentInformationHeadingText: PAYMENT_INFORMATION,
+  headingText: PAYMENT_INFORMATION,
   paymentScheduleHeadingText: PAYMENT_SCHEDULE,
   paymentScheduleText: null,
   taxesDescriptionText: null,
@@ -154,14 +154,14 @@ Component.propTypes = {
   damageDepositText: PropTypes.string,
   /** The Extra Notes text to display. */
   extraNotesText: PropTypes.string,
+  /** The text to display as a heading at the top of the widget. */
+  headingText: PropTypes.string,
   /** The View More trigger text */
-  modalViewMoreTriggerText: PropTypes.string,
+  modalTriggerText: PropTypes.string,
   /** The Notes heading text */
   notesHeadingText: PropTypes.string,
   /** The Notes text to display. */
   notesText: PropTypes.string,
-  /** The Payment Information heading text */
-  paymentInformationHeadingText: PropTypes.string,
   /** The Payment Schedule heading text */
   paymentScheduleHeadingText: PropTypes.string,
   /** The Payment Schedule text to display. */

--- a/src/components/property-page-widgets/Pictures/Readme.md
+++ b/src/components/property-page-widgets/Pictures/Readme.md
@@ -13,6 +13,7 @@ const { pictures } = require('./mock-data/pictures');
 
 <Pictures
   pictures={pictures}
-  propertyPicturesHeadingText="The Heading text"
-  propertyPicturesLinkText="Click here" />
+  headingText="Photos of the property"
+  linkText="Click here for more" 
+/>
 ```

--- a/src/components/property-page-widgets/Pictures/component.js
+++ b/src/components/property-page-widgets/Pictures/component.js
@@ -15,14 +15,10 @@ import { Link } from 'elements/Link';
  * The standard widget for displaying pictures of a property.
  * @returns {Object}
  */
-export const Component = ({
-  pictures,
-  propertyPicturesHeadingText,
-  propertyPicturesLinkText,
-}) => (
+export const Component = ({ headingText, linkText, pictures }) => (
   <Grid>
     <GridColumn width={12}>
-      <Heading>{propertyPicturesHeadingText}</Heading>
+      <Heading>{headingText}</Heading>
     </GridColumn>
     {pictures.map(({ imageUrl, label }, index) => (
       <GridColumn key={buildKeyFromStrings(label, index)} width={4}>
@@ -41,7 +37,7 @@ export const Component = ({
       </GridColumn>
     ))}
     <GridColumn width={12}>
-      <Link>{propertyPicturesLinkText}</Link>
+      <Link>{linkText}</Link>
     </GridColumn>
   </Grid>
 );
@@ -49,11 +45,15 @@ export const Component = ({
 Component.displayName = 'Pictures';
 
 Component.defaultProps = {
-  propertyPicturesHeadingText: PROPERTY_PICTURES,
-  propertyPicturesLinkText: EXPLORE_ALL_PICTURES,
+  headingText: PROPERTY_PICTURES,
+  linkText: EXPLORE_ALL_PICTURES,
 };
 
 Component.propTypes = {
+  /** The text to display as a heading at the top of the widget. */
+  headingText: PropTypes.string,
+  /** The text to display on the link at the bottom of the widget. */
+  linkText: PropTypes.string,
   /** The pictures to display as responsive images. */
   pictures: PropTypes.arrayOf(
     PropTypes.shape({
@@ -63,8 +63,4 @@ Component.propTypes = {
       label: PropTypes.string.isRequired,
     })
   ).isRequired,
-  /** The heading text */
-  propertyPicturesHeadingText: PropTypes.string,
-  /** The link text */
-  propertyPicturesLinkText: PropTypes.string,
 };

--- a/src/components/property-page-widgets/Reviews/Readme.md
+++ b/src/components/property-page-widgets/Reviews/Readme.md
@@ -32,6 +32,8 @@ const reviews = [
 <Reviews ratingAverage={ratingAverage} reviews={reviews} />;
 ```
 
+### Content
+
 #### Strings
 
 ```jsx
@@ -49,5 +51,10 @@ const reviews = [
   },
 ];
 
-<Reviews ratingAverage={ratingAverage} reviews={reviews} reviewsHeadingText="The title" submitReviewButtonText="Add a new review" />;
+<Reviews
+  headingText="What our guests say..."
+  ratingAverage={ratingAverage}
+  reviews={reviews}
+  submitButtonText="Add a new review"
+/>;
 ```

--- a/src/components/property-page-widgets/Reviews/component.js
+++ b/src/components/property-page-widgets/Reviews/component.js
@@ -17,15 +17,15 @@ import { REVIEWS, SUBMIT_REVIEW } from 'utils/default-strings';
  * @returns {Object}
  */
 export const Component = ({
+  headingText,
   reviews,
   ratingAverage,
-  reviewsHeadingText,
-  submitReviewButtonText,
+  submitButtonText,
 }) => (
   <Grid>
     <GridRow>
       <GridColumn width={12}>
-        <Heading>{reviewsHeadingText}</Heading>
+        <Heading>{headingText}</Heading>
       </GridColumn>
     </GridRow>
     <GridRow verticalAlign="middle">
@@ -53,7 +53,7 @@ export const Component = ({
         verticalAlign="middle"
       >
         <Button isCompact isPositionedRight isRounded size="medium">
-          {submitReviewButtonText}
+          {submitButtonText}
         </Button>
       </GridColumn>
     </GridRow>
@@ -71,12 +71,14 @@ export const Component = ({
 Component.displayName = 'Reviews';
 
 Component.defaultProps = {
+  headingText: REVIEWS,
   reviews: [],
-  reviewsHeadingText: REVIEWS,
-  submitReviewButtonText: SUBMIT_REVIEW,
+  submitButtonText: SUBMIT_REVIEW,
 };
 
 Component.propTypes = {
+  /** The text to display as a heading at the top of the widget. */
+  headingText: PropTypes.string,
   /** The average numeral rating for the properties. */
   ratingAverage: PropTypes.number.isRequired,
   /** The collection of reviews. */
@@ -107,8 +109,6 @@ Component.propTypes = {
       reviewerStayDate: PropTypes.string.isRequired,
     })
   ),
-  /** The reviews heading text */
-  reviewsHeadingText: PropTypes.string,
-  /** The submit a new review text */
-  submitReviewButtonText: PropTypes.string,
+  /** The text to display on the submit button. */
+  submitButtonText: PropTypes.string,
 };

--- a/src/components/property-page-widgets/Rules/component.js
+++ b/src/components/property-page-widgets/Rules/component.js
@@ -58,7 +58,7 @@ Component.propTypes = {
   checkInTime: PropTypes.string.isRequired,
   /** The propery check-out time. */
   checkOutTime: PropTypes.string.isRequired,
-  /** The text to display as a heading at the top of the rules. */
+  /** The text to display as a heading at the top of the widget. */
   headingText: PropTypes.string,
   /** The collection of rules. */
   rules: PropTypes.arrayOf(PropTypes.string).isRequired,

--- a/src/components/property-page-widgets/SleepingArrangements/Readme.md
+++ b/src/components/property-page-widgets/SleepingArrangements/Readme.md
@@ -26,7 +26,7 @@ const sleepingArrangements = [
 ];
 
 <SleepingArrangements
-  headingText="The title!"
+  headingText="Beds and bedrooms"
   sleepingArrangements={sleepingArrangements}
 />
 ```

--- a/src/components/property-page-widgets/SleepingArrangements/component.js
+++ b/src/components/property-page-widgets/SleepingArrangements/component.js
@@ -37,7 +37,7 @@ Component.defaultProps = {
 };
 
 Component.propTypes = {
-  /** The text for the heading displayed above the sleeping arrangments */
+  /** The text to display as a heading at the top of the widget. */
   headingText: PropTypes.string,
   /** The sleeping arrangements to display as icon cards. */
   sleepingArrangements: PropTypes.arrayOf(


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-920)

### What **one** thing does this PR do?
Makes strings props names and documentation consistent

### Any other notes

We must focus on the following things to save our API from becoming confusing to use...

#### Consistency is king

These PRs featured two or more variations for naming the same thing. 

Some examples:

- `formHeadingText`, `headingText`, `[widgetNameSpace]headingText` can all be `headingText`
- `propertyInputLabel`, `propertyDropdownLabel` can be `propertyInputLabel`
- `formButtonText`, `submitButtonText` can be `submitButtonText`

Copy and paste is your friend. 

#### Avoid double namespacing

No need for `paymentInformationHeadingText` inside `PaymentInformation`. Just use `headingText`.

#### Documentation is sacred

Prop documentation isn't an afterthought. It's the most important thing. 

- Don't be lazy when writing prop documentation. Things like `/** The email label for forgot password */` are super ambiguous.
- In our examples, don't use lazy dummy values like 'heading text'. These are fine in unit tests but not for public-facing documentation.

