### PR TITLE
TE-1033: Allows the vertical spacing to be optional in `Amenities`

### DIFF
--- a/src/components/property-page-widgets/Amenities/Readme.md
+++ b/src/components/property-page-widgets/Amenities/Readme.md
@@ -243,7 +243,7 @@ const amenities = [
 
 ```
 
-#### Remove vertical padding
+#### Without vertical padding
 
 ```jsx
 const amenities = [
@@ -265,6 +265,6 @@ const amenities = [
 ];
 
 
-<Amenities isNested amenities={amenities} headingText="Property Amenities" />
+<Amenities hasVerticalGutters={false} amenities={amenities} headingText="Property Amenities" />
 
 ```

--- a/src/components/property-page-widgets/Amenities/Readme.md
+++ b/src/components/property-page-widgets/Amenities/Readme.md
@@ -242,3 +242,29 @@ const amenities = [
 <Amenities hasExtraItemsInModal amenities={amenities} headingText="Property Amenities" />
 
 ```
+
+#### Remove vertical padding
+
+```jsx
+const amenities = [
+  {
+    name: 'Cooking',
+    iconName: 'coffee',
+    items: ['Toaster', 'Microwave', 'Coffee Machine'],
+  },
+  {
+    name: 'Bathroom',
+    iconName: 'bathroom',
+    items: ['Bidet', 'Hair Dryer'],
+  },
+  {
+    name: 'Outside',
+    iconName: 'sun',
+    items: ['Tennis Court'],
+  }
+];
+
+
+<Amenities isNested amenities={amenities} headingText="Property Amenities" />
+
+```

--- a/src/components/property-page-widgets/Amenities/component.js
+++ b/src/components/property-page-widgets/Amenities/component.js
@@ -1,16 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Grid } from 'layout/Grid';
-import { GridColumn } from 'layout/GridColumn';
-import { Heading } from 'typography/Heading';
 import { VIEW_MORE } from 'utils/default-strings';
 import { VerticalGutters } from 'layout/VerticalGutters';
 
-import { getDefaultItems } from './utils/getDefaultItems';
-import { hasExtraItems } from './utils/hasExtraItems';
-import { getCategoryMarkup } from './utils/getCategoryMarkup';
-import { getExtraItemsMarkup } from './utils/getExtraItemsMarkup';
+import { getAmenityMarkup } from './utils/getAmenityMarkup';
 
 /**
  * The standard widget for displaying the amenities of a property.
@@ -20,35 +14,36 @@ export const Component = ({
   amenities,
   hasExtraItemsInModal,
   headingText,
+  isNested,
   isStacked,
   modalTriggerText,
-}) => (
-  <VerticalGutters>
-    <Grid stackable>
-      {headingText && (
-        <GridColumn width={12}>
-          <Heading>{headingText}</Heading>
-        </GridColumn>
+}) =>
+  isNested ? (
+    getAmenityMarkup(
+      amenities,
+      hasExtraItemsInModal,
+      headingText,
+      isStacked,
+      modalTriggerText
+    )
+  ) : (
+    <VerticalGutters>
+      {getAmenityMarkup(
+        amenities,
+        hasExtraItemsInModal,
+        headingText,
+        isStacked,
+        modalTriggerText
       )}
-      {getDefaultItems(amenities, isStacked).map((amenity, index) =>
-        getCategoryMarkup(amenity, index, isStacked)
-      )}
-      {hasExtraItems(amenities, isStacked) &&
-        getExtraItemsMarkup(
-          hasExtraItemsInModal,
-          modalTriggerText,
-          amenities,
-          isStacked
-        )}
-    </Grid>
-  </VerticalGutters>
-);
+    </VerticalGutters>
+  );
 
 Component.displayName = 'Amenities';
 
 Component.defaultProps = {
   hasExtraItemsInModal: false,
   headingText: null,
+  isNested: false,
   isStacked: false,
   modalTriggerText: VIEW_MORE,
 };
@@ -71,6 +66,8 @@ Component.propTypes = {
   hasExtraItemsInModal: PropTypes.bool,
   /** The text to display as a heading at the top of the amenities. */
   headingText: PropTypes.string,
+  /** Is the component nested in another component */
+  isNested: PropTypes.bool,
   /** Are the amenities displayed stacked on top of one another */
   isStacked: PropTypes.bool,
   /** The text for the modal trigger */

--- a/src/components/property-page-widgets/Amenities/component.js
+++ b/src/components/property-page-widgets/Amenities/component.js
@@ -13,20 +13,12 @@ import { getAmenityMarkup } from './utils/getAmenityMarkup';
 export const Component = ({
   amenities,
   hasExtraItemsInModal,
+  hasVerticalGutters,
   headingText,
-  isNested,
   isStacked,
   modalTriggerText,
 }) =>
-  isNested ? (
-    getAmenityMarkup(
-      amenities,
-      hasExtraItemsInModal,
-      headingText,
-      isStacked,
-      modalTriggerText
-    )
-  ) : (
+  hasVerticalGutters ? (
     <VerticalGutters>
       {getAmenityMarkup(
         amenities,
@@ -36,6 +28,14 @@ export const Component = ({
         modalTriggerText
       )}
     </VerticalGutters>
+  ) : (
+    getAmenityMarkup(
+      amenities,
+      hasExtraItemsInModal,
+      headingText,
+      isStacked,
+      modalTriggerText
+    )
   );
 
 Component.displayName = 'Amenities';
@@ -43,7 +43,7 @@ Component.displayName = 'Amenities';
 Component.defaultProps = {
   hasExtraItemsInModal: false,
   headingText: null,
-  isNested: false,
+  hasVerticalGutters: true,
   isStacked: false,
   modalTriggerText: VIEW_MORE,
 };
@@ -64,10 +64,10 @@ Component.propTypes = {
   ).isRequired,
   /** Are the extra items displayed in a modal. */
   hasExtraItemsInModal: PropTypes.bool,
+  /** Does the component have vertical gutters */
+  hasVerticalGutters: PropTypes.bool,
   /** The text to display as a heading at the top of the amenities. */
   headingText: PropTypes.string,
-  /** Is the component nested in another component */
-  isNested: PropTypes.bool,
   /** Are the amenities displayed stacked on top of one another */
   isStacked: PropTypes.bool,
   /** The text for the modal trigger */

--- a/src/components/property-page-widgets/Amenities/component.spec.js
+++ b/src/components/property-page-widgets/Amenities/component.spec.js
@@ -1,22 +1,14 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Modal as SemanticModal } from 'semantic-ui-react';
 import {
   expectComponentToBe,
   expectComponentToHaveChildren,
-  expectComponentToHaveProps,
 } from '@lodgify/enzyme-jest-expect-helpers';
 
-import { getArrayOfLengthOfItem } from 'utils/get-array-of-length-of-item';
-import { VIEW_MORE } from 'utils/default-strings';
 import { Grid } from 'layout/Grid';
-import { GridColumn } from 'layout/GridColumn';
-import { Heading } from 'typography/Heading';
-import { Link } from 'elements/Link';
-import { Modal } from 'elements/Modal';
 import { VerticalGutters } from 'layout/VerticalGutters';
 
-import { twoAmenities, sixAmenities } from './mock-data/amenities';
+import { twoAmenities } from './mock-data/amenities';
 import { Component as Amenities } from './component';
 
 const getAmenities = (props = {}) =>
@@ -36,140 +28,20 @@ describe('<Amenities />', () => {
 
     expectComponentToBe(wrapper, VerticalGutters);
   });
+
+  it('should not have `VerticalGutters` component as a wrapper', () => {
+    const wrapper = getAmenities({
+      isNested: true,
+    });
+
+    expectComponentToBe(wrapper, Grid);
+  });
+
   describe('the `VerticalGutters` component', () => {
     it('should have `Grid` as its only children', () => {
       const wrapper = getAmenities();
 
       expectComponentToHaveChildren(wrapper, Grid);
-    });
-  });
-
-  describe('the `Grid` component', () => {
-    it('should render the right children', () => {
-      const wrapper = getAmenities().find(Grid);
-
-      expectComponentToHaveChildren(
-        wrapper,
-        ...getArrayOfLengthOfItem(2, GridColumn)
-      );
-    });
-  });
-
-  describe('the first `GridColumn` component', () => {
-    const getFirstGridColumn = () =>
-      getAmenities({
-        headingText: 'Hello world',
-      })
-        .find(GridColumn)
-        .first();
-
-    it('should have the right right props', () => {
-      const wrapper = getFirstGridColumn();
-
-      expectComponentToHaveProps(wrapper, { width: 12 });
-    });
-
-    it('should render the right children', () => {
-      const wrapper = getFirstGridColumn();
-
-      expectComponentToHaveChildren(wrapper, Heading);
-    });
-  });
-
-  describe('the `Heading` component', () => {
-    it('should render the right children', () => {
-      const wrapper = getAmenities({
-        headingText: 'Property Amenities',
-      }).find(Heading);
-
-      expectComponentToHaveChildren(wrapper, 'Property Amenities');
-    });
-  });
-
-  describe('if `hasExtraItems` returns true', () => {
-    const getAmenitiesWithSixCategories = () =>
-      getAmenities({ amenities: sixAmenities });
-
-    describe('the `Grid` component', () => {
-      it('should render the right children', () => {
-        const wrapper = getAmenitiesWithSixCategories()
-          .find(Grid)
-          .at(0);
-
-        expectComponentToHaveChildren(
-          wrapper,
-          ...getArrayOfLengthOfItem(4, GridColumn)
-        );
-      });
-    });
-
-    describe('the last child `GridColumn` of `Grid`', () => {
-      const getLastGridColumn = () =>
-        getAmenitiesWithSixCategories()
-          .find(GridColumn)
-          .at(3);
-
-      it('should have the right props', () => {
-        const wrapper = getLastGridColumn();
-
-        expectComponentToHaveProps(wrapper, { width: 12 });
-      });
-
-      it('should render the right children', () => {
-        const wrapper = getLastGridColumn();
-
-        expectComponentToHaveChildren(wrapper, Modal);
-      });
-    });
-
-    describe('the `Modal`', () => {
-      const getModal = () => getAmenitiesWithSixCategories().find(Modal);
-
-      it('should have the right props', () => {
-        const wrapper = getModal();
-
-        expectComponentToHaveProps(wrapper, {
-          trigger: <Link>{VIEW_MORE}</Link>,
-        });
-      });
-
-      it('should have the right children', () => {
-        const wrapper = getModal();
-
-        expectComponentToHaveChildren(wrapper, SemanticModal.Content);
-      });
-    });
-
-    describe('the `SemanticModal.Content`', () => {
-      it('should have the right children', () => {
-        const wrapper = getAmenitiesWithSixCategories().find(
-          SemanticModal.Content
-        );
-
-        expectComponentToHaveChildren(wrapper, Grid);
-      });
-    });
-
-    describe('the `Grid` child of `SemanticModal.Content`', () => {
-      const getSecondGrid = () =>
-        getAmenitiesWithSixCategories()
-          .find(Grid)
-          .at(1);
-
-      it('should have the right props', () => {
-        const wrapper = getSecondGrid();
-
-        expectComponentToHaveProps(wrapper, { padded: true, stackable: true });
-      });
-
-      it('should render the right children', () => {
-        const wrapper = getSecondGrid();
-
-        expectComponentToHaveChildren(
-          wrapper,
-          ...getArrayOfLengthOfItem(5, GridColumn)
-        );
-      });
     });
   });
 });

--- a/src/components/property-page-widgets/Amenities/component.spec.js
+++ b/src/components/property-page-widgets/Amenities/component.spec.js
@@ -31,7 +31,7 @@ describe('<Amenities />', () => {
 
   it('should not have `VerticalGutters` component as a wrapper', () => {
     const wrapper = getAmenities({
-      isNested: true,
+      hasVerticalGutters: false,
     });
 
     expectComponentToBe(wrapper, Grid);

--- a/src/components/property-page-widgets/Amenities/utils/getAmenityMarkup.js
+++ b/src/components/property-page-widgets/Amenities/utils/getAmenityMarkup.js
@@ -1,0 +1,43 @@
+import React from 'react';
+
+import { Grid } from 'layout/Grid';
+import { GridColumn } from 'layout/GridColumn';
+import { Heading } from 'typography/Heading';
+
+import { getDefaultItems } from './getDefaultItems';
+import { hasExtraItems } from './hasExtraItems';
+import { getCategoryMarkup } from './getCategoryMarkup';
+import { getExtraItemsMarkup } from './getExtraItemsMarkup';
+
+/**
+ * @param {Object[]} amenities
+ * @param {boolean} hasExtraItemsInModal
+ * @param {string} headingText
+ * @param {boolean} isStacked
+ * @param {string} modalTriggerText
+ */
+export const getAmenityMarkup = (
+  amenities,
+  hasExtraItemsInModal,
+  headingText,
+  isStacked,
+  modalTriggerText
+) => (
+  <Grid stackable>
+    {headingText && (
+      <GridColumn width={12}>
+        <Heading>{headingText}</Heading>
+      </GridColumn>
+    )}
+    {getDefaultItems(amenities, isStacked).map((amenity, index) =>
+      getCategoryMarkup(amenity, index, isStacked)
+    )}
+    {hasExtraItems(amenities, isStacked) &&
+      getExtraItemsMarkup(
+        hasExtraItemsInModal,
+        modalTriggerText,
+        amenities,
+        isStacked
+      )}
+  </Grid>
+);

--- a/src/components/property-page-widgets/Amenities/utils/getAmenityMarkup.js
+++ b/src/components/property-page-widgets/Amenities/utils/getAmenityMarkup.js
@@ -10,11 +10,12 @@ import { getCategoryMarkup } from './getCategoryMarkup';
 import { getExtraItemsMarkup } from './getExtraItemsMarkup';
 
 /**
- * @param {Object[]} amenities
- * @param {boolean} hasExtraItemsInModal
- * @param {string} headingText
- * @param {boolean} isStacked
- * @param {string} modalTriggerText
+ * @param {Object[]}  amenities
+ * @param {boolean}   hasExtraItemsInModal
+ * @param {string}    headingText
+ * @param {boolean}   isStacked
+ * @param {string}    modalTriggerText
+ * @return {Object}
  */
 export const getAmenityMarkup = (
   amenities,

--- a/src/components/property-page-widgets/Amenities/utils/getAmenityMarkup.spec.js
+++ b/src/components/property-page-widgets/Amenities/utils/getAmenityMarkup.spec.js
@@ -1,0 +1,169 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { Modal as SemanticModal } from 'semantic-ui-react';
+import {
+  expectComponentToHaveChildren,
+  expectComponentToHaveProps,
+} from '@lodgify/enzyme-jest-expect-helpers';
+
+import { getArrayOfLengthOfItem } from 'utils/get-array-of-length-of-item';
+import { VIEW_MORE } from 'utils/default-strings';
+import { Grid } from 'layout/Grid';
+import { GridColumn } from 'layout/GridColumn';
+import { Heading } from 'typography/Heading';
+import { Link } from 'elements/Link';
+import { Modal } from 'elements/Modal';
+
+import { twoAmenities, sixAmenities } from '../mock-data/amenities';
+
+import { getAmenityMarkup } from './getAmenityMarkup';
+
+const amenities = twoAmenities;
+const hasExtraItemsInModal = true;
+const headingText = '';
+const isStacked = true;
+const modalTriggerText = VIEW_MORE;
+
+const getAmenities = (props = {}) =>
+  shallow(
+    <div>
+      {getAmenityMarkup(
+        props.amenities || amenities,
+        hasExtraItemsInModal,
+        props.headingText || headingText,
+        isStacked,
+        props.modalTriggerText || modalTriggerText
+      )}
+    </div>
+  ).first();
+
+describe('getAmenityMarkup', () => {
+  describe('the `Grid` component', () => {
+    it('should render the right children', () => {
+      const wrapper = getAmenities().find(Grid);
+
+      expectComponentToHaveChildren(
+        wrapper,
+        ...getArrayOfLengthOfItem(2, GridColumn)
+      );
+    });
+  });
+
+  describe('the first `GridColumn` component', () => {
+    const getFirstGridColumn = () =>
+      getAmenities({
+        headingText: 'Hello world',
+      })
+        .find(GridColumn)
+        .first();
+
+    it('should have the right right props', () => {
+      const wrapper = getFirstGridColumn();
+
+      expectComponentToHaveProps(wrapper, { width: 12 });
+    });
+
+    it('should render the right children', () => {
+      const wrapper = getFirstGridColumn();
+
+      expectComponentToHaveChildren(wrapper, Heading);
+    });
+  });
+
+  describe('the `Heading` component', () => {
+    it('should render the right children', () => {
+      const wrapper = getAmenities({
+        headingText: 'Property Amenities',
+      }).find(Heading);
+
+      expectComponentToHaveChildren(wrapper, 'Property Amenities');
+    });
+  });
+
+  describe('if `hasExtraItems` returns true', () => {
+    const getAmenitiesWithSixCategories = () =>
+      getAmenities({ amenities: sixAmenities });
+
+    describe('the `Grid` component', () => {
+      it('should render the right children', () => {
+        const wrapper = getAmenitiesWithSixCategories()
+          .find(Grid)
+          .at(0);
+
+        expectComponentToHaveChildren(
+          wrapper,
+          ...getArrayOfLengthOfItem(4, GridColumn)
+        );
+      });
+    });
+
+    describe('the last child `GridColumn` of `Grid`', () => {
+      const getLastGridColumn = () =>
+        getAmenitiesWithSixCategories()
+          .find(GridColumn)
+          .at(3);
+
+      it('should have the right props', () => {
+        const wrapper = getLastGridColumn();
+
+        expectComponentToHaveProps(wrapper, { width: 12 });
+      });
+
+      it('should render the right children', () => {
+        const wrapper = getLastGridColumn();
+
+        expectComponentToHaveChildren(wrapper, Modal);
+      });
+    });
+
+    describe('the `Modal`', () => {
+      const getModal = () => getAmenitiesWithSixCategories().find(Modal);
+
+      it('should have the right props', () => {
+        const wrapper = getModal();
+
+        expectComponentToHaveProps(wrapper, {
+          trigger: <Link>{VIEW_MORE}</Link>,
+        });
+      });
+
+      it('should have the right children', () => {
+        const wrapper = getModal();
+
+        expectComponentToHaveChildren(wrapper, SemanticModal.Content);
+      });
+    });
+
+    describe('the `SemanticModal.Content`', () => {
+      it('should have the right children', () => {
+        const wrapper = getAmenitiesWithSixCategories().find(
+          SemanticModal.Content
+        );
+
+        expectComponentToHaveChildren(wrapper, Grid);
+      });
+    });
+
+    describe('the `Grid` child of `SemanticModal.Content`', () => {
+      const getSecondGrid = () =>
+        getAmenitiesWithSixCategories()
+          .find(Grid)
+          .at(1);
+
+      it('should have the right props', () => {
+        const wrapper = getSecondGrid();
+
+        expectComponentToHaveProps(wrapper, { padded: true, stackable: true });
+      });
+
+      it('should render the right children', () => {
+        const wrapper = getSecondGrid();
+
+        expectComponentToHaveChildren(
+          wrapper,
+          ...getArrayOfLengthOfItem(5, GridColumn)
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1033)

### What **one** thing does this PR do?
Allows the vertical spacing to be optional in `Amenities`

### Other Notes
- Since Amenities may exist nested in another component, we need to remove the spacing
- Since Amenities can appear as a primary component in our pages, we need to keep the padding

__Before__
<img width="710" alt="screen shot 2018-09-10 at 12 22 50" src="https://user-images.githubusercontent.com/25742275/45292159-98993f00-b4f4-11e8-9ed1-6b4868d772a4.png">

__After__
<img width="713" alt="screen shot 2018-09-10 at 12 22 41" src="https://user-images.githubusercontent.com/25742275/45292165-9df68980-b4f4-11e8-913a-583ed78c19a5.png">

