### PR TITLE
TE-960: remove border and shadow from Menu if in Header

### DIFF
--- a/src/components/collections/Header/component.js
+++ b/src/components/collections/Header/component.js
@@ -15,7 +15,7 @@ import { getDesktopMenuMarkup } from './utils/getDesktopMenuMarkup';
  * @return {Object}
  */
 const Component = props => (
-  <Menu borderless className="is-header">
+  <Menu borderless className="is-header" text>
     {getLogoMarkup(props.logoSrc, props.logoText)}
     <Menu.Menu position="right">
       {props.isUserOnMobile

--- a/src/styles/semantic/themes/livingstone/collections/menu.variables
+++ b/src/styles/semantic/themes/livingstone/collections/menu.variables
@@ -34,6 +34,7 @@
 @footerTopMenuHeadingVerticalPadding: @footerMenuItemVerticalPadding;
 
 /* Text Item */
+@textMenuMargin: 0;
 
 /*--------------
     Elements


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-X)

### What **one** thing does this PR do?
Removes the box shadow and border from the menu if it is used in `Header` and has the class `borderless`

- The `text` prop will add the class `text` to the menu, more info here https://react.semantic-ui.com/collections/menu/#types-text

__Before__
<img width="1209" alt="screen shot 2018-09-03 at 11 06 49" src="https://user-images.githubusercontent.com/25742275/44977859-81dd7000-af69-11e8-9af4-82b105d12cea.png">

__After__
<img width="1119" alt="screen shot 2018-09-03 at 11 07 00" src="https://user-images.githubusercontent.com/25742275/44977866-87d35100-af69-11e8-8655-bcb2cf41d023.png">

