### PR TITLE
TE-990: Stop featured images from growing to 100% of container

### DIFF
--- a/src/styles/semantic/themes/livingstone/views/card.overrides
+++ b/src/styles/semantic/themes/livingstone/views/card.overrides
@@ -91,6 +91,8 @@
 
     img.ui.image {
       flex-grow: @featuredImageFlexGrow;
+      height: @featuredImageHeight;
+      object-fit: cover;
     }
   }
 

--- a/src/styles/semantic/themes/livingstone/views/card.variables
+++ b/src/styles/semantic/themes/livingstone/views/card.variables
@@ -73,6 +73,7 @@
 
 /* Featured */
 @featuredHeight: 400px;
+@featuredImageHeight: 200px;
 @featuredImageFlexGrow: 1;
 
 /*-------------------


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-990)

### What **one** thing does this PR do?
Adds a height to the images so the image mixed with flex grow doesn't stretch to 100% of it's container. 

### Any other notes
- Object fit is not fully supported by IE 11 but as a fallback the image doesn't maintain it's proportions but this gives us a nice fallback for when the image src is portrait.

#### Before
![image](https://user-images.githubusercontent.com/10498995/45165500-40f98b80-b1f5-11e8-88ee-a545f47f6762.png)

#### After
![image](https://user-images.githubusercontent.com/10498995/45165463-28897100-b1f5-11e8-9870-d78307a2ccdc.png)

