### PR TITLE
TE-1041: Ensure items in Amenities always display in a 3 column grid

### DIFF
--- a/src/components/layout/Grid/Readme.md
+++ b/src/components/layout/Grid/Readme.md
@@ -30,3 +30,48 @@
  </GridRow>
 </Grid>
 ```
+
+### Variations
+
+#### Columns have a fixed width
+
+Using the prop `hasFixedWidth` will ensure the grid columns will remain their defined 
+width and not expand to fill the extra whitespace
+
+```jsx
+// Change this value to see the impact of the `hasFixedWidth` prop
+const hasFixedWidth = true;
+
+<Grid hasFixedWidth={hasFixedWidth}>
+  <GridColumn width={4}>
+    🔴 🔴 ⚪️ ⚪️<br />
+    🔴 🔴 ⚪️ ⚪️<br />
+    ⚪️ ⚪️ ⚪️ ⚪️<br />
+    ⚪️ ⚪️ ⚪️ ⚪️<br />
+  </GridColumn>
+  <GridColumn width={4}>
+    ⚪️ ⚪️ 🔴 🔴<br />
+    ⚪️ ⚪️ 🔴 🔴<br />
+    ⚪️ ⚪️ ⚪️ ⚪️<br />
+    ⚪️ ⚪️ ⚪️ ⚪️<br />
+  </GridColumn>
+  <GridColumn width={4}>
+    ⚪️ ⚪️ ⚪️ ⚪️<br />
+    ⚪️ ⚪️ ⚪️ ⚪️<br />
+    🔴 🔴 ⚪️ ⚪️<br />
+    🔴 🔴 ⚪️ ⚪️<br />
+  </GridColumn>
+  <GridColumn width={4}>
+    ⚪️ ⚪️ ⚪️ ⚪️<br />
+    ⚪️ ⚪️ ⚪️ ⚪️<br />
+    🔴 🔴 ⚪️ ⚪️<br />
+    🔴 🔴 ⚪️ ⚪️<br />
+  </GridColumn>
+  <GridColumn width={4}>
+    ⚪️ ⚪️ ⚪️ ⚪️<br />
+    ⚪️ ⚪️ ⚪️ ⚪️<br />
+    ⚪️ ⚪️ 🔴 🔴<br />
+    ⚪️ ⚪️ 🔴 🔴<br />
+  </GridColumn>
+</Grid>
+```

--- a/src/components/layout/Grid/component.js
+++ b/src/components/layout/Grid/component.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Grid } from 'semantic-ui-react';
+import getClassNames from 'classnames';
 
 /**
  * Grid is the Lodgify UI interface for the
@@ -10,17 +11,26 @@ import { Grid } from 'semantic-ui-react';
  * definition of Semantic UI.
  */
 // eslint-disable-next-line jsdoc/require-jsdoc
-export const Component = ({ areColumnsCentered, ...props }) => (
-  <Grid {...props} centered={areColumnsCentered} />
+export const Component = ({ areColumnsCentered, hasFixedWidth, ...props }) => (
+  <Grid
+    className={getClassNames({
+      'has-fixed-width': hasFixedWidth,
+    })}
+    {...props}
+    centered={areColumnsCentered}
+  />
 );
 
 Component.displayName = 'Grid';
 
 Component.defaultProps = {
   areColumnsCentered: false,
+  hasFixedWidth: false,
 };
 
 Component.propTypes = {
   /** Are the columns in the grid centered. */
   areColumnsCentered: PropTypes.bool,
+  /** Should the columns stick to their defined width. */
+  hasFixedWidth: PropTypes.bool,
 };

--- a/src/components/layout/Grid/component.spec.js
+++ b/src/components/layout/Grid/component.spec.js
@@ -28,6 +28,18 @@ describe('<Grid />', () => {
     });
   });
 
+  describe('if `props.hasFixedWidth` is passed', () => {
+    it('should set `className` to `has-fixed-width`', () => {
+      const wrapper = getGrid({
+        hasFixedWidth: true,
+      });
+
+      expectComponentToHaveProps(wrapper, {
+        className: 'has-fixed-width',
+      });
+    });
+  });
+
   it('should have displayName `Grid`', () => {
     expectComponentToHaveDisplayName(LodgifyGrid, 'Grid');
   });

--- a/src/components/property-page-widgets/Amenities/utils/getAmenityMarkup.js
+++ b/src/components/property-page-widgets/Amenities/utils/getAmenityMarkup.js
@@ -24,7 +24,7 @@ export const getAmenityMarkup = (
   isStacked,
   modalTriggerText
 ) => (
-  <Grid stackable>
+  <Grid hasFixedWidth stackable>
     {headingText && (
       <GridColumn width={12}>
         <Heading>{headingText}</Heading>

--- a/src/styles/semantic/themes/livingstone/collections/grid.overrides
+++ b/src/styles/semantic/themes/livingstone/collections/grid.overrides
@@ -7,3 +7,7 @@
   padding-left: 0;
   padding-right: 0;
 }
+
+.grid.has-fixed-width > *:not(.container):not(.row) {
+  flex-grow: 0;
+}


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1041)

### What **one** thing does this PR do?
Updates the amenities to ensure items always display in a three column grid

### Other notes
1. This involved adding the prop `isStrict` to the Grid

__Before__
<img width="719" alt="screen shot 2018-09-13 at 14 25 29" src="https://user-images.githubusercontent.com/25742275/45488328-5de80e80-b761-11e8-9e72-072276c3dd62.png">

__After__
<img width="697" alt="screen shot 2018-09-13 at 14 25 20" src="https://user-images.githubusercontent.com/25742275/45488335-62142c00-b761-11e8-8632-f7f51f498d4f.png">

