### PR TITLE
TE-1066: Add in reduced version for `Summary`

### DIFF
--- a/src/components/property-page-widgets/Summary/Readme.md
+++ b/src/components/property-page-widgets/Summary/Readme.md
@@ -6,3 +6,17 @@
   ratingNumber={4.8}
 />
 ```
+
+### Variations
+
+#### Reduced version
+
+```jsx
+<Summary
+  hasReducedVersion
+  locationName="Catania"
+  nightPrice="$280"
+  propertyName="The Cat House"
+  ratingNumber={4.8}
+/>
+```

--- a/src/components/property-page-widgets/Summary/component.js
+++ b/src/components/property-page-widgets/Summary/component.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { Rating, Segment } from 'semantic-ui-react';
 
@@ -11,37 +11,61 @@ import { getNightPriceMarkup } from 'utils/get-night-price-markup/';
  */
 // eslint-disable-next-line jsdoc/require-jsdoc
 export const Component = ({
+  hasReducedVersion,
   locationName,
   nightPrice,
   propertyName,
   ratingNumber,
 }) => (
   <Segment.Group compact>
-    <Segment>
-      <Heading>{propertyName}</Heading>
-    </Segment>
-    <Segment.Group horizontal>
-      <Segment>
-        {locationName}
-        <Icon color="yellow" name={ICON_NAMES.MAP_PIN} size="small" />
-      </Segment>
-      <Segment>
-        {ratingNumber}
-        <Rating
-          disabled
-          maxRating={5}
-          rating={Math.round(ratingNumber)}
-          size="tiny"
-        />
-      </Segment>
-      <Segment>{getNightPriceMarkup(nightPrice, 'small')}</Segment>
-    </Segment.Group>
+    {hasReducedVersion ? (
+      <Fragment>
+        <Segment as="p">
+          {ratingNumber}
+          <Rating
+            disabled
+            maxRating={5}
+            rating={Math.round(ratingNumber)}
+            size="tiny"
+          />
+        </Segment>
+        <Segment as="p">{getNightPriceMarkup(nightPrice, 'small')}</Segment>
+      </Fragment>
+    ) : (
+      <Fragment>
+        <Segment>
+          <Heading>{propertyName}</Heading>
+        </Segment>
+        <Segment.Group horizontal>
+          <Segment>
+            {locationName}
+            <Icon color="yellow" name={ICON_NAMES.MAP_PIN} size="small" />
+          </Segment>
+          <Segment>
+            {ratingNumber}
+            <Rating
+              disabled
+              maxRating={5}
+              rating={Math.round(ratingNumber)}
+              size="tiny"
+            />
+          </Segment>
+          <Segment>{getNightPriceMarkup(nightPrice, 'small')}</Segment>
+        </Segment.Group>
+      </Fragment>
+    )}
   </Segment.Group>
 );
 
 Component.displayName = 'Summary';
 
+Component.defaultProps = {
+  hasReducedVersion: false,
+};
+
 Component.propTypes = {
+  /** Should the reduced version be shown */
+  hasReducedVersion: PropTypes.bool,
   /** The name of the location of the property. */
   locationName: PropTypes.string.isRequired,
   /** The price per night of the property, with currency symbol. */

--- a/src/components/property-page-widgets/Summary/component.spec.js
+++ b/src/components/property-page-widgets/Summary/component.spec.js
@@ -8,6 +8,7 @@ import {
   expectComponentToHaveProps,
 } from '@lodgify/enzyme-jest-expect-helpers';
 
+import { getNightPriceMarkup } from 'utils/get-night-price-markup';
 import { getArrayOfLengthOfItem } from 'utils/get-array-of-length-of-item';
 import { Icon } from 'elements/Icon';
 import { Heading } from 'typography/Heading';
@@ -21,7 +22,8 @@ const props = {
   ratingNumber: 4.8,
 };
 
-const getSummary = () => shallow(<Summary {...props} />);
+const getSummary = otherProps =>
+  shallow(<Summary {...props} {...otherProps} />);
 
 describe('<Summary />', () => {
   it('should render a single Semantic UI `Segment.Group` component', () => {
@@ -184,6 +186,56 @@ describe('<Summary />', () => {
       const wrapper = getLastHeading();
 
       expectComponentToHaveChildren(wrapper, props.nightPrice);
+    });
+  });
+
+  describe('the reduced version', () => {
+    const getReducedSummary = () =>
+      getSummary({
+        hasReducedVersion: true,
+      });
+
+    it('should have the right children', () => {
+      const wrapper = getReducedSummary();
+
+      expectComponentToHaveChildren(wrapper, Segment, Segment);
+    });
+
+    describe('the first `Segment`', () => {
+      const getFirstSegment = () =>
+        getReducedSummary()
+          .find(Segment)
+          .at(0);
+
+      it('should have the right props', () => {
+        const wrapper = getFirstSegment();
+
+        expectComponentToHaveProps(wrapper, {
+          as: 'p',
+        });
+      });
+
+      it('should have the right children', () => {
+        const wrapper = getFirstSegment();
+
+        expectComponentToHaveChildren(wrapper, props.ratingNumber + '', Rating);
+      });
+    });
+
+    describe('the second `Segment`', () => {
+      const getSecondSegment = () =>
+        getReducedSummary()
+          .find(Segment)
+          .at(1);
+
+      it('should have the right props', () => {
+        const wrapper = getSecondSegment();
+
+        expectComponentToHaveProps(wrapper, {
+          as: 'p',
+          children: getNightPriceMarkup(props.nightPrice, 'small'),
+        });
+      });
     });
   });
 


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1066)

### What **one** thing does this PR do?
Adds in a reduced version of the `Summary` component

__Before__
<img width="438" alt="screen shot 2018-09-14 at 15 16 09" src="https://user-images.githubusercontent.com/25742275/45555476-2c427680-b839-11e8-911c-53c2f864dd05.png">

__After__
<img width="391" alt="screen shot 2018-09-14 at 15 16 15" src="https://user-images.githubusercontent.com/25742275/45555481-31072a80-b839-11e8-8fe5-9279bd9d2dc4.png">

