### PR TITLE
TE-958: Set spacing between icons to 4px for Rating

### DIFF
--- a/src/styles/semantic/themes/livingstone/modules/rating.variables
+++ b/src/styles/semantic/themes/livingstone/modules/rating.variables
@@ -6,7 +6,7 @@
 
 @marginLeft: @5px;
 
-@iconWidth: @20px;
+@iconWidth: @14px;
 
 @siblingSpanMarginRight: 0.25em;
 @siblingSpanFloat: left;


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-958)

### What **one** thing does this PR do?
Sets the rating icon to 14px for any component that consumes the `Rating` component, this will set the spacing between each icon to 4px

__Before__
<img width="308" alt="screen shot 2018-09-03 at 10 56 35" src="https://user-images.githubusercontent.com/25742275/44977352-0f1fc500-af68-11e8-884d-9d06b568e639.png">

__After__
<img width="305" alt="screen shot 2018-09-03 at 10 56 55" src="https://user-images.githubusercontent.com/25742275/44977373-19da5a00-af68-11e8-8ebe-bba877d214cd.png">
