### PR TITLE
TE-1035: icon should be the correct width in Button

### DIFF
--- a/src/styles/semantic/themes/livingstone/elements/button.overrides
+++ b/src/styles/semantic/themes/livingstone/elements/button.overrides
@@ -28,6 +28,14 @@
   margin: @iconSvgMargin;
 }
 
+.ui.button.circular,
+.ui.button {
+
+  > .icon {
+    width: auto;
+  }
+}
+
 /* Loader */
 
 /*


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1035)

### What **one** thing does this PR do?
updates icon width in Button

__Before__
<img width="470" alt="screen shot 2018-09-12 at 13 06 40" src="https://user-images.githubusercontent.com/25742275/45421310-e648af80-b68c-11e8-8cc1-ba09159ff891.png">

__After__
<img width="428" alt="screen shot 2018-09-12 at 13 06 24" src="https://user-images.githubusercontent.com/25742275/45421317-eba5fa00-b68c-11e8-935d-a9f7e9b0fac8.png">

