### PR TITLE
TE-1100 Gallery: expose component with tests and examples

### DIFF
--- a/src/components/elements/Quote/component.js
+++ b/src/components/elements/Quote/component.js
@@ -16,12 +16,12 @@ export const Component = ({ quoteDateTime, quoteSource, quoteText }) => (
   <blockquote className="ui quote">
     <Grid>
       <GridRow>
-        <GridColumn>
+        <GridColumn width={12}>
           <Paragraph>{quoteText}</Paragraph>
         </GridColumn>
       </GridRow>
       <GridRow horizontalAlignContent="right">
-        <GridColumn>
+        <GridColumn width={12}>
           <Paragraph size="tiny">
             {getQuoteSource(quoteSource, quoteDateTime)}
           </Paragraph>

--- a/src/components/elements/Quote/component.spec.js
+++ b/src/components/elements/Quote/component.spec.js
@@ -69,10 +69,19 @@ describe('<Quote />', () => {
   });
 
   describe('the first `GridColumn` component', () => {
-    it('should render a single `Paragraph` component', () => {
-      const wrapper = getQuote()
+    const getFirstGridColumn = () =>
+      getQuote()
         .find(GridColumn)
-        .at(0);
+        .first();
+
+    it('should have the right props', () => {
+      const wrapper = getFirstGridColumn();
+
+      expectComponentToHaveProps(wrapper, { width: 12 });
+    });
+
+    it('should render a single `Paragraph` component', () => {
+      const wrapper = getFirstGridColumn();
 
       expectComponentToHaveChildren(wrapper, Paragraph);
     });
@@ -110,10 +119,19 @@ describe('<Quote />', () => {
   });
 
   describe('the second `GridColumn` component', () => {
-    it('should render a `Paragraph` component', () => {
-      const wrapper = getQuote()
+    const getSecondGridColumn = () =>
+      getQuote()
         .find(GridColumn)
         .at(1);
+
+    it('should have the right props', () => {
+      const wrapper = getSecondGridColumn();
+
+      expectComponentToHaveProps(wrapper, { width: 12 });
+    });
+
+    it('should render a `Paragraph` component', () => {
+      const wrapper = getSecondGridColumn();
 
       expectComponentToHaveChildren(wrapper, Paragraph);
     });

--- a/src/components/general-widgets/Promotion/component.js
+++ b/src/components/general-widgets/Promotion/component.js
@@ -46,13 +46,16 @@ export const Component = ({
         >
           <Grid padded>
             <GridRow verticalAlign="top">
-              <GridColumn textAlign={isDisplayedStacked ? 'center' : 'left'}>
+              <GridColumn
+                textAlign={isDisplayedStacked ? 'center' : 'left'}
+                width={12}
+              >
                 <Heading>{headingText}</Heading>
               </GridColumn>
             </GridRow>
             {!isDisplayedStacked && (
               <GridRow className="book-now-button-container">
-                <GridColumn textAlign="center">
+                <GridColumn textAlign="center" width={12}>
                   <Button isRounded>{discountHoverButtonText}</Button>
                 </GridColumn>
               </GridRow>

--- a/src/components/general-widgets/Promotion/component.spec.js
+++ b/src/components/general-widgets/Promotion/component.spec.js
@@ -166,6 +166,7 @@ describe('The `Promotion` component', () => {
 
       expectComponentToHaveProps(wrapper, {
         textAlign: 'left',
+        width: 12,
       });
     });
 
@@ -218,6 +219,7 @@ describe('The `Promotion` component', () => {
 
       expectComponentToHaveProps(wrapper, {
         textAlign: 'center',
+        width: 12,
       });
     });
 

--- a/src/components/layout/GridColumn/component.js
+++ b/src/components/layout/GridColumn/component.js
@@ -15,12 +15,12 @@ Component.displayName = 'GridColumn';
 
 Component.defaultProps = {
   verticalAlignContent: 'top',
-  width: 12,
+  width: null,
 };
 
 Component.propTypes = {
   /** Vertically align the content of the column to the bottom, middle or top. */
   verticalAlignContent: PropTypes.oneOf(['bottom', 'middle', 'top']),
   /** The width of the column */
-  width: PropTypes.oneOf([null, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
+  width: PropTypes.oneOf([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
 };

--- a/src/components/layout/GridColumn/component.spec.js
+++ b/src/components/layout/GridColumn/component.spec.js
@@ -24,7 +24,7 @@ describe('<GridColumn />', () => {
 
       expectComponentToHaveProps(wrapper, {
         verticalAlign: expect.any(String),
-        width: 12,
+        width: null,
       });
     });
   });

--- a/src/components/media/Gallery/Readme.md
+++ b/src/components/media/Gallery/Readme.md
@@ -1,0 +1,48 @@
+```jsx
+const images = [
+  {
+    imageUrl: 'https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max',
+    label: 'Two Cats',
+  },
+  {
+    imageUrl: 'https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max',
+    label: 'The Roof',
+  },
+  {
+    imageUrl: 'https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max',
+    label: 'The Church',
+  },
+];
+
+<Gallery
+  images={images}
+  trigger={<Button>See gallery</Button>}
+/>
+```
+
+### Content
+
+#### Heading
+
+```jsx
+const images = [
+  {
+    imageUrl: 'https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max',
+    label: 'Two Cats',
+  },
+  {
+    imageUrl: 'https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max',
+    label: 'The Roof',
+  },
+  {
+    imageUrl: 'https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max',
+    label: 'The Church',
+  },
+];
+
+<Gallery
+  heading={<Heading>Gallery</Heading>}
+  images={images}
+  trigger={<Button>See gallery</Button>}
+/>
+```

--- a/src/components/media/Gallery/component.js
+++ b/src/components/media/Gallery/component.js
@@ -1,0 +1,79 @@
+import React, { Fragment } from 'react';
+import PropTypes from 'prop-types';
+
+import { Modal } from 'elements/Modal';
+import { HorizontalGutters } from 'layout/HorizontalGutters';
+import { Divider } from 'elements/Divider';
+import { Grid } from 'layout/Grid';
+import { GridRow } from 'layout/GridRow';
+import { GridColumn } from 'layout/GridColumn';
+import { buildKeyFromStrings } from 'utils/build-key-from-strings';
+import { Heading } from 'typography/Heading';
+import { ResponsiveImage } from 'media/ResponsiveImage';
+
+/**
+ * A gallery displays a collection of images in a modal.
+ */
+// eslint-disable-next-line jsdoc/require-jsdoc
+export const Component = ({ heading, images, trigger }) => (
+  <Modal isFullscreen trigger={trigger}>
+    <HorizontalGutters>
+      <Divider />
+      {heading && (
+        <Fragment>
+          {heading}
+          <Divider hasLine />
+        </Fragment>
+      )}
+      <Grid columns={2} stackable>
+        <GridRow>
+          {images.map(({ label, ...otherImageProps }, index) => (
+            <GridColumn key={buildKeyFromStrings(label, index)}>
+              <Heading size="small">{label}</Heading>
+              <ResponsiveImage {...otherImageProps} />
+              <Divider />
+            </GridColumn>
+          ))}
+        </GridRow>
+      </Grid>
+      <Divider size="large" />
+    </HorizontalGutters>
+  </Modal>
+);
+
+Component.displayName = 'Gallery';
+
+Component.defaultProps = {
+  heading: null,
+};
+
+Component.propTypes = {
+  /** The content to display as a heading at the top of the gallery. */
+  heading: PropTypes.node,
+  /** The images to display. */
+  images: PropTypes.arrayOf(
+    PropTypes.shape({
+      /** Alternative text to show if the image can't be loaded by the browser */
+      alternativeText: PropTypes.string,
+      /** The label text for the when the image is not found. */
+      imageNotFoundLabelText: PropTypes.string,
+      /** Title of the image to show when hovering it on desktop browsers */
+      imageTitle: PropTypes.string,
+      /** URL pointing to the image to display. */
+      imageUrl: PropTypes.string.isRequired,
+      /** A visible label for the image. */
+      label: PropTypes.string.isRequired,
+      /** Collection of objects to specify different image sources
+       *  [See this for more info](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images)
+       */
+      sources: PropTypes.arrayOf(
+        PropTypes.shape({
+          media: PropTypes.string.isRequired,
+          srcset: PropTypes.string.isRequired,
+        })
+      ),
+    })
+  ).isRequired,
+  /** The element to be clicked to display the gallery. */
+  trigger: PropTypes.node.isRequired,
+};

--- a/src/components/media/Gallery/component.spec.js
+++ b/src/components/media/Gallery/component.spec.js
@@ -1,0 +1,150 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import {
+  expectComponentToBe,
+  expectComponentToHaveProps,
+  expectComponentToHaveChildren,
+  expectComponentToHaveDisplayName,
+} from '@lodgify/enzyme-jest-expect-helpers';
+
+import { Modal } from 'elements/Modal';
+import { HorizontalGutters } from 'layout/HorizontalGutters';
+import { Divider } from 'elements/Divider';
+import { Grid } from 'layout/Grid';
+import { GridRow } from 'layout/GridRow';
+import { GridColumn } from 'layout/GridColumn';
+import { Heading } from 'typography/Heading';
+import { ResponsiveImage } from 'media/ResponsiveImage';
+
+import { Component as Gallery } from './component';
+
+const images = [
+  { imageUrl: '💻', label: '🔷' },
+  { imageUrl: '💻', label: '🔷' },
+];
+const trigger = 'someTrigger';
+
+const getGallery = props =>
+  shallow(<Gallery images={images} trigger={trigger} {...props} />);
+
+describe('<Gallery />', () => {
+  it('should render a `Modal`', () => {
+    const wrapper = getGallery();
+
+    expectComponentToBe(wrapper, Modal);
+  });
+
+  describe('the `Modal`', () => {
+    it('should get the right props', () => {
+      const wrapper = getGallery();
+
+      expectComponentToHaveProps(wrapper, {
+        isFullscreen: true,
+        trigger,
+      });
+    });
+
+    it('should have the right children', () => {
+      const wrapper = getGallery();
+
+      expectComponentToHaveChildren(wrapper, HorizontalGutters);
+    });
+  });
+
+  describe('the `HorizontalGutters`', () => {
+    const getHorizontalGutters = props =>
+      getGallery(props).find(HorizontalGutters);
+
+    it('should have the right children', () => {
+      const wrapper = getHorizontalGutters();
+
+      expectComponentToHaveChildren(wrapper, Divider, Grid, Divider);
+    });
+
+    describe('if `props.heading` is defined', () => {
+      it('shoul have the right children', () => {
+        const heading = ':hurtrealbad:';
+        const wrapper = getHorizontalGutters({ heading });
+
+        expectComponentToHaveChildren(
+          wrapper,
+          Divider,
+          heading,
+          Divider,
+          Grid,
+          Divider
+        );
+      });
+    });
+  });
+
+  describe('the `Grid`', () => {
+    const getGrid = () => getGallery().find(Grid);
+
+    it('should have the right props', () => {
+      const wrapper = getGrid();
+
+      expectComponentToHaveProps(wrapper, {
+        columns: 2,
+        stackable: true,
+      });
+    });
+
+    it('should have the right children', () => {
+      const wrapper = getGrid();
+
+      expectComponentToHaveChildren(wrapper, GridRow);
+    });
+  });
+
+  describe('the `GridRow`', () => {
+    it('should have the right children', () => {
+      const wrapper = getGallery().find(GridRow);
+
+      expectComponentToHaveChildren(wrapper, GridColumn, GridColumn);
+    });
+  });
+
+  describe('each `GridColumn`', () => {
+    it('should have the right children', () => {
+      const wrapper = getGallery()
+        .find(GridColumn)
+        .first();
+
+      expectComponentToHaveChildren(wrapper, Heading, ResponsiveImage, Divider);
+    });
+  });
+
+  describe('each `Heading`', () => {
+    const getFirstHeading = () =>
+      getGallery()
+        .find(Heading)
+        .first();
+
+    it('should havce the right props', () => {
+      const wrapper = getFirstHeading();
+
+      expectComponentToHaveProps(wrapper, { size: 'small' });
+    });
+
+    it('should have the right children', () => {
+      const wrapper = getFirstHeading();
+
+      expectComponentToHaveChildren(wrapper, images[0].label);
+    });
+  });
+
+  describe('each `ResponsiveImage`', () => {
+    it('should havce the right props', () => {
+      const wrapper = getGallery()
+        .find(ResponsiveImage)
+        .first();
+
+      expectComponentToHaveProps(wrapper, { imageUrl: images[0].imageUrl });
+    });
+  });
+
+  it('should have `displayName` Gallery', () => {
+    expectComponentToHaveDisplayName(Gallery, 'Gallery');
+  });
+});

--- a/src/components/media/Gallery/index.js
+++ b/src/components/media/Gallery/index.js
@@ -1,0 +1,1 @@
+export { Component as Gallery } from './component';

--- a/src/components/property-page-widgets/Amenities/utils/getCategoryMarkup.js
+++ b/src/components/property-page-widgets/Amenities/utils/getCategoryMarkup.js
@@ -13,7 +13,7 @@ import { getFormattedAmenityItems } from './getFormattedAmenityItems';
  * @return {Object}
  */
 export const getCategoryMarkup = (category, index) => (
-  <GridColumn key={buildKeyFromStrings(category.name, index)} width={null}>
+  <GridColumn key={buildKeyFromStrings(category.name, index)}>
     <Icon
       isLabelLeft
       labelText={category.name}

--- a/src/components/property-page-widgets/Amenities/utils/getExtraItemsMarkup.js
+++ b/src/components/property-page-widgets/Amenities/utils/getExtraItemsMarkup.js
@@ -21,7 +21,7 @@ export const getExtraItemsMarkup = (
   amenities
 ) =>
   hasExtraItemsInModal ? (
-    <GridColumn>
+    <GridColumn width={12}>
       <Modal trigger={<Link>{modalTriggerText}</Link>}>
         <SemanticModal.Content>
           <Grid className="is-amenities" columns={1} padded stackable>

--- a/src/components/property-page-widgets/Availability/component.js
+++ b/src/components/property-page-widgets/Availability/component.js
@@ -158,7 +158,7 @@ class Component extends PureComponent {
           </Grid>
         </Card>
         <Grid>
-          <GridColumn only="mobile" textAlign="right">
+          <GridColumn only="mobile" textAlign="right" width={12}>
             <GridColumn>
               <Icon
                 color="grey"

--- a/src/components/property-page-widgets/Description/component.js
+++ b/src/components/property-page-widgets/Description/component.js
@@ -32,11 +32,11 @@ export const Component = ({
   propertyType,
 }) => (
   <Grid columns={1}>
-    <GridColumn>
+    <GridColumn width={12}>
       <Subheading>{propertyType}</Subheading>
       <Heading size="large">{propertyName}</Heading>
     </GridColumn>
-    <GridColumn>
+    <GridColumn width={12}>
       <ShowOnDesktop parent={List} parentProps={{ horizontal: true }}>
         {getFirstFourItems(propertyMainCharacteristics).map(
           ({ iconName, text }, index) => (
@@ -60,7 +60,7 @@ export const Component = ({
         )}
       </ShowOnMobile>
     </GridColumn>
-    <GridColumn>
+    <GridColumn width={12}>
       {getParagraphsFromStrings(descriptionText).map(
         (paragraphText, index, descriptionTextArray) => (
           <Paragraph key={buildKeyFromStrings(paragraphText, index)}>
@@ -79,10 +79,10 @@ export const Component = ({
         )
       )}
     </GridColumn>
-    <GridColumn>
+    <GridColumn width={12}>
       <Subheading>{homeHighlightsHeadingText}</Subheading>
     </GridColumn>
-    <GridColumn>
+    <GridColumn width={12}>
       {homeHighlights.map(({ iconName, text }) => (
         <Icon
           hasBorder

--- a/src/components/property-page-widgets/Rates/component.js
+++ b/src/components/property-page-widgets/Rates/component.js
@@ -51,7 +51,7 @@ export const Component = ({
             <Card.Content>
               <Grid padded>
                 <GridRow>
-                  <GridColumn>
+                  <GridColumn width={12}>
                     {getRateCategoryHeadingMarkup(
                       rateCategory,
                       costPerExtraGuestLabel

--- a/src/index.js
+++ b/src/index.js
@@ -65,6 +65,7 @@ export { VerticalGutters } from './components/layout/VerticalGutters';
 
 // Media
 export { FullBleed } from './components/media/FullBleed';
+export { Gallery } from './components/media/Gallery';
 export { ResponsiveImage } from './components/media/ResponsiveImage';
 export { Slideshow } from './components/media/Slideshow';
 export { Thumbnail } from './components/media/Thumbnail';

--- a/src/styles/semantic/themes/livingstone/modules/modal.overrides
+++ b/src/styles/semantic/themes/livingstone/modules/modal.overrides
@@ -45,6 +45,7 @@
 .ui.fullscreen.modal {
   bottom: 0;
   height: @fullScreenHeight;
+  overflow-y: scroll;
   position: absolute;
   top: 0;
 
@@ -83,4 +84,3 @@
 /* Size Widths */
 
 /* Derived Responsive Sizes */
-


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1100)

### What **one** thing does this PR do?
Exposes `Gallery` component with tests and examples

#### Mobile

<img width="387" alt="screen shot 2018-09-26 at 11 02 21" src="https://user-images.githubusercontent.com/8591501/46073046-d1374a80-c17b-11e8-9e01-a9c5f1acc995.png">

#### Desktop

<img width="1040" alt="screen shot 2018-09-26 at 11 02 06" src="https://user-images.githubusercontent.com/8591501/46072986-b4027c00-c17b-11e8-9ae2-a3da00d901a1.png">
