### PR TITLE
TE-962: Apply the Container to the Header & Footer

### DIFF
--- a/src/components/collections/Footer/component.js
+++ b/src/components/collections/Footer/component.js
@@ -29,7 +29,7 @@ export const Component = ({
   propertyAddress,
   socialMediaLinks,
 }) => (
-  <div className="is-footer">
+  <footer>
     <div className="top-navigation">
       <Container as={Menu} borderless inverted stackable>
         {getAreNavigationItemsGrouped(navigationItems)
@@ -89,7 +89,7 @@ export const Component = ({
         )}
       </Container>
     </div>
-  </div>
+  </footer>
 );
 
 Component.displayName = 'Footer';

--- a/src/components/collections/Footer/component.js
+++ b/src/components/collections/Footer/component.js
@@ -7,6 +7,7 @@ import { buildKeyFromStrings } from 'utils/build-key-from-strings';
 import { Submenu } from 'elements/Submenu';
 import { Icon, ICON_NAMES } from 'elements/Icon';
 import { Divider } from 'elements/Divider';
+import { Container } from 'layout/Container';
 
 import { getAreNavigationItemsGrouped } from './utils/getAreNavigationItemsGrouped';
 import { getGroupedNavigationItems } from './utils/getGroupedNavigationItems';
@@ -29,55 +30,65 @@ export const Component = ({
   socialMediaLinks,
 }) => (
   <div className="is-footer">
-    <Menu borderless inverted stackable>
-      {getAreNavigationItemsGrouped(navigationItems)
-        ? getGroupedNavigationItems(navigationItems).map(
-            ({ text, subItems }, index) => (
-              <Menu.Item
-                key={buildKeyFromStrings(text || subItems[0].text, index)}
-              >
-                <Menu.Menu>
-                  {text && <Menu.Header>{toUpper(text)}</Menu.Header>}
-                  {subItems.map(getMenuItemMarkup)}
-                </Menu.Menu>
-              </Menu.Item>
+    <div className="top-navigation">
+      <Container as={Menu} borderless inverted stackable>
+        {getAreNavigationItemsGrouped(navigationItems)
+          ? getGroupedNavigationItems(navigationItems).map(
+              ({ text, subItems }, index) => (
+                <Menu.Item
+                  key={buildKeyFromStrings(text || subItems[0].text, index)}
+                >
+                  <Menu.Menu>
+                    {text && <Menu.Header>{toUpper(text)}</Menu.Header>}
+                    {subItems.map(getMenuItemMarkup)}
+                  </Menu.Menu>
+                </Menu.Item>
+              )
             )
-          )
-        : navigationItems.map(getMenuItemMarkup)}
-    </Menu>
-    <Menu borderless color="grey" inverted stackable>
-      <Menu.Item>
-        <Submenu
-          items={languageOptions}
-          name="language"
-          onChange={onChangeLanguage}
-          willOpenAbove
-        />
-      </Menu.Item>
-      <Menu.Item>
-        <Submenu
-          items={currencyOptions}
-          name="currency"
-          onChange={onChangeCurrency}
-          willOpenAbove
-        />
-      </Menu.Item>
-      <Menu.Item>
-        <Icon labelText={phoneNumber} name={ICON_NAMES.PHONE} />
-      </Menu.Item>
-      {!!socialMediaLinks.length && (
-        <Menu.Menu position="right">
-          {socialMediaLinks.map(({ href, iconName, iconPath }, index) => (
-            <Menu.Item href={href} key={buildKeyFromStrings(href, index)} link>
-              <Icon name={iconName} path={iconPath} />
-            </Menu.Item>
-          ))}
-        </Menu.Menu>
-      )}
-      <Divider hasLine />
-      <Menu.Item>{propertyAddress}</Menu.Item>
-      {copyrightText && <Menu.Item position="right">{copyrightText}</Menu.Item>}
-    </Menu>
+          : navigationItems.map(getMenuItemMarkup)}
+      </Container>
+    </div>
+    <div className="bottom-navigation">
+      <Container as={Menu} borderless inverted stackable>
+        <Menu.Item>
+          <Submenu
+            items={languageOptions}
+            name="language"
+            onChange={onChangeLanguage}
+            willOpenAbove
+          />
+        </Menu.Item>
+        <Menu.Item>
+          <Submenu
+            items={currencyOptions}
+            name="currency"
+            onChange={onChangeCurrency}
+            willOpenAbove
+          />
+        </Menu.Item>
+        <Menu.Item>
+          <Icon labelText={phoneNumber} name={ICON_NAMES.PHONE} />
+        </Menu.Item>
+        {!!socialMediaLinks.length && (
+          <Menu.Menu position="right">
+            {socialMediaLinks.map(({ href, iconName, iconPath }, index) => (
+              <Menu.Item
+                href={href}
+                key={buildKeyFromStrings(href, index)}
+                link
+              >
+                <Icon name={iconName} path={iconPath} />
+              </Menu.Item>
+            ))}
+          </Menu.Menu>
+        )}
+        <Divider hasLine />
+        <Menu.Item>{propertyAddress}</Menu.Item>
+        {copyrightText && (
+          <Menu.Item position="right">{copyrightText}</Menu.Item>
+        )}
+      </Container>
+    </div>
   </div>
 );
 

--- a/src/components/collections/Footer/component.spec.js
+++ b/src/components/collections/Footer/component.spec.js
@@ -8,6 +8,7 @@ import {
 } from '@lodgify/enzyme-jest-expect-helpers';
 import { Menu } from 'semantic-ui-react';
 
+import { Container } from 'layout/Container';
 import { getArrayOfLengthOfItem } from 'utils/get-array-of-length-of-item';
 import { Divider } from 'elements/Divider';
 import { Submenu } from 'elements/Submenu';
@@ -67,14 +68,54 @@ describe('<Footer />', () => {
     it('should have the right children', () => {
       const wrapper = getFooter();
 
-      expectComponentToHaveChildren(wrapper, Menu, Menu);
+      expectComponentToHaveChildren(wrapper, 'div', 'div');
     });
   });
 
-  describe('the first `Menu` component', () => {
+  describe('the `div.top-navigation`', () => {
+    it('should have the right children', () => {
+      const wrapper = getFooter()
+        .find('div.top-navigation')
+        .at(0);
+
+      expectComponentToHaveChildren(wrapper, Container);
+    });
+
+    it('should have the right props', () => {
+      const wrapper = getFooter()
+        .find('div.top-navigation')
+        .at(0);
+
+      expectComponentToHaveProps(wrapper, {
+        className: 'top-navigation',
+      });
+    });
+  });
+
+  describe('the `div.bottom-navigation`', () => {
+    it('should have the right children', () => {
+      const wrapper = getFooter()
+        .find('div.bottom-navigation')
+        .at(0);
+
+      expectComponentToHaveChildren(wrapper, Container);
+    });
+
+    it('should have the right props', () => {
+      const wrapper = getFooter()
+        .find('div.bottom-navigation')
+        .at(0);
+
+      expectComponentToHaveProps(wrapper, {
+        className: 'bottom-navigation',
+      });
+    });
+  });
+
+  describe('the first `Container` component', () => {
     const getFirstMenu = () =>
       getFooter()
-        .children(Menu)
+        .find(Container)
         .at(0);
 
     it('should have the right props', () => {
@@ -84,6 +125,7 @@ describe('<Footer />', () => {
         borderless: true,
         inverted: true,
         stackable: true,
+        as: Menu,
       });
     });
 
@@ -97,7 +139,7 @@ describe('<Footer />', () => {
   describe('if `props.navigationItems` are grouped', () => {
     const getFirstMenuWithGroupeNavigationItems = () =>
       getFooter({ navigationItems: groupedNavigationItems })
-        .children(Menu)
+        .find(Container)
         .at(0);
 
     describe('the first `Menu` component', () => {
@@ -150,7 +192,7 @@ describe('<Footer />', () => {
 
   const getSecondMenu = otherProps =>
     getFooter(otherProps)
-      .children(Menu)
+      .find(Container)
       .at(1);
 
   describe('the second `Menu` component', () => {
@@ -159,9 +201,9 @@ describe('<Footer />', () => {
 
       expectComponentToHaveProps(wrapper, {
         borderless: true,
-        color: 'grey',
         inverted: true,
         stackable: true,
+        as: Menu,
       });
     });
 

--- a/src/components/collections/Footer/component.spec.js
+++ b/src/components/collections/Footer/component.spec.js
@@ -58,13 +58,13 @@ const getFooter = otherProps =>
   );
 
 describe('<Footer />', () => {
-  it('should render a single `div.is-footer` element', () => {
+  it('should render a single `footer` element', () => {
     const wrapper = getFooter();
 
-    expectComponentToBe(wrapper, 'div.is-footer');
+    expectComponentToBe(wrapper, 'footer');
   });
 
-  describe('the `div.is-footer` element', () => {
+  describe('the `footer` element', () => {
     it('should have the right children', () => {
       const wrapper = getFooter();
 

--- a/src/components/collections/Header/component.js
+++ b/src/components/collections/Header/component.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Menu } from 'semantic-ui-react';
 
 import { withResponsive } from 'utils/with-responsive';
+import { Container } from 'layout/Container';
 
 import { getLogoMarkup } from './utils/getLogoMarkup';
 import { getMobileMenuMarkup } from './utils/getMobileMenuMarkup';
@@ -14,14 +15,16 @@ import { getDesktopMenuMarkup } from './utils/getDesktopMenuMarkup';
  */
 // eslint-disable-next-line jsdoc/require-jsdoc
 const Component = props => (
-  <Menu borderless className="is-header" text>
-    {getLogoMarkup(props.logoSrc, props.logoText)}
-    <Menu.Menu position="right">
-      {props.isUserOnMobile
-        ? getMobileMenuMarkup(props)
-        : getDesktopMenuMarkup(props)}
-    </Menu.Menu>
-  </Menu>
+  <header>
+    <Container as={Menu} borderless className="is-header" text>
+      {getLogoMarkup(props.logoSrc, props.logoText)}
+      <Menu.Menu position="right">
+        {props.isUserOnMobile
+          ? getMobileMenuMarkup(props)
+          : getDesktopMenuMarkup(props)}
+      </Menu.Menu>
+    </Container>
+  </header>
 );
 
 Component.displayName = 'Header';

--- a/src/components/collections/Header/component.js
+++ b/src/components/collections/Header/component.js
@@ -16,7 +16,7 @@ import { getDesktopMenuMarkup } from './utils/getDesktopMenuMarkup';
 // eslint-disable-next-line jsdoc/require-jsdoc
 const Component = props => (
   <header>
-    <Container as={Menu} borderless className="is-header" text>
+    <Container as={Menu} borderless text>
       {getLogoMarkup(props.logoSrc, props.logoText)}
       <Menu.Menu position="right">
         {props.isUserOnMobile

--- a/src/components/collections/Header/component.spec.js
+++ b/src/components/collections/Header/component.spec.js
@@ -8,6 +8,8 @@ import {
   expectComponentToHaveDisplayName,
 } from '@lodgify/enzyme-jest-expect-helpers';
 
+import { Container } from 'layout/Container';
+
 import { ComponentWithResponsive as Header } from './component';
 import { navigationItems } from './mock-data/navigationItems';
 
@@ -34,20 +36,33 @@ describe('<Header />', () => {
   });
 
   describe('the wrapped `Header` component', () => {
-    it('should be a single Semantic UI `Menu` component', () => {
+    it('should be a single header', () => {
       const wrapper = getWrappedHeader();
 
-      expectComponentToBe(wrapper, Menu);
+      expectComponentToBe(wrapper, 'header');
     });
 
-    it('should have the right props', () => {
+    it('should have the right children', () => {
       const wrapper = getWrappedHeader();
 
-      expectComponentToHaveProps(wrapper, { borderless: true });
+      expectComponentToHaveChildren(wrapper, Container);
+    });
+  });
+
+  describe('the `Container` component', () => {
+    const getFirstContainer = () => getWrappedHeader().find(Container);
+
+    it('should have the right props', () => {
+      const wrapper = getFirstContainer();
+
+      expectComponentToHaveProps(wrapper, {
+        borderless: true,
+        as: Menu,
+      });
     });
 
     it('should render the right children', () => {
-      const wrapper = getWrappedHeader();
+      const wrapper = getFirstContainer();
 
       expectComponentToHaveChildren(wrapper, Menu.Item, Menu.Menu);
     });
@@ -59,7 +74,7 @@ describe('<Header />', () => {
         logoText,
         navigationItems,
       })
-        .find(Menu)
+        .find(Container)
         .children(Menu.Menu);
 
       expectComponentToHaveProps(wrapper, { position: 'right' });

--- a/src/styles/semantic/themes/livingstone/collections/menu.overrides
+++ b/src/styles/semantic/themes/livingstone/collections/menu.overrides
@@ -10,44 +10,6 @@
 
 .ui.menu {
 
-  /* Header */
-  &.is-header {
-
-    /* Menu Item */
-    .item {
-      color: @headerMenuItemTextColor;
-      margin: 0 @headerMenuItemHorizontalMargin;
-      padding: @headerMenuItemVerticalPadding 0;
-
-      @media @mobileScreen {
-        padding: @headerMenuItemMobileVerticalPadding 0;
-      }
-
-      &:hover {
-        color: @headerMenuItemTextColor;
-      }
-
-      &:first-child {
-        margin-left: @headerMenuHorizontalMargin;
-
-        @media @mobileScreen {
-          margin-left: @headerMenuMobileHorizontalMargin;
-        }
-      }
-
-      &:last-child {
-        margin-right: @headerMenuHorizontalMargin;
-
-        @media @mobileScreen {
-          margin-right: @headerMenuMobileHorizontalMargin;
-        }
-      }
-    }
-  }
-}
-
-.ui.menu {
-
   /* Text Item */
 
   /*--------------
@@ -109,36 +71,6 @@
   /* Pressed Item */
 
   /* Active Item */
-  /* stylelint-disable-next-line no-duplicate-selectors */
-  &.is-header {
-
-    .right.menu {
-
-      & > .item:not(.no-underline):after {
-        border-bottom: @activeItemUnderlineBorder;
-        bottom: @activeItemUnderlineBottomPosition;
-        content: '';
-        left: 0;
-        opacity: 0.2;
-        position: absolute;
-        transform: scaleX(0);
-        transform-origin: left;
-        transition: @activeItemUnderlineTransition;
-        width: 100%;
-
-        @media @mobileScreen {
-          border: none;
-        }
-      }
-
-      & > .active.item:after,
-      & > .underlined.item:after,
-      & > .item:hover:after {
-        opacity: 1;
-        transform: scaleX(1);
-      }
-    }
-  }
 
   /* Active Hovered Item */
 
@@ -286,6 +218,78 @@
 /* Resize large sizes */
 
 /* Sizes */
+
+/* Header */
+header > .ui.menu.text {
+
+  /* Menu Item */
+  .item {
+    margin: 0 @headerMenuItemHorizontalMargin;
+    padding: @headerMenuItemVerticalPadding 0;
+
+    &,
+    &:hover,
+    &.active {
+      color: @headerMenuItemTextColor;
+    }
+
+    @media @mobileScreen {
+      padding: @headerMenuItemMobileVerticalPadding 0;
+    }
+
+    &:first-child {
+      margin-left: @headerMenuHorizontalMargin;
+
+      @media @mobileScreen {
+        margin-left: @headerMenuMobileHorizontalMargin;
+      }
+    }
+
+    &:last-child {
+      margin-right: @headerMenuHorizontalMargin;
+
+      @media @mobileScreen {
+        margin-right: @headerMenuMobileHorizontalMargin;
+      }
+    }
+  }
+
+  /*--------------
+     States
+---------------*/
+
+  /* Active Item */
+  /* stylelint-disable-next-line no-duplicate-selectors */
+  > .right.menu {
+
+    > .item:not(.no-underline):after {
+      border-bottom: @activeItemUnderlineBorder;
+      bottom: @activeItemUnderlineBottomPosition;
+      content: '';
+      left: 0;
+      opacity: 0.2;
+      position: absolute;
+      transform: scaleX(0);
+      transform-origin: left;
+      transition: @activeItemUnderlineTransition;
+      width: 100%;
+
+      @media @mobileScreen {
+        border: none;
+      }
+    }
+
+    > .active.item,
+    > .underlined.item,
+    > .item:hover {
+
+      &:after {
+        opacity: 1;
+        transform: scaleX(1);
+      }
+    }
+  }
+}
 
 /* Footer */
 footer {

--- a/src/styles/semantic/themes/livingstone/collections/menu.overrides
+++ b/src/styles/semantic/themes/livingstone/collections/menu.overrides
@@ -44,6 +44,9 @@
       }
     }
   }
+}
+
+.ui.menu {
 
   /* Text Item */
 
@@ -285,7 +288,7 @@
 /* Sizes */
 
 /* Footer */
-.is-footer {
+footer {
 
   .top-navigation {
     background-color: @black;
@@ -330,6 +333,10 @@
   .bottom-navigation {
     margin: 0;
     padding: @footerMenuVerticalPadding @footerMenuHorizontalPadding;
+
+    > .ui.inverted.menu {
+      background-color: inherit;
+    }
 
     /* Menu Item */
     .menu .item {

--- a/src/styles/semantic/themes/livingstone/collections/menu.overrides
+++ b/src/styles/semantic/themes/livingstone/collections/menu.overrides
@@ -45,65 +45,6 @@
     }
   }
 
-  /* Footer */
-  .is-footer > & {
-    margin: 0;
-    padding: @footerMenuVerticalPadding @footerMenuHorizontalPadding;
-
-    /* Menu Item */
-    & .item {
-      padding:
-        @footerMenuItemVerticalPadding
-        @footerMenuItemHorizontalPadding
-        @footerMenuItemVerticalPadding
-        0;
-    }
-
-    &:first-child {
-
-      /* Menu Item */
-      & .item {
-        align-items: flex-start;
-      }
-
-      /* Sub Menu */
-      .menu {
-
-        .header {
-          font-weight: @footerTopMenuHeadingFontWeight;
-          padding: @footerTopMenuHeadingVerticalPadding 0;
-        }
-      }
-    }
-
-    &:nth-child(2) {
-      flex-wrap: wrap;
-
-      /* Menu Item */
-      .item {
-        color: @footerBottomMenuColor;
-      }
-
-      .right.menu {
-        flex-direction: row;
-
-        .item {
-          flex: 0;
-          padding-right: 0;
-        }
-      }
-
-      .right.item {
-        padding-right: 0;
-      }
-
-      /* Divider */
-      .ui.divider {
-        width: @footerBottomMenuDividerWidth;
-      }
-    }
-  }
-
   /* Text Item */
 
   /*--------------
@@ -342,3 +283,78 @@
 /* Resize large sizes */
 
 /* Sizes */
+
+/* Footer */
+.is-footer {
+
+  .top-navigation {
+    background-color: @black;
+  }
+
+  .bottom-navigation {
+
+    &,
+    .menu {
+      background-color: @greyEight;
+    }
+
+    .menu {
+      flex-wrap: wrap;
+
+      /* Menu Item */
+      .item {
+        color: @footerBottomMenuColor;
+      }
+
+      .right.menu {
+        flex-direction: row;
+
+        .item {
+          flex: 0;
+          padding-right: 0;
+        }
+      }
+
+      .right.item {
+        padding-right: 0;
+      }
+
+      /* Divider */
+      .ui.divider {
+        width: @footerBottomMenuDividerWidth;
+      }
+    }
+  }
+
+  .top-navigation,
+  .bottom-navigation {
+    margin: 0;
+    padding: @footerMenuVerticalPadding @footerMenuHorizontalPadding;
+
+    /* Menu Item */
+    .menu .item {
+      padding:
+        @footerMenuItemVerticalPadding
+        @footerMenuItemHorizontalPadding
+        @footerMenuItemVerticalPadding
+        0;
+    }
+
+    &:first-child {
+
+      /* Menu Item */
+      .menu .item {
+        align-items: flex-start;
+      }
+
+      /* Sub Menu */
+      .menu {
+
+        .header {
+          font-weight: @footerTopMenuHeadingFontWeight;
+          padding: @footerTopMenuHeadingVerticalPadding 0;
+        }
+      }
+    }
+  }
+}

--- a/src/styles/semantic/themes/livingstone/collections/menu.variables
+++ b/src/styles/semantic/themes/livingstone/collections/menu.variables
@@ -12,7 +12,7 @@
 @headerMenuMobileHorizontalMargin: @25px;
 
 @footerMenuVerticalPadding: @30px;
-@footerMenuHorizontalPadding: @35px;
+@footerMenuHorizontalPadding: 0;
 
 /* Menu Item */
 // Need to use margin rather than padding to implement 'active' state bottom border
@@ -22,7 +22,7 @@
 @headerMenuItemTextColor: @pureWhite;
 
 @footerMenuItemVerticalPadding: @8px;
-@footerMenuItemHorizontalPadding: @footerMenuHorizontalPadding;
+@footerMenuItemHorizontalPadding: @35px;
 
 @footerBottomMenuColor: @greySix;
 

--- a/src/styles/semantic/themes/livingstone/elements/container.overrides
+++ b/src/styles/semantic/themes/livingstone/elements/container.overrides
@@ -29,3 +29,13 @@
     }
   }
 }
+
+/*--------------
+   Variations
+---------------*/
+
+/* with menu */
+
+.container.ui.menu.text {
+  max-width: @maxWidth !important;
+}


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-962)

### What **one** thing does this PR do?
Applies the `Container` to the `Header` and `Footer`

### Any other notes
- I had to slightly refactor the `Footer` to accommodate the `Container`, I added two divs with the classes `.bottom-navigation` and `.top-navigation` to contain the `Menu` components
- The content of the `Header` and `Footer` will now be restricted to `1040px`

### Footer

__Before__
![screen shot 2018-09-03 at 16 04 02](https://user-images.githubusercontent.com/25742275/44992316-32159d80-af97-11e8-84a3-a73185efed24.png)

__After__
<img width="1363" alt="screen shot 2018-09-03 at 16 03 43" src="https://user-images.githubusercontent.com/25742275/44992326-380b7e80-af97-11e8-83af-af367cd4239f.png">

### Header

__Before__
<img width="1550" alt="screen shot 2018-09-03 at 16 17 31" src="https://user-images.githubusercontent.com/25742275/44992340-448fd700-af97-11e8-9d16-506764b2b5e2.png">

__After__
<img width="1235" alt="screen shot 2018-09-03 at 16 17 14" src="https://user-images.githubusercontent.com/25742275/44992360-4eb1d580-af97-11e8-822f-e412bcbd4a27.png">

