### PR TITLE
TE-955: Add styles for featured cards

### DIFF
--- a/src/components/general-widgets/FeaturedProperty/component.js
+++ b/src/components/general-widgets/FeaturedProperty/component.js
@@ -23,7 +23,7 @@ export const Component = ({
   propertyUrl,
   ratingNumber,
 }) => (
-  <Card href={propertyUrl}>
+  <Card className="has-featured" href={propertyUrl}>
     <Image alt={imageAlternativeText} src={imageUrl} />
     <Card.Content>
       <Card.Meta>

--- a/src/components/general-widgets/FeaturedRoomType/component.js
+++ b/src/components/general-widgets/FeaturedRoomType/component.js
@@ -23,7 +23,7 @@ export const Component = ({
   roomTypeName,
   roomTypeUrl,
 }) => (
-  <Card href={roomTypeUrl}>
+  <Card className="has-featured" href={roomTypeUrl}>
     <Image alt={imageAlternativeText} src={imageUrl} />
     <Card.Content>
       <Card.Header>{roomTypeName}</Card.Header>

--- a/src/styles/semantic/themes/livingstone/views/card.overrides
+++ b/src/styles/semantic/themes/livingstone/views/card.overrides
@@ -83,6 +83,14 @@
     }
   }
 
+  /* Featured */
+  &.has-featured {
+
+    img.ui.image {
+      height: @featuredImageHeight;
+    }
+  }
+
   /*-------------------
       Variations
 --------------------*/

--- a/src/styles/semantic/themes/livingstone/views/card.variables
+++ b/src/styles/semantic/themes/livingstone/views/card.variables
@@ -69,6 +69,9 @@
 @hasFormHeaderMargin: 0 0 @45px 0;
 @hasFormMobileHeaderMargin: 0 0 @25px 0;
 
+/* Featured */
+@featuredImageHeight: 155px;
+
 /*-------------------
       Variations
 --------------------*/


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-955)

### What **one** thing does this PR do?
adds styling for the featured properties such as:
1. Sets the height of the feature property cards to 155px
2. Updates the spacing between the star icons is 4px

Please refer to the ticket for more information.

__Preview of featured property__
<img width="305" alt="screen shot 2018-08-31 at 12 01 31" src="https://user-images.githubusercontent.com/25742275/44906769-24051a00-ad16-11e8-807e-c8a3463f8157.png">

__Preview of feature room type__
<img width="305" alt="screen shot 2018-08-31 at 12 01 55" src="https://user-images.githubusercontent.com/25742275/44906759-1d76a280-ad16-11e8-8138-2669c91b9c28.png">

---

__Before, Preview of featured property__
<img width="311" alt="screen shot 2018-08-31 at 12 06 39" src="https://user-images.githubusercontent.com/25742275/44906846-5d3d8a00-ad16-11e8-8355-57496901cff3.png">


