### PR TITLE
TE-989 Remove underline from form action

### DIFF
--- a/src/components/collections/Form/component.js
+++ b/src/components/collections/Form/component.js
@@ -3,8 +3,9 @@ import PropTypes from 'prop-types';
 import { Card, Form } from 'semantic-ui-react';
 import { size, forEach } from 'lodash';
 
-import { Heading } from 'typography/Heading';
 import { Button } from 'elements/Button';
+import { Heading } from 'typography/Heading';
+import { Link } from 'elements/Link';
 
 import { getValidationWithDefaults } from './utils/getValidationWithDefaults';
 import { getIsRequiredError } from './utils/getIsRequiredError';
@@ -69,7 +70,7 @@ export class Component extends PureComponent {
           <Form onSubmit={this.handleSubmit}>
             {Children.map(children, child => getFormChild(child, this))}
             {actionLink && (
-              <a onClick={actionLink.onClick}>{actionLink.text}</a>
+              <Link onClick={actionLink.onClick}>{actionLink.text}</Link>
             )}
             {submitButtonText && (
               <Button

--- a/src/components/collections/Form/component.spec.js
+++ b/src/components/collections/Form/component.spec.js
@@ -10,6 +10,7 @@ import {
 
 import { Button } from 'elements/Button';
 import { Heading } from 'typography/Heading';
+import { Link } from 'elements/Link';
 
 import { Component as Form } from './component';
 import { DEFAULT_IS_REQUIRED_MESSAGE } from './constants';
@@ -65,11 +66,11 @@ describe('<Form />', () => {
       it('should render the right children', () => {
         const wrapper = getFormWithActionLink();
 
-        expectComponentToHaveChildren(wrapper, FormField, 'a');
+        expectComponentToHaveChildren(wrapper, FormField, Link);
       });
 
       describe('the `actionLink`', () => {
-        const getActionLink = () => getFormWithActionLink().find('a');
+        const getActionLink = () => getFormWithActionLink().find(Link);
 
         it('should have the right props', () => {
           const wrapper = getActionLink();


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-989)

### What **one** thing does this PR do?
Replaces the form actionLink `a` with `Link` which removes the underline

### Any other notes
#### Before
![image](https://user-images.githubusercontent.com/10498995/45146836-e3991680-b1c3-11e8-81f9-be1c14924d78.png)

#### After
![image](https://user-images.githubusercontent.com/10498995/45146794-d1b77380-b1c3-11e8-9cfc-005d2b424e1b.png)
