### PR TITLE
TE-1046 Header and SearchBar LocationOptions

### DIFF
--- a/src/components/collections/Header/utils/hasSearchBarOptions.js
+++ b/src/components/collections/Header/utils/hasSearchBarOptions.js
@@ -6,4 +6,4 @@ import { size } from 'lodash';
  * @return {boolean}
  */
 export const hasSearchBarOptions = (guestsOptions, locationOptions) =>
-  size(guestsOptions) > 0 && size(locationOptions) > 0;
+  size(guestsOptions) > 0 || size(locationOptions) > 0;

--- a/src/components/collections/Header/utils/hasSearchBarOptions.spec.js
+++ b/src/components/collections/Header/utils/hasSearchBarOptions.spec.js
@@ -12,15 +12,20 @@ describe('hasSearchBarOptions', () => {
   });
 
   describe('if either of `guestsOptions` and `locationOptions` is undefined or not populated', () => {
+    it('should return `true`', () => {
+      const testCases = [[[{}], undefined], [undefined, [{}]], [[{}], [{}]]];
+
+      testCases.forEach(([guestsOptions, locationOptions]) => {
+        const actual = hasSearchBarOptions(guestsOptions, locationOptions);
+
+        expect(actual).toBe(true);
+      });
+    });
+  });
+
+  describe('if both of `guestsOptions` and `locationOptions` is undefined or not populated', () => {
     it('should return `false`', () => {
-      const testCases = [
-        [undefined, undefined],
-        [[{}], undefined],
-        [undefined, [{}]],
-        [[{}], []],
-        [[], [{}]],
-        [[], []],
-      ];
+      const testCases = [[undefined, undefined]];
 
       testCases.forEach(([guestsOptions, locationOptions]) => {
         const actual = hasSearchBarOptions(guestsOptions, locationOptions);

--- a/src/components/general-widgets/SearchBar/Readme.md
+++ b/src/components/general-widgets/SearchBar/Readme.md
@@ -39,8 +39,6 @@ const { guestsOptions, locationOptions } = require('./mock-data/options');
 
 <SearchBar
   guestsOptions={guestsOptions}
-  locationOptions={locationOptions}
-  isShowingLocationDropdown={false}
 />
 ```
 
@@ -53,7 +51,6 @@ const displayAsFixed = false;
 
 <SearchBar
   isFixed={displayAsFixed}
-  isShowingLocationDropdown={false}
   guestsOptions={guestsOptions}
   searchButton={<Button isRounded isCompact>Availability</Button>}
   summaryElement={
@@ -72,7 +69,6 @@ const displayAsFixed = false;
 <SearchBar
   isFixed={displayAsFixed}
   isDisplayedAsModal
-  isShowingLocationDropdown={false}
   guestsOptions={guestsOptions}
   modalTrigger={<Button isPositionedRight isRounded isCompact>Availability</Button>}
   modalSummaryElement={

--- a/src/components/general-widgets/SearchBar/component.js
+++ b/src/components/general-widgets/SearchBar/component.js
@@ -114,12 +114,12 @@ Component.defaultProps = {
   isDisplayedAsModal: false,
   isFixed: false,
   isShowingSummary: false,
-  isShowingLocationDropdown: true,
   searchButton: (
     <Button icon={ICON_NAMES.SEARCH} isPositionedRight isRounded>
       Search
     </Button>
   ),
+  locationOptions: null,
   summaryElement: null,
 };
 /* eslint react/no-unused-prop-types: 0 */
@@ -147,8 +147,6 @@ Component.propTypes = {
   isDisplayedAsModal: PropTypes.bool,
   /** Is the Search Bar fixed to the bottom of the window */
   isFixed: PropTypes.bool,
-  /** Is Search Bar showing the Location Dropdown. */
-  isShowingLocationDropdown: PropTypes.bool,
   /** Is Search Bar showing the Property Summary info. */
   isShowingSummary: PropTypes.bool,
   /** The options which the user can select in the location field. */
@@ -163,7 +161,7 @@ Component.propTypes = {
         PropTypes.string,
       ]),
     })
-  ).isRequired,
+  ),
   /** The heading text to display in the modal */
   modalHeadingText: PropTypes.string,
   /** The summary element to display in the mobile modal  */

--- a/src/components/general-widgets/SearchBar/component.spec.js
+++ b/src/components/general-widgets/SearchBar/component.spec.js
@@ -113,9 +113,9 @@ describe('<SearchBar />', () => {
       });
     });
 
-    describe('if `props.isShowingLocationDropdown` is false', () => {
+    describe('if `props.locationOptions` is not passed', () => {
       it('should render three `Form.Field` components', () => {
-        const wrapper = getFormGroup({ isShowingLocationDropdown: false }).find(
+        const wrapper = getFormGroup({ locationOptions: null }).find(
           Form.Field
         );
 

--- a/src/components/general-widgets/SearchBar/utils/getFormFieldMarkup.js
+++ b/src/components/general-widgets/SearchBar/utils/getFormFieldMarkup.js
@@ -1,6 +1,7 @@
 /* eslint react/prop-types: 0 */
 import React, { Fragment } from 'react';
 import { Form } from 'semantic-ui-react';
+import { size } from 'lodash';
 
 import { Icon, ICON_NAMES } from 'elements/Icon';
 import { Dropdown } from 'inputs/Dropdown';
@@ -9,7 +10,6 @@ import { DateRangePicker } from 'inputs/DateRangePicker';
 /**
  * @param  {Object}   props
  * @param  {boolean}  props.isShowingSummary
- * @param  {boolean}  props.isShowingLocationDropdown
  * @param  {Function} props.getIsDayBlocked
  * @param  {Object[]} props.locationOptions
  * @param  {Object[]} props.guestsOptions
@@ -22,7 +22,6 @@ import { DateRangePicker } from 'inputs/DateRangePicker';
 export const getFormFieldMarkup = (
   {
     isShowingSummary,
-    isShowingLocationDropdown,
     getIsDayBlocked,
     locationOptions,
     guestsOptions,
@@ -46,7 +45,7 @@ export const getFormFieldMarkup = (
           />
         </Form.Field>
       )}
-      {!!isShowingLocationDropdown && (
+      {!!size(locationOptions) > 0 && (
         <Form.Field width={defaultColumnWidth}>
           <Dropdown
             icon={ICON_NAMES.MAP_PIN}

--- a/src/components/general-widgets/SearchBar/utils/getFormFieldMarkup.spec.js
+++ b/src/components/general-widgets/SearchBar/utils/getFormFieldMarkup.spec.js
@@ -37,10 +37,10 @@ const getMarkup = overrideProps =>
   );
 
 describe('getFormFieldMarkup', () => {
-  it('should return 5 `Form.Field`', () => {
+  it('should return 4 `Form.Field`', () => {
     const wrapper = getMarkup().find(Form.Field);
 
-    expect(wrapper).toHaveLength(5);
+    expect(wrapper).toHaveLength(4);
   });
 
   describe('first `Form.Field`', () => {
@@ -56,6 +56,7 @@ describe('getFormFieldMarkup', () => {
         width: 'three',
       });
     });
+
     it('should have the correct children', () => {
       const wrapper = getField();
 
@@ -86,42 +87,10 @@ describe('getFormFieldMarkup', () => {
       const wrapper = getField();
 
       expectComponentToHaveProps(wrapper, {
-        width: 'three',
-      });
-    });
-    it('should have the correct children', () => {
-      const wrapper = getField();
-
-      expectComponentToHaveChildren(wrapper, Dropdown);
-    });
-  });
-  describe('first `Dropdown`', () => {
-    it('should have the right props', () => {
-      const wrapper = getMarkup()
-        .find(Dropdown)
-        .at(0);
-
-      expectComponentToHaveProps(wrapper, {
-        icon: 'map pin',
-        label: 'Location',
-        onChange: expect.any(Function),
-      });
-    });
-  });
-
-  describe('third `Form.Field`', () => {
-    const getField = () =>
-      getMarkup()
-        .find(Form.Field)
-        .at(2);
-
-    it('should have the right props', () => {
-      const wrapper = getField();
-
-      expectComponentToHaveProps(wrapper, {
         width: 'seven',
       });
     });
+
     it('should have the correct children', () => {
       const wrapper = getField();
 
@@ -141,11 +110,11 @@ describe('getFormFieldMarkup', () => {
       });
     });
   });
-  describe('fourth `Form.Field`', () => {
+  describe('third `Form.Field`', () => {
     const getField = () =>
       getMarkup()
         .find(Form.Field)
-        .at(3);
+        .at(2);
 
     it('should have the right props', () => {
       const wrapper = getField();
@@ -164,7 +133,7 @@ describe('getFormFieldMarkup', () => {
     it('should have the right props', () => {
       const wrapper = getMarkup()
         .find(Dropdown)
-        .at(1);
+        .at(0);
 
       expectComponentToHaveProps(wrapper, {
         name: 'guests',
@@ -173,11 +142,11 @@ describe('getFormFieldMarkup', () => {
       });
     });
   });
-  describe('fifth `Form.Field`', () => {
+  describe('fourth `Form.Field`', () => {
     const getField = () =>
       getMarkup()
         .find(Form.Field)
-        .at(4);
+        .at(3);
 
     it('should have the right props', () => {
       const wrapper = getField();
@@ -186,10 +155,57 @@ describe('getFormFieldMarkup', () => {
         width: 'three',
       });
     });
+
     it('should have the correct children', () => {
       const wrapper = getField();
 
       expectComponentToHaveChildren(wrapper, 'div');
+    });
+  });
+
+  describe('if `props.locationOptions` size is greater than 0', () => {
+    const getMerkupWithLocationOptions = () =>
+      getMarkup({ locationOptions: [{ text: 'yo' }] });
+
+    it('should render an extra `Form.Field`', () => {
+      const wrapper = getMerkupWithLocationOptions().find(Form.Field);
+
+      expect(wrapper).toHaveLength(5);
+    });
+
+    describe('the `Form.Field`', () => {
+      const getField = () =>
+        getMerkupWithLocationOptions()
+          .find(Form.Field)
+          .at(1);
+
+      it('should have the right props', () => {
+        const wrapper = getField();
+
+        expectComponentToHaveProps(wrapper, {
+          width: 'three',
+        });
+      });
+
+      it('should have the correct children', () => {
+        const wrapper = getField();
+
+        expectComponentToHaveChildren(wrapper, Dropdown);
+      });
+
+      describe('first `Dropdown`', () => {
+        it('should have the right props', () => {
+          const wrapper = getMerkupWithLocationOptions()
+            .find(Dropdown)
+            .at(0);
+
+          expectComponentToHaveProps(wrapper, {
+            icon: 'map pin',
+            label: 'Location',
+            onChange: expect.any(Function),
+          });
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1046)

### What **one** thing does this PR do?
Removes `props.isShowingLocationDropdown` from SearchBar as we can just check if there are any being passed into the component and updates the Header to correctly render the SearchBar depending on the options available

### Any other notes
![kapture 2018-09-18 at 16 32 03](https://user-images.githubusercontent.com/10498995/45694868-7e003f00-bb60-11e8-9cdc-8ab57bedf92e.gif)

