### PR TITLE
TE-1034: active link inherit background color for inverted `Menu`

### DIFF
--- a/src/styles/semantic/themes/livingstone/collections/menu.overrides
+++ b/src/styles/semantic/themes/livingstone/collections/menu.overrides
@@ -295,7 +295,7 @@ header > .ui.menu.text {
 footer {
 
   .top-navigation {
-    background-color: @black;
+    background-color: @footerTopBackground;
   }
 
   .bottom-navigation {

--- a/src/styles/semantic/themes/livingstone/collections/menu.variables
+++ b/src/styles/semantic/themes/livingstone/collections/menu.variables
@@ -25,6 +25,8 @@
 @footerBottomBackground: @greyEight;
 @footerBottomMenuColor: @greySix;
 
+@footerTopBackground: @black;
+
 /* Divider */
 @footerBottomMenuDividerWidth: 100%;
 
@@ -164,7 +166,8 @@
 /* Inverted Sub Menu */
 
 /* Inverted Hover */
-@invertedHoverBackground: @invertedBackground;
+@invertedHoverBackground: @footerTopBackground;
+@invertedMenuPressedBackground: @footerTopBackground;
 @invertedHoverColor: @invertedItemTextColor;
 
 /* Pressed */


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1034)

### What **one** thing does this PR do?
Fixes active link style for inverted `Menu`

__Before__
<img width="716" alt="screen shot 2018-09-10 at 12 43 04" src="https://user-images.githubusercontent.com/25742275/45293050-5a514f00-b4f7-11e8-99c4-99ebcc349ef3.png">

__After__
<img width="702" alt="screen shot 2018-09-10 at 12 42 57" src="https://user-images.githubusercontent.com/25742275/45293055-5e7d6c80-b4f7-11e8-9483-23098429b8dc.png">
