### PR TITLE
TE-1098 locking Webpack version to v4.19.0 until new version fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "style-loader": "^0.20.2",
     "stylelint": "^9.2.0",
     "stylelint-config-standard": "^18.2.0",
-    "webpack": "^4.5.0",
+    "webpack": "4.19.0",
     "webpack-cli": "^2.0.14"
   },
   "dependencies": {


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1098)

### What **one** thing does this PR do?
Locks Webpack to version until the latest version has been resolved

__The problem__
When running `npm run build:less` we get an error in the log:
```
> @lodgify/ui@1.55.1 build:less /Users/stephen.kerr/Projects/lodgify-ui
> webpack --config $npm_package_config_less_build_config

/Users/stephen.kerr/Projects/lodgify-ui/node_modules/webpack-cli/bin/config-yargs.js:89
                                describe: optionsSchema.definitions.output.properties.path.description,
                                                                           ^

TypeError: Cannot read property 'properties' of undefined
    at module.exports (/Users/stephen.kerr/Projects/lodgify-ui/node_modules/webpack-cli/bin/config-yargs.js:89:48)
    at /Users/stephen.kerr/Projects/lodgify-ui/node_modules/webpack-cli/bin/webpack.js:60:27
```

This was introduced in Webpack@4.20.0, the temporary solution is to fall back to v4.19.0 until a solution has been published.

### Any other notes
The issue is currently being followed here `https://github.com/webpack/webpack/issues/8082`
