### PR TITLE
TE-1081: add spacing after the Hero

### DIFF
--- a/src/components/collections/Hero/component.js
+++ b/src/components/collections/Hero/component.js
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 
+import { Divider } from 'elements/Divider';
 import { Heading } from 'typography/Heading';
 import { Header } from 'collections/Header';
 import { FullBleed } from 'media/FullBleed';
@@ -22,18 +23,21 @@ export const Component = ({
   headerSearchBarLocationOptions,
   heading,
 }) => (
-  <FullBleed className="is-hero" hasGradient imageUrl={backgroundImageUrl}>
-    <Header
-      logoSrc={headerLogoSrc}
-      logoText={headerLogoText}
-      navigationItems={headerNavigationItems}
-      primaryCTA={headerPrimaryCTA}
-      searchBarGuestsOptions={headerSearchBarGuestsOptions}
-      searchBarLocationOptions={headerSearchBarLocationOptions}
-    />
-    <Heading size="huge">{heading}</Heading>
-    <Container textAlign="center">{!!extraContent && extraContent}</Container>
-  </FullBleed>
+  <Fragment>
+    <FullBleed className="is-hero" hasGradient imageUrl={backgroundImageUrl}>
+      <Header
+        logoSrc={headerLogoSrc}
+        logoText={headerLogoText}
+        navigationItems={headerNavigationItems}
+        primaryCTA={headerPrimaryCTA}
+        searchBarGuestsOptions={headerSearchBarGuestsOptions}
+        searchBarLocationOptions={headerSearchBarLocationOptions}
+      />
+      <Heading size="huge">{heading}</Heading>
+      <Container textAlign="center">{!!extraContent && extraContent}</Container>
+    </FullBleed>
+    <Divider size="large" />
+  </Fragment>
 );
 
 Component.displayName = 'Hero';

--- a/src/components/collections/Hero/component.spec.js
+++ b/src/components/collections/Hero/component.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import { shallow } from 'enzyme';
 import {
   expectComponentToBe,
@@ -33,26 +33,36 @@ const getContainerComponent = extraProps =>
   getHeroComponent(extraProps).find(Container);
 
 describe('<Hero />', () => {
-  it('should render a single `FullBleed` component', () => {
+  it('should render a single `Fragment` component', () => {
     const wrapper = getHeroComponent();
 
-    expectComponentToBe(wrapper, FullBleed);
+    expectComponentToBe(wrapper, Fragment);
   });
 
-  it('should have the right props', () => {
-    const wrapper = getHeroComponent();
+  describe('the `Fragment`', () => {
+    const getFullBleed = () => getHeroComponent().childAt(0);
 
-    expectComponentToHaveProps(wrapper, {
-      className: 'is-hero',
-      hasGradient: true,
-      imageUrl: 'https://darkpurple.com',
+    it('should render a single `FullBleed` component', () => {
+      const wrapper = getFullBleed();
+
+      expectComponentToBe(wrapper, FullBleed);
     });
-  });
 
-  it('should have the right children', () => {
-    const wrapper = getHeroComponent();
+    it('should have the right props', () => {
+      const wrapper = getFullBleed();
 
-    expectComponentToHaveChildren(wrapper, Header, Heading, Container);
+      expectComponentToHaveProps(wrapper, {
+        className: 'is-hero',
+        hasGradient: true,
+        imageUrl: 'https://darkpurple.com',
+      });
+    });
+
+    it('should have the right children', () => {
+      const wrapper = getFullBleed();
+
+      expectComponentToHaveChildren(wrapper, Header, Heading, Container);
+    });
   });
 
   describe('the `Header` component', () => {


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1081)

### What **one** thing does this PR do?
Add a divider after the `Hero`

__Preview__
<img width="774" alt="screen shot 2018-09-25 at 15 16 38" src="https://user-images.githubusercontent.com/25742275/46016802-0ab57a80-c0d6-11e8-9341-b9c22cdd918d.png">


