### PR TITLE
TE-1020: remove vertical padding for `Review`

### DIFF
--- a/src/components/general-widgets/Review/component.js
+++ b/src/components/general-widgets/Review/component.js
@@ -8,7 +8,6 @@ import { GridColumn } from 'layout/GridColumn';
 import { GridRow } from 'layout/GridRow';
 import { Quote } from 'elements/Quote';
 import { Subheading } from 'typography/Subheading';
-import { VerticalGutters } from 'layout/VerticalGutters';
 
 import { getReviewerCategoryAndStayDateString } from './utils/getReviewerCategoryAndStayDateString';
 import { getReviewerNameAndLocationString } from './utils/getReviewerNameAndLocationString';
@@ -27,60 +26,58 @@ export const Component = ({
   reviewText,
   reviewTitle,
 }) => (
-  <VerticalGutters>
-    <Card fluid>
-      <Card.Content>
-        <Card.Meta>
-          <Grid>
-            <GridRow verticalAlign="middle">
-              <GridColumn computer={6} mobile={12} tablet={7}>
-                <Subheading>
-                  {getReviewerNameAndLocationString(
-                    reviewerName,
-                    reviewerLocation
-                  )}
-                </Subheading>
-              </GridColumn>
-              <GridColumn
-                computer={6}
-                mobile={12}
-                tablet={5}
-                textAlign="right"
-                verticalAlign="middle"
-              >
-                <Rating
-                  disabled
-                  maxRating={5}
-                  rating={Math.round(ratingNumber)}
-                  size="small"
-                />
-              </GridColumn>
-            </GridRow>
-          </Grid>
-        </Card.Meta>
-        <Divider />
-        <Card.Header>{reviewTitle}</Card.Header>
-        <Card.Description>{reviewText}</Card.Description>
-        <Divider />
-        {!!reviewResponse && (
-          <div>
-            <Quote
-              quoteDateTime={reviewResponse.dateTime}
-              quoteSource={reviewResponse.source}
-              quoteText={reviewResponse.text}
-            />
-            <Divider />
-          </div>
+  <Card fluid>
+    <Card.Content>
+      <Card.Meta>
+        <Grid>
+          <GridRow verticalAlign="middle">
+            <GridColumn computer={6} mobile={12} tablet={7}>
+              <Subheading>
+                {getReviewerNameAndLocationString(
+                  reviewerName,
+                  reviewerLocation
+                )}
+              </Subheading>
+            </GridColumn>
+            <GridColumn
+              computer={6}
+              mobile={12}
+              tablet={5}
+              textAlign="right"
+              verticalAlign="middle"
+            >
+              <Rating
+                disabled
+                maxRating={5}
+                rating={Math.round(ratingNumber)}
+                size="small"
+              />
+            </GridColumn>
+          </GridRow>
+        </Grid>
+      </Card.Meta>
+      <Divider />
+      <Card.Header>{reviewTitle}</Card.Header>
+      <Card.Description>{reviewText}</Card.Description>
+      <Divider />
+      {!!reviewResponse && (
+        <div>
+          <Quote
+            quoteDateTime={reviewResponse.dateTime}
+            quoteSource={reviewResponse.source}
+            quoteText={reviewResponse.text}
+          />
+          <Divider />
+        </div>
+      )}
+      <Card.Description textAlign="right">
+        {getReviewerCategoryAndStayDateString(
+          reviewerCategory,
+          reviewerStayDate
         )}
-        <Card.Description textAlign="right">
-          {getReviewerCategoryAndStayDateString(
-            reviewerCategory,
-            reviewerStayDate
-          )}
-        </Card.Description>
-      </Card.Content>
-    </Card>
-  </VerticalGutters>
+      </Card.Description>
+    </Card.Content>
+  </Card>
 );
 
 Component.displayName = 'Review';

--- a/src/components/general-widgets/Review/component.spec.js
+++ b/src/components/general-widgets/Review/component.spec.js
@@ -14,7 +14,6 @@ import { GridRow } from 'layout/GridRow';
 import { GridColumn } from 'layout/GridColumn';
 import { Quote } from 'elements/Quote';
 import { Subheading } from 'typography/Subheading';
-import { VerticalGutters } from 'layout/VerticalGutters';
 
 import { getReviewerNameAndLocationString } from './utils/getReviewerNameAndLocationString';
 import { getReviewerCategoryAndStayDateString } from './utils/getReviewerCategoryAndStayDateString';
@@ -40,17 +39,10 @@ const getReview = additionalProps =>
   shallow(<Review {...requiredProps} {...additionalProps} />);
 
 describe('<Review />', () => {
-  it('should have `VerticalGutters` component as a wrapper', () => {
+  it('should have `Card` component as a wrapper', () => {
     const wrapper = getReview();
 
-    expectComponentToBe(wrapper, VerticalGutters);
-  });
-  describe('the `VerticalGutters` component', () => {
-    it('should have `Card` as its only children', () => {
-      const wrapper = getReview();
-
-      expectComponentToHaveChildren(wrapper, Card);
-    });
+    expectComponentToBe(wrapper, Card);
   });
 
   describe('the first `Card` component', () => {


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1020)

### What **one** thing does this PR do?
Removes the vertical spacing for the `Review`

__Before__
<img width="694" alt="screen shot 2018-09-10 at 12 48 19" src="https://user-images.githubusercontent.com/25742275/45293413-6c7fbd00-b4f8-11e8-9b52-9418c1a9831a.png">

__After__
<img width="705" alt="screen shot 2018-09-10 at 12 51 11" src="https://user-images.githubusercontent.com/25742275/45293417-70abda80-b4f8-11e8-8fff-d5bb855aa62c.png">
