### PR TITLE
TE-1081: Remove `VerticalGutters` from components

### DIFF
--- a/src/components/general-widgets/CallMeBack/component.js
+++ b/src/components/general-widgets/CallMeBack/component.js
@@ -21,7 +21,6 @@ import { PhoneInput } from 'inputs/PhoneInput';
 import { SingleDatePicker } from 'inputs/SingleDatePicker';
 import { TextArea } from 'inputs/TextArea';
 import { TextInput } from 'inputs/TextInput';
-import { VerticalGutters } from 'layout/VerticalGutters';
 
 /**
  * The standard widget for a user to request a call back.
@@ -44,42 +43,40 @@ export const Component = ({
   timeZoneOptions,
   validation,
 }) => (
-  <VerticalGutters>
-    <Form
-      headingText={headingText}
-      onSubmit={onSubmit}
-      submitButtonText={submitButtonText}
-      validation={validation}
-    >
-      <InputGroup>
-        <TextInput label={nameInputLabel} name="name" />
-        <PhoneInput label={phoneInputLabel} name="phone" />
-      </InputGroup>
-      <TextInput label={emailInputLabel} name="email" />
-      <InputGroup>
-        <SingleDatePicker name="date" placeholderText={dateInputPlaceholder} />
-        <Dropdown
-          icon={ICON_NAMES.CLOCK}
-          label={timeInputLabel}
-          name="time"
-          options={timeOptions}
-        />
-      </InputGroup>
-      <InputGroup>
-        <Dropdown
-          label={timeZoneInputLabel}
-          name="timeZone"
-          options={timeZoneOptions}
-        />
-        <Dropdown
-          label={propertyInputLabel}
-          name="property"
-          options={propertyOptions}
-        />
-      </InputGroup>
-      <TextArea label={notesInputLabel} name="notes" />
-    </Form>
-  </VerticalGutters>
+  <Form
+    headingText={headingText}
+    onSubmit={onSubmit}
+    submitButtonText={submitButtonText}
+    validation={validation}
+  >
+    <InputGroup>
+      <TextInput label={nameInputLabel} name="name" />
+      <PhoneInput label={phoneInputLabel} name="phone" />
+    </InputGroup>
+    <TextInput label={emailInputLabel} name="email" />
+    <InputGroup>
+      <SingleDatePicker name="date" placeholderText={dateInputPlaceholder} />
+      <Dropdown
+        icon={ICON_NAMES.CLOCK}
+        label={timeInputLabel}
+        name="time"
+        options={timeOptions}
+      />
+    </InputGroup>
+    <InputGroup>
+      <Dropdown
+        label={timeZoneInputLabel}
+        name="timeZone"
+        options={timeZoneOptions}
+      />
+      <Dropdown
+        label={propertyInputLabel}
+        name="property"
+        options={propertyOptions}
+      />
+    </InputGroup>
+    <TextArea label={notesInputLabel} name="notes" />
+  </Form>
 );
 
 Component.displayName = 'CallMeBack';

--- a/src/components/general-widgets/CallMeBack/component.spec.js
+++ b/src/components/general-widgets/CallMeBack/component.spec.js
@@ -26,7 +26,6 @@ import { PhoneInput } from 'inputs/PhoneInput';
 import { SingleDatePicker } from 'inputs/SingleDatePicker';
 import { TextArea } from 'inputs/TextArea';
 import { TextInput } from 'inputs/TextInput';
-import { VerticalGutters } from 'layout/VerticalGutters';
 
 import { Component as CallMeBack } from './component';
 
@@ -75,18 +74,10 @@ const getCallMeBack = () =>
 const getForm = () => getCallMeBack().find(Form);
 
 describe('<CallMeBack />', () => {
-  it('should have `VerticalGutters` component as a wrapper', () => {
+  it('should have `Form` component as a wrapper', () => {
     const wrapper = getCallMeBack();
 
-    expectComponentToBe(wrapper, VerticalGutters);
-  });
-
-  describe('the `VerticalGutters` component', () => {
-    it('should have `Form` as its only children', () => {
-      const wrapper = getCallMeBack();
-
-      expectComponentToHaveChildren(wrapper, Form);
-    });
+    expectComponentToBe(wrapper, Form);
   });
 
   describe('the `Form` component', () => {

--- a/src/components/general-widgets/Contact/component.js
+++ b/src/components/general-widgets/Contact/component.js
@@ -23,7 +23,6 @@ import {
   SECURITY_CODE,
   SEND,
 } from 'utils/default-strings';
-import { VerticalGutters } from 'layout/VerticalGutters';
 
 /**
  * The standard widget for a user contact an owner.
@@ -49,59 +48,53 @@ export const Component = ({
   submitButtonText,
   validation,
 }) => (
-  <VerticalGutters>
-    <Form
-      headingText={headingText}
-      onSubmit={onSubmit}
-      submitButtonText={submitButtonText}
-      validation={validation}
-    >
-      <InputGroup>
-        <TextInput label={nameInputLabel} name="name" />
-        <PhoneInput label={phoneInputLabel} name="phone" />
-      </InputGroup>
-      <TextInput label={emailInputLabel} name="email" />
-      <InputGroup>
-        <DateRangePicker
-          endDatePlaceholderText={departureDateInputLabel}
-          name="dates"
-          startDatePlaceholderText={arrivalDateInputLabel}
-          width="eight"
-        />
-        <TextInput
-          label={guestsInputLabel}
-          name="guests"
-          type="number"
-          width="four"
-        />
-      </InputGroup>
-      <TextArea label={commentsInputLabel} name="comments" />
-      {(roomOptions || propertyOptions) && (
-        <InputGroup>
-          {propertyOptions && (
-            <Dropdown
-              label={propertyInputLabel}
-              name="property"
-              onChange={onChangeProperty}
-              options={propertyOptions}
-            />
-          )}
-          {roomOptions && (
-            <Dropdown
-              label={roomInputLabel}
-              name="room"
-              options={roomOptions}
-            />
-          )}
-        </InputGroup>
-      )}
-      <CaptchaInput
-        image={captchaInputImage}
-        label={captchaInputLabel}
-        name="captcha"
+  <Form
+    headingText={headingText}
+    onSubmit={onSubmit}
+    submitButtonText={submitButtonText}
+    validation={validation}
+  >
+    <InputGroup>
+      <TextInput label={nameInputLabel} name="name" />
+      <PhoneInput label={phoneInputLabel} name="phone" />
+    </InputGroup>
+    <TextInput label={emailInputLabel} name="email" />
+    <InputGroup>
+      <DateRangePicker
+        endDatePlaceholderText={departureDateInputLabel}
+        name="dates"
+        startDatePlaceholderText={arrivalDateInputLabel}
+        width="eight"
       />
-    </Form>
-  </VerticalGutters>
+      <TextInput
+        label={guestsInputLabel}
+        name="guests"
+        type="number"
+        width="four"
+      />
+    </InputGroup>
+    <TextArea label={commentsInputLabel} name="comments" />
+    {(roomOptions || propertyOptions) && (
+      <InputGroup>
+        {propertyOptions && (
+          <Dropdown
+            label={propertyInputLabel}
+            name="property"
+            onChange={onChangeProperty}
+            options={propertyOptions}
+          />
+        )}
+        {roomOptions && (
+          <Dropdown label={roomInputLabel} name="room" options={roomOptions} />
+        )}
+      </InputGroup>
+    )}
+    <CaptchaInput
+      image={captchaInputImage}
+      label={captchaInputLabel}
+      name="captcha"
+    />
+  </Form>
 );
 
 Component.displayName = 'Contact';

--- a/src/components/general-widgets/Contact/component.spec.js
+++ b/src/components/general-widgets/Contact/component.spec.js
@@ -29,7 +29,6 @@ import {
   SECURITY_CODE,
   SEND,
 } from 'utils/default-strings';
-import { VerticalGutters } from 'layout/VerticalGutters';
 
 import { roomOptions, propertyOptions } from './mock-data/options';
 import { Component as Contact } from './component';
@@ -41,18 +40,10 @@ const getContact = extraProps =>
 const getForm = extraProps => getContact(extraProps).find(Form);
 
 describe('<Contact />', () => {
-  it('should have `VerticalGutters` component as a wrapper', () => {
+  it('should have `Form` component as a wrapper', () => {
     const wrapper = getContact();
 
-    expectComponentToBe(wrapper, VerticalGutters);
-  });
-
-  describe('the `VerticalGutters` component', () => {
-    it('should have `Form` as its only children', () => {
-      const wrapper = getContact();
-
-      expectComponentToHaveChildren(wrapper, Form);
-    });
+    expectComponentToBe(wrapper, Form);
   });
 
   describe('the `Form` component', () => {

--- a/src/components/general-widgets/FeaturedProperties/component.js
+++ b/src/components/general-widgets/FeaturedProperties/component.js
@@ -6,32 +6,29 @@ import { GridColumn } from 'layout/GridColumn';
 import { Heading } from 'typography/Heading';
 import { FeaturedProperty } from 'general-widgets/FeaturedProperty';
 import { buildKeyFromStrings } from 'utils/build-key-from-strings';
-import { VerticalGutters } from 'layout/VerticalGutters';
 
 /**
  * The standard widget for displaying a list of featured properties.
  */
 // eslint-disable-next-line jsdoc/require-jsdoc
 export const Component = ({ featuredProperties, headingText }) => (
-  <VerticalGutters>
-    <Grid>
-      {headingText && (
-        <GridColumn width={12}>
-          <Heading>{headingText}</Heading>
-        </GridColumn>
-      )}
-      {featuredProperties.map((featuredProperty, index) => (
-        <GridColumn
-          computer={4}
-          key={buildKeyFromStrings(featuredProperty.propertyName, index)}
-          mobile={12}
-          tablet={6}
-        >
-          <FeaturedProperty {...featuredProperty} />
-        </GridColumn>
-      ))}
-    </Grid>
-  </VerticalGutters>
+  <Grid>
+    {headingText && (
+      <GridColumn width={12}>
+        <Heading>{headingText}</Heading>
+      </GridColumn>
+    )}
+    {featuredProperties.map((featuredProperty, index) => (
+      <GridColumn
+        computer={4}
+        key={buildKeyFromStrings(featuredProperty.propertyName, index)}
+        mobile={12}
+        tablet={6}
+      >
+        <FeaturedProperty {...featuredProperty} />
+      </GridColumn>
+    ))}
+  </Grid>
 );
 
 Component.displayName = 'FeaturedProperties';

--- a/src/components/general-widgets/FeaturedProperties/component.spec.js
+++ b/src/components/general-widgets/FeaturedProperties/component.spec.js
@@ -12,7 +12,6 @@ import { Grid } from 'layout/Grid';
 import { GridColumn } from 'layout/GridColumn';
 import { FeaturedProperty } from 'general-widgets/FeaturedProperty';
 import { Heading } from 'typography/Heading';
-import { VerticalGutters } from 'layout/VerticalGutters';
 
 import { Component as FeaturedProperties } from './component';
 
@@ -52,18 +51,10 @@ const getFeaturedProperties = otherProps =>
   );
 
 describe('<FeaturedProperties />', () => {
-  it('should have `VerticalGutters` component as a wrapper', () => {
+  it('should have `Grid` component as a wrapper', () => {
     const wrapper = getFeaturedProperties();
 
-    expectComponentToBe(wrapper, VerticalGutters);
-  });
-
-  describe('the `VerticalGutters` component', () => {
-    it('should have `Grid` as its only children', () => {
-      const wrapper = getFeaturedProperties();
-
-      expectComponentToHaveChildren(wrapper, Grid);
-    });
+    expectComponentToBe(wrapper, Grid);
   });
 
   describe('if `props.headingText` is not passed', () => {

--- a/src/components/general-widgets/FeaturedRoomTypes/component.js
+++ b/src/components/general-widgets/FeaturedRoomTypes/component.js
@@ -6,32 +6,29 @@ import { GridColumn } from 'layout/GridColumn';
 import { Heading } from 'typography/Heading';
 import { FeaturedRoomType } from 'general-widgets/FeaturedRoomType';
 import { buildKeyFromStrings } from 'utils/build-key-from-strings';
-import { VerticalGutters } from 'layout/VerticalGutters';
 
 /**
  * The standard widget for displaying a list of featured rooms.
  */
 // eslint-disable-next-line jsdoc/require-jsdoc
 export const Component = ({ featuredRoomTypes, headingText }) => (
-  <VerticalGutters>
-    <Grid>
-      {headingText && (
-        <GridColumn width={12}>
-          <Heading>{headingText}</Heading>
-        </GridColumn>
-      )}
-      {featuredRoomTypes.map((featuredRoomType, index) => (
-        <GridColumn
-          computer={4}
-          key={buildKeyFromStrings(featuredRoomType.roomTypeName, index)}
-          mobile={12}
-          tablet={6}
-        >
-          <FeaturedRoomType {...featuredRoomType} />
-        </GridColumn>
-      ))}
-    </Grid>
-  </VerticalGutters>
+  <Grid>
+    {headingText && (
+      <GridColumn width={12}>
+        <Heading>{headingText}</Heading>
+      </GridColumn>
+    )}
+    {featuredRoomTypes.map((featuredRoomType, index) => (
+      <GridColumn
+        computer={4}
+        key={buildKeyFromStrings(featuredRoomType.roomTypeName, index)}
+        mobile={12}
+        tablet={6}
+      >
+        <FeaturedRoomType {...featuredRoomType} />
+      </GridColumn>
+    ))}
+  </Grid>
 );
 
 Component.displayName = 'FeaturedRoomTypes';

--- a/src/components/general-widgets/FeaturedRoomTypes/component.spec.js
+++ b/src/components/general-widgets/FeaturedRoomTypes/component.spec.js
@@ -12,7 +12,6 @@ import { Grid } from 'layout/Grid';
 import { GridColumn } from 'layout/GridColumn';
 import { FeaturedRoomType } from 'general-widgets/FeaturedRoomType';
 import { Heading } from 'typography/Heading';
-import { VerticalGutters } from 'layout/VerticalGutters';
 
 import { Component as FeaturedRoomTypes } from './component';
 
@@ -47,18 +46,10 @@ const getFeaturedRoomTypes = otherProps =>
   );
 
 describe('<FeaturedRoomTypes />', () => {
-  it('should have `VerticalGutters` component as a wrapper', () => {
+  it('should have `Grid` component as a wrapper', () => {
     const wrapper = getFeaturedRoomTypes();
 
-    expectComponentToBe(wrapper, VerticalGutters);
-  });
-
-  describe('the `VerticalGutters` component', () => {
-    it('should have `Grid` as its only children', () => {
-      const wrapper = getFeaturedRoomTypes();
-
-      expectComponentToHaveChildren(wrapper, Grid);
-    });
+    expectComponentToBe(wrapper, Grid);
   });
 
   describe('if `props.headingText` is not passed', () => {

--- a/src/components/general-widgets/HTML/component.js
+++ b/src/components/general-widgets/HTML/component.js
@@ -2,8 +2,6 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import DOMPurify from 'dompurify';
 
-import { VerticalGutters } from 'layout/VerticalGutters';
-
 /**
  * The HTML widget sanitises and renders HTML strings.
  * @extends {React.PureComponent}
@@ -28,16 +26,12 @@ export class Component extends PureComponent {
     const { children } = this.props;
 
     return children ? (
-      <VerticalGutters>
-        <div>
-          <div dangerouslySetInnerHTML={{ __html: cleanHTMLString }} />
-          {children}
-        </div>
-      </VerticalGutters>
-    ) : (
-      <VerticalGutters>
+      <div>
         <div dangerouslySetInnerHTML={{ __html: cleanHTMLString }} />
-      </VerticalGutters>
+        {children}
+      </div>
+    ) : (
+      <div dangerouslySetInnerHTML={{ __html: cleanHTMLString }} />
     );
   }
 }

--- a/src/components/general-widgets/HTML/component.spec.js
+++ b/src/components/general-widgets/HTML/component.spec.js
@@ -7,8 +7,6 @@ import {
   expectComponentToHaveProps,
 } from '@lodgify/enzyme-jest-expect-helpers';
 
-import { VerticalGutters } from 'layout/VerticalGutters';
-
 import { Component as HTML } from './component';
 
 const { headings } = require('./mock-data/examples');
@@ -16,32 +14,17 @@ const { headings } = require('./mock-data/examples');
 const getHTMLWidget = props => shallow(<HTML {...props} />);
 
 describe('<HTML />', () => {
-  it('should have `VerticalGutters` component as a wrapper', () => {
+  it('should have `div` component as a wrapper', () => {
     const wrapper = getHTMLWidget();
 
-    expectComponentToBe(wrapper, VerticalGutters);
-  });
-  describe('the `VerticalGutters` component', () => {
-    it('should have `div` as its only children', () => {
-      const wrapper = getHTMLWidget();
-
-      expectComponentToHaveChildren(wrapper, 'div');
-    });
+    expectComponentToBe(wrapper, 'div');
   });
 
   describe('if `props.children` is passed', () => {
-    it('should have `VerticalGutters` component as a wrapper', () => {
+    it('should have `div` component as a wrapper', () => {
       const wrapper = getHTMLWidget();
 
-      expectComponentToBe(wrapper, VerticalGutters);
-    });
-
-    describe('the `VerticalGutters` component', () => {
-      it('should have `div` as its only children', () => {
-        const wrapper = getHTMLWidget();
-
-        expectComponentToHaveChildren(wrapper, 'div');
-      });
+      expectComponentToBe(wrapper, 'div');
     });
 
     describe('the `div` element', () => {
@@ -62,7 +45,7 @@ describe('<HTML />', () => {
           htmlString: headings,
         })
           .children('div')
-          .childAt(0);
+          .at(0);
 
         expectComponentToHaveProps(wrapper, {
           dangerouslySetInnerHTML: expect.objectContaining({
@@ -74,22 +57,14 @@ describe('<HTML />', () => {
   });
 
   describe('if `props.children` is not passed', () => {
-    it('should have `VerticalGutters` as a wrapper`', () => {
+    it('should have `div` as a wrapper`', () => {
       const wrapper = getHTMLWidget({ headings });
 
-      expectComponentToBe(wrapper, VerticalGutters);
-    });
-
-    describe('the `VerticalGutters` component', () => {
-      it('should have `div` as its only child', () => {
-        const wrapper = getHTMLWidget({ headings });
-
-        expectComponentToHaveChildren(wrapper, 'div');
-      });
+      expectComponentToBe(wrapper, 'div');
     });
     describe('the `div` element', () => {
       it('should have the right props', () => {
-        const wrapper = getHTMLWidget({ headings }).children();
+        const wrapper = getHTMLWidget({ headings });
 
         expectComponentToHaveProps(wrapper, {
           dangerouslySetInnerHTML: expect.objectContaining({

--- a/src/components/general-widgets/OwnerLogin/component.js
+++ b/src/components/general-widgets/OwnerLogin/component.js
@@ -11,7 +11,6 @@ import {
   SEND_RESET,
   LOGIN,
 } from 'utils/default-strings';
-import { VerticalGutters } from 'layout/VerticalGutters';
 
 import { getForgotPasswordFormMarkup } from './utils/getForgotPasswordFormMarkup';
 
@@ -33,27 +32,25 @@ export const Component = ({
   passwordInputLabel,
   validation,
 }) => (
-  <VerticalGutters>
-    <Form
-      actionLink={{
-        text: getForgotPasswordFormMarkup(
-          onForgotPasswordSubmit,
-          forgotPasswordSubmitButtonText,
-          forgotPasswordEmailInputLabel,
-          forgotPasswordHeadingText,
-          forgotPasswordModalTriggerText,
-          forgotPasswordValidation
-        ),
-      }}
-      headingText={headingText}
-      onSubmit={onSubmit}
-      submitButtonText={submitButtonText}
-      validation={validation}
-    >
-      <TextInput label={emailInputLabel} name="email" />
-      <TextInput label={passwordInputLabel} name="password" type="password" />
-    </Form>
-  </VerticalGutters>
+  <Form
+    actionLink={{
+      text: getForgotPasswordFormMarkup(
+        onForgotPasswordSubmit,
+        forgotPasswordSubmitButtonText,
+        forgotPasswordEmailInputLabel,
+        forgotPasswordHeadingText,
+        forgotPasswordModalTriggerText,
+        forgotPasswordValidation
+      ),
+    }}
+    headingText={headingText}
+    onSubmit={onSubmit}
+    submitButtonText={submitButtonText}
+    validation={validation}
+  >
+    <TextInput label={emailInputLabel} name="email" />
+    <TextInput label={passwordInputLabel} name="password" type="password" />
+  </Form>
 );
 
 Component.displayName = 'OwnerLogin';

--- a/src/components/general-widgets/OwnerLogin/component.spec.js
+++ b/src/components/general-widgets/OwnerLogin/component.spec.js
@@ -10,24 +10,16 @@ import {
 import { EMAIL, OWNER_LOGIN, PASSWORD, LOGIN } from 'utils/default-strings';
 import { Form } from 'collections/Form';
 import { TextInput } from 'inputs/TextInput';
-import { VerticalGutters } from 'layout/VerticalGutters';
 
 import { Component as OwnerLogin } from './component';
 
 const getOwnerLogin = () => shallow(<OwnerLogin />);
 
 describe('<OwnerLogin />', () => {
-  it('should have `VerticalGutters` component as a wrapper', () => {
+  it('should have `Form` component as a wrapper', () => {
     const wrapper = getOwnerLogin();
 
-    expectComponentToBe(wrapper, VerticalGutters);
-  });
-  describe('the `VerticalGutters` component', () => {
-    it('should have `Form` as its only children', () => {
-      const wrapper = getOwnerLogin();
-
-      expectComponentToHaveChildren(wrapper, Form);
-    });
+    expectComponentToBe(wrapper, Form);
   });
 
   describe('the `Form` component', () => {

--- a/src/components/general-widgets/OwnerSignUp/component.js
+++ b/src/components/general-widgets/OwnerSignUp/component.js
@@ -10,7 +10,6 @@ import {
 } from 'utils/default-strings';
 import { Form } from 'collections/Form';
 import { TextInput } from 'inputs/TextInput';
-import { VerticalGutters } from 'layout/VerticalGutters';
 
 /**
  * The standard widget for owner sign up.
@@ -25,18 +24,16 @@ export const Component = ({
   submitButtonText,
   validation,
 }) => (
-  <VerticalGutters>
-    <Form
-      headingText={headingText}
-      onSubmit={onSubmit}
-      submitButtonText={submitButtonText}
-      validation={validation}
-    >
-      <TextInput label={firstNameInputLabel} name="firstName" />
-      <TextInput label={lastNameInputLabel} name="lastName" />
-      <TextInput label={emailInputLabel} name="email" />
-    </Form>
-  </VerticalGutters>
+  <Form
+    headingText={headingText}
+    onSubmit={onSubmit}
+    submitButtonText={submitButtonText}
+    validation={validation}
+  >
+    <TextInput label={firstNameInputLabel} name="firstName" />
+    <TextInput label={lastNameInputLabel} name="lastName" />
+    <TextInput label={emailInputLabel} name="email" />
+  </Form>
 );
 
 Component.displayName = 'OwnerSignUp';

--- a/src/components/general-widgets/OwnerSignUp/component.spec.js
+++ b/src/components/general-widgets/OwnerSignUp/component.spec.js
@@ -16,7 +16,6 @@ import {
 } from 'utils/default-strings';
 import { Form } from 'collections/Form';
 import { TextInput } from 'inputs/TextInput';
-import { VerticalGutters } from 'layout/VerticalGutters';
 
 import { getArrayOfLengthOfItem } from '../../../utils/get-array-of-length-of-item';
 
@@ -25,17 +24,10 @@ import { Component as OwnerSignUp } from './component';
 const getOwnerSignUp = () => shallow(<OwnerSignUp />);
 
 describe('<OwnerSignUp />', () => {
-  it('should have `VerticalGutters` component as a wrapper', () => {
+  it('should have `Form` component as a wrapper', () => {
     const wrapper = getOwnerSignUp();
 
-    expectComponentToBe(wrapper, VerticalGutters);
-  });
-  describe('the `VerticalGutters` component', () => {
-    it('should have `Form` as its only children', () => {
-      const wrapper = getOwnerSignUp();
-
-      expectComponentToHaveChildren(wrapper, Form);
-    });
+    expectComponentToBe(wrapper, Form);
   });
 
   describe('the `Form` component', () => {

--- a/src/components/general-widgets/Promotion/component.js
+++ b/src/components/general-widgets/Promotion/component.js
@@ -14,7 +14,6 @@ import { GridRow } from 'layout/GridRow';
 import { Heading } from 'typography/Heading';
 import { Paragraph } from 'typography/Paragraph';
 import { Button } from 'elements/Button';
-import { VerticalGutters } from 'layout/VerticalGutters';
 
 /**
  * The Promotion component, used to display a discount code along with a discount amount
@@ -31,73 +30,69 @@ export const Component = ({
   isDisplayedStacked,
   onClick,
 }) => (
-  <VerticalGutters>
-    <Segment
-      basic
-      className={getClassNames('is-promotion', {
-        'display-stacked': isDisplayedStacked,
-      })}
-      onClick={onClick}
-    >
-      <Grid className="first-grid" stackable stretched>
-        <GridRow verticalAlign="middle">
-          <GridColumn
-            className="content-section"
-            style={{ backgroundImage: `url(${backgroundImage})` }}
-            width={isDisplayedStacked ? 12 : 9}
-          >
-            <Grid padded>
-              <GridRow verticalAlign="top">
-                <GridColumn textAlign={isDisplayedStacked ? 'center' : 'left'}>
-                  <Heading>{headingText}</Heading>
+  <Segment
+    basic
+    className={getClassNames('is-promotion', {
+      'display-stacked': isDisplayedStacked,
+    })}
+    onClick={onClick}
+  >
+    <Grid className="first-grid" stackable stretched>
+      <GridRow verticalAlign="middle">
+        <GridColumn
+          className="content-section"
+          style={{ backgroundImage: `url(${backgroundImage})` }}
+          width={isDisplayedStacked ? 12 : 9}
+        >
+          <Grid padded>
+            <GridRow verticalAlign="top">
+              <GridColumn textAlign={isDisplayedStacked ? 'center' : 'left'}>
+                <Heading>{headingText}</Heading>
+              </GridColumn>
+            </GridRow>
+            {!isDisplayedStacked && (
+              <GridRow className="book-now-button-container">
+                <GridColumn textAlign="center">
+                  <Button isRounded>{discountHoverButtonText}</Button>
                 </GridColumn>
               </GridRow>
-              {!isDisplayedStacked && (
-                <GridRow className="book-now-button-container">
-                  <GridColumn textAlign="center">
-                    <Button isRounded>{discountHoverButtonText}</Button>
-                  </GridColumn>
-                </GridRow>
-              )}
-              <GridRow verticalAlign={isDisplayedStacked ? 'top' : 'bottom'}>
-                <GridColumn
-                  floated="right"
-                  textAlign={isDisplayedStacked ? 'center' : 'right'}
-                  width={isDisplayedStacked ? 12 : 6}
-                >
-                  <div>
-                    <Paragraph size="tiny">
-                      {discountCodeParagraphText}
-                    </Paragraph>
-                    <Button hasShadow isPositionedRight>
-                      {discountCode}
-                    </Button>
-                  </div>
-                </GridColumn>
-              </GridRow>
-            </Grid>
-          </GridColumn>
-          <GridColumn
-            className="discount-section"
-            textAlign="center"
-            verticalAlign="middle"
-            width={isDisplayedStacked ? 12 : 3}
-          >
-            <Statistic size="small">
-              <Statistic.Label>
-                <Paragraph weight="heavy">
-                  {discountAmountParagraphText}
-                </Paragraph>
-              </Statistic.Label>
-              <Statistic.Value>
-                <Heading size="large">{discountAmount}</Heading>
-              </Statistic.Value>
-            </Statistic>
-          </GridColumn>
-        </GridRow>
-      </Grid>
-    </Segment>
-  </VerticalGutters>
+            )}
+            <GridRow verticalAlign={isDisplayedStacked ? 'top' : 'bottom'}>
+              <GridColumn
+                floated="right"
+                textAlign={isDisplayedStacked ? 'center' : 'right'}
+                width={isDisplayedStacked ? 12 : 6}
+              >
+                <div>
+                  <Paragraph size="tiny">{discountCodeParagraphText}</Paragraph>
+                  <Button hasShadow isPositionedRight>
+                    {discountCode}
+                  </Button>
+                </div>
+              </GridColumn>
+            </GridRow>
+          </Grid>
+        </GridColumn>
+        <GridColumn
+          className="discount-section"
+          textAlign="center"
+          verticalAlign="middle"
+          width={isDisplayedStacked ? 12 : 3}
+        >
+          <Statistic size="small">
+            <Statistic.Label>
+              <Paragraph weight="heavy">
+                {discountAmountParagraphText}
+              </Paragraph>
+            </Statistic.Label>
+            <Statistic.Value>
+              <Heading size="large">{discountAmount}</Heading>
+            </Statistic.Value>
+          </Statistic>
+        </GridColumn>
+      </GridRow>
+    </Grid>
+  </Segment>
 );
 
 Component.displayName = 'Promotion';

--- a/src/components/general-widgets/Promotion/component.spec.js
+++ b/src/components/general-widgets/Promotion/component.spec.js
@@ -14,7 +14,6 @@ import { Paragraph } from 'typography/Paragraph';
 import { Grid } from 'layout/Grid';
 import { GridRow } from 'layout/GridRow';
 import { GridColumn } from 'layout/GridColumn';
-import { VerticalGutters } from 'layout/VerticalGutters';
 
 import { Component as Promotion } from './component';
 
@@ -32,17 +31,10 @@ const getPromotionAsStacked = () =>
   shallow(<Promotion {...componentProps} isDisplayedStacked />);
 
 describe('The `Promotion` component', () => {
-  it('should have `VerticalGutters` component as a wrapper', () => {
+  it('should have `Segment` component as a wrapper', () => {
     const wrapper = getPromotion();
 
-    expectComponentToBe(wrapper, VerticalGutters);
-  });
-  describe('the `VerticalGutters` component', () => {
-    it('should have `Segment` as its only children', () => {
-      const wrapper = getPromotion();
-
-      expectComponentToHaveChildren(wrapper, Segment);
-    });
+    expectComponentToBe(wrapper, Segment);
   });
 
   describe('the `Segment`', () => {

--- a/src/components/media/ResponsiveImage/component.js
+++ b/src/components/media/ResponsiveImage/component.js
@@ -10,7 +10,6 @@ import {
 } from 'utils/default-strings';
 import { buildKeyFromStrings } from 'utils/build-key-from-strings';
 import { Paragraph } from 'typography/Paragraph';
-import { VerticalGutters } from 'layout/VerticalGutters';
 
 /**
  * The standard widget for displaying an image.
@@ -28,29 +27,27 @@ export const Component = ({
   onLoad,
   sources,
 }) => (
-  <VerticalGutters>
-    <picture role="figure">
-      {sources.map(({ srcset, media }, index) => (
-        <source
-          key={buildKeyFromStrings(srcset, index)}
-          media={media}
-          srcSet={srcset}
-        />
-      ))}
-      <Image
-        alt={alternativeText}
-        avatar={isAvatar}
-        className={cx(className)}
-        fluid={isFluid}
-        onLoad={onLoad}
-        src={imageUrl}
-        title={imageTitle}
-      >
-        {!imageUrl ? <Label content={imageNotFoundLabelText} /> : null}
-      </Image>
-      {label ? <Paragraph>{label}</Paragraph> : null}
-    </picture>
-  </VerticalGutters>
+  <picture role="figure">
+    {sources.map(({ srcset, media }, index) => (
+      <source
+        key={buildKeyFromStrings(srcset, index)}
+        media={media}
+        srcSet={srcset}
+      />
+    ))}
+    <Image
+      alt={alternativeText}
+      avatar={isAvatar}
+      className={cx(className)}
+      fluid={isFluid}
+      onLoad={onLoad}
+      src={imageUrl}
+      title={imageTitle}
+    >
+      {!imageUrl ? <Label content={imageNotFoundLabelText} /> : null}
+    </Image>
+    {label ? <Paragraph>{label}</Paragraph> : null}
+  </picture>
 );
 
 Component.displayName = 'ResponsiveImage';

--- a/src/components/media/ResponsiveImage/component.spec.js
+++ b/src/components/media/ResponsiveImage/component.spec.js
@@ -2,11 +2,9 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { Image as SemanticImage, Label } from 'semantic-ui-react';
 import { expectComponentToBe } from '@lodgify/enzyme-jest-expect-helpers';
-import { expectComponentToHaveChildren } from '@lodgify/enzyme-jest-expect-helpers/lib/expectComponentToHaveChildren';
 
 import { Paragraph } from 'typography/Paragraph';
 import { IMAGE_NOT_FOUND } from 'utils/default-strings';
-import { VerticalGutters } from 'layout/VerticalGutters';
 
 import { expectComponentToHaveProps } from '../../../../node_modules/@lodgify/enzyme-jest-expect-helpers/lib/expectComponentToHaveProps';
 
@@ -15,18 +13,10 @@ import { Component as ResponsiveImage } from './component';
 const getResponsiveImage = props => shallow(<ResponsiveImage {...props} />);
 
 describe('<ResponsiveImage />', () => {
-  it('should have `VerticalGutters` component as a wrapper', () => {
+  it('should have `picture` component as a wrapper', () => {
     const wrapper = getResponsiveImage();
 
-    expectComponentToBe(wrapper, VerticalGutters);
-  });
-
-  describe('the `VerticalGutters` component', () => {
-    it('should have `picture` as its only children', () => {
-      const wrapper = getResponsiveImage();
-
-      expectComponentToHaveChildren(wrapper, 'picture');
-    });
+    expectComponentToBe(wrapper, 'picture');
   });
 
   describe('the `ResponsiveImage` component', () => {

--- a/src/components/property-page-widgets/Amenities/Readme.md
+++ b/src/components/property-page-widgets/Amenities/Readme.md
@@ -242,29 +242,3 @@ const amenities = [
 <Amenities hasExtraItemsInModal amenities={amenities} headingText="Property Amenities" />
 
 ```
-
-#### Without vertical padding
-
-```jsx
-const amenities = [
-  {
-    name: 'Cooking',
-    iconName: 'coffee',
-    items: ['Toaster', 'Microwave', 'Coffee Machine'],
-  },
-  {
-    name: 'Bathroom',
-    iconName: 'bathroom',
-    items: ['Bidet', 'Hair Dryer'],
-  },
-  {
-    name: 'Outside',
-    iconName: 'sun',
-    items: ['Tennis Court'],
-  }
-];
-
-
-<Amenities hasVerticalGutters={false} amenities={amenities} headingText="Property Amenities" />
-
-```

--- a/src/components/property-page-widgets/Amenities/component.js
+++ b/src/components/property-page-widgets/Amenities/component.js
@@ -2,9 +2,15 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { VIEW_MORE } from 'utils/default-strings';
-import { VerticalGutters } from 'layout/VerticalGutters';
+import { Grid } from 'layout/Grid';
+import { GridRow } from 'layout/GridRow';
+import { GridColumn } from 'layout/GridColumn';
+import { Heading } from 'typography/Heading';
 
-import { getAmenityMarkup } from './utils/getAmenityMarkup';
+import { getDefaultItems } from './utils/getDefaultItems';
+import { hasExtraItems } from './utils/hasExtraItems';
+import { getCategoryMarkup } from './utils/getCategoryMarkup';
+import { getExtraItemsMarkup } from './utils/getExtraItemsMarkup';
 
 /**
  * The standard widget for displaying the amenities of a property.
@@ -13,37 +19,36 @@ import { getAmenityMarkup } from './utils/getAmenityMarkup';
 export const Component = ({
   amenities,
   hasExtraItemsInModal,
-  hasVerticalGutters,
   headingText,
   isStacked,
   modalTriggerText,
-}) =>
-  hasVerticalGutters ? (
-    <VerticalGutters>
-      {getAmenityMarkup(
-        amenities,
-        hasExtraItemsInModal,
-        headingText,
-        isStacked,
-        modalTriggerText
+}) => (
+  <Grid className="is-amenities" columns={isStacked ? 1 : 3}>
+    <GridRow>
+      {headingText && (
+        <GridColumn width={12}>
+          <Heading>{headingText}</Heading>
+        </GridColumn>
       )}
-    </VerticalGutters>
-  ) : (
-    getAmenityMarkup(
-      amenities,
-      hasExtraItemsInModal,
-      headingText,
-      isStacked,
-      modalTriggerText
-    )
-  );
+      {getDefaultItems(amenities, isStacked).map((amenity, index) =>
+        getCategoryMarkup(amenity, index, isStacked)
+      )}
+      {hasExtraItems(amenities, isStacked) &&
+        getExtraItemsMarkup(
+          hasExtraItemsInModal,
+          modalTriggerText,
+          amenities,
+          isStacked
+        )}
+    </GridRow>
+  </Grid>
+);
 
 Component.displayName = 'Amenities';
 
 Component.defaultProps = {
   hasExtraItemsInModal: false,
   headingText: null,
-  hasVerticalGutters: true,
   isStacked: false,
   modalTriggerText: VIEW_MORE,
 };
@@ -64,8 +69,6 @@ Component.propTypes = {
   ).isRequired,
   /** Are the extra items displayed in a modal. */
   hasExtraItemsInModal: PropTypes.bool,
-  /** Does the component have vertical gutters */
-  hasVerticalGutters: PropTypes.bool,
   /** The text to display as a heading at the top of the amenities. */
   headingText: PropTypes.string,
   /** Are the amenities displayed stacked on top of one another */

--- a/src/components/property-page-widgets/Amenities/component.spec.js
+++ b/src/components/property-page-widgets/Amenities/component.spec.js
@@ -1,14 +1,22 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import { Modal as SemanticModal } from 'semantic-ui-react';
 import {
   expectComponentToBe,
   expectComponentToHaveChildren,
+  expectComponentToHaveProps,
 } from '@lodgify/enzyme-jest-expect-helpers';
 
+import { getArrayOfLengthOfItem } from 'utils/get-array-of-length-of-item';
+import { VIEW_MORE } from 'utils/default-strings';
 import { Grid } from 'layout/Grid';
-import { VerticalGutters } from 'layout/VerticalGutters';
+import { GridRow } from 'layout/GridRow';
+import { GridColumn } from 'layout/GridColumn';
+import { Heading } from 'typography/Heading';
+import { Link } from 'elements/Link';
+import { Modal } from 'elements/Modal';
 
-import { twoAmenities } from './mock-data/amenities';
+import { twoAmenities, sixAmenities } from './mock-data/amenities';
 import { Component as Amenities } from './component';
 
 const getAmenities = (props = {}) =>
@@ -16,32 +24,193 @@ const getAmenities = (props = {}) =>
     <Amenities
       amenities={props.amenities || twoAmenities}
       hasExtraItemsInModal
-      isStacked
+      isStacked={
+        typeof props.isStacked !== 'undefined' ? props.isStacked : true
+      }
       isUserOnMobile
       {...props}
     />
   );
 
 describe('<Amenities />', () => {
-  it('should have `VerticalGutters` component as a wrapper', () => {
+  it('should have `Grid` component as a wrapper', () => {
     const wrapper = getAmenities();
-
-    expectComponentToBe(wrapper, VerticalGutters);
-  });
-
-  it('should not have `VerticalGutters` component as a wrapper', () => {
-    const wrapper = getAmenities({
-      hasVerticalGutters: false,
-    });
 
     expectComponentToBe(wrapper, Grid);
   });
+});
 
-  describe('the `VerticalGutters` component', () => {
-    it('should have `Grid` as its only children', () => {
-      const wrapper = getAmenities();
+describe('getAmenityMarkup', () => {
+  describe('the `Grid` component', () => {
+    const getGrid = () => getAmenities().find(Grid);
 
-      expectComponentToHaveChildren(wrapper, Grid);
+    it('should render the right children', () => {
+      const wrapper = getGrid();
+
+      expectComponentToHaveChildren(wrapper, GridRow);
+    });
+
+    it('should have the right props', () => {
+      const wrapper = getGrid();
+
+      expectComponentToHaveProps(wrapper, {
+        className: 'is-amenities',
+        columns: 1,
+      });
+    });
+
+    describe('the `Grid` component where isStacked is false', () => {
+      it('should have the right props', () => {
+        const wrapper = getAmenities({
+          isStacked: false,
+        }).find(Grid);
+
+        expectComponentToHaveProps(wrapper, {
+          className: 'is-amenities',
+          columns: 3,
+        });
+      });
+    });
+  });
+
+  describe('the first `GridColumn` component', () => {
+    const getFirstGridColumn = () =>
+      getAmenities({
+        headingText: 'Hello world',
+      })
+        .find(GridColumn)
+        .first();
+
+    it('should have the right right props', () => {
+      const wrapper = getFirstGridColumn();
+
+      expectComponentToHaveProps(wrapper, { width: 12 });
+    });
+
+    it('should render the right children', () => {
+      const wrapper = getFirstGridColumn();
+
+      expectComponentToHaveChildren(wrapper, Heading);
+    });
+  });
+
+  describe('the `Heading` component', () => {
+    it('should render the right children', () => {
+      const wrapper = getAmenities({
+        headingText: 'Property Amenities',
+      }).find(Heading);
+
+      expectComponentToHaveChildren(wrapper, 'Property Amenities');
+    });
+  });
+
+  describe('if `hasExtraItems` returns true', () => {
+    const getAmenitiesWithSixCategories = () =>
+      getAmenities({ amenities: sixAmenities });
+
+    describe('the `Grid` component', () => {
+      it('should render the right children', () => {
+        const wrapper = getAmenitiesWithSixCategories()
+          .find(Grid)
+          .first();
+
+        expectComponentToHaveChildren(wrapper, GridRow);
+      });
+    });
+
+    describe('the `GridRow` component', () => {
+      it('should render the right children', () => {
+        const wrapper = getAmenitiesWithSixCategories()
+          .find(GridRow)
+          .first();
+
+        expectComponentToHaveChildren(
+          wrapper,
+          ...getArrayOfLengthOfItem(4, GridColumn)
+        );
+      });
+    });
+
+    describe('the last child `GridColumn` of `Grid`', () => {
+      const getLastGridColumn = () =>
+        getAmenitiesWithSixCategories()
+          .find(GridColumn)
+          .at(3);
+
+      it('should have the right props', () => {
+        const wrapper = getLastGridColumn();
+
+        expectComponentToHaveProps(wrapper, { width: 12 });
+      });
+
+      it('should render the right children', () => {
+        const wrapper = getLastGridColumn();
+
+        expectComponentToHaveChildren(wrapper, Modal);
+      });
+    });
+
+    describe('the `Modal`', () => {
+      const getModal = () => getAmenitiesWithSixCategories().find(Modal);
+
+      it('should have the right props', () => {
+        const wrapper = getModal();
+
+        expectComponentToHaveProps(wrapper, {
+          trigger: <Link>{VIEW_MORE}</Link>,
+        });
+      });
+
+      it('should have the right children', () => {
+        const wrapper = getModal();
+
+        expectComponentToHaveChildren(wrapper, SemanticModal.Content);
+      });
+    });
+
+    describe('the `SemanticModal.Content`', () => {
+      it('should have the right children', () => {
+        const wrapper = getAmenitiesWithSixCategories().find(
+          SemanticModal.Content
+        );
+
+        expectComponentToHaveChildren(wrapper, Grid);
+      });
+    });
+
+    describe('the `Grid` child of `SemanticModal.Content`', () => {
+      const getSecondGrid = () =>
+        getAmenitiesWithSixCategories()
+          .find(Grid)
+          .at(1);
+
+      it('should have the right props', () => {
+        const wrapper = getSecondGrid();
+
+        expectComponentToHaveProps(wrapper, { padded: true, stackable: true });
+      });
+
+      it('should render the right children', () => {
+        const wrapper = getSecondGrid();
+
+        expectComponentToHaveChildren(wrapper, GridRow);
+      });
+    });
+
+    describe('the second GridRow', () => {
+      const getSecondGrid = () =>
+        getAmenitiesWithSixCategories()
+          .find(GridRow)
+          .at(1);
+
+      it('should render the right children', () => {
+        const wrapper = getSecondGrid();
+
+        expectComponentToHaveChildren(
+          wrapper,
+          ...getArrayOfLengthOfItem(5, GridColumn)
+        );
+      });
     });
   });
 });

--- a/src/components/property-page-widgets/Availability/component.js
+++ b/src/components/property-page-widgets/Availability/component.js
@@ -14,7 +14,6 @@ import { GridColumn } from 'layout/GridColumn';
 import { withResponsive } from 'utils/with-responsive';
 import { Icon, ICON_NAMES } from 'elements/Icon';
 import { Dropdown } from 'inputs/Dropdown';
-import { VerticalGutters } from 'layout/VerticalGutters';
 
 import { getMonthsToDisplay } from './utils/getMonthsToDisplay';
 import { getNextStartDate } from './utils/getNextStartDate';
@@ -71,108 +70,106 @@ class Component extends PureComponent {
     const { isUserOnMobile, roomOptionsWithImages } = this.props;
 
     return (
-      <VerticalGutters>
-        <div>
-          <Heading size="small">Availability</Heading>
-          <Grid>
+      <div>
+        <Heading size="small">Availability</Heading>
+        <Grid>
+          <GridRow>
+            <GridColumn
+              computer={7}
+              mobile={12}
+              tablet={6}
+              verticalAlignContent="middle"
+            >
+              <Grid>
+                <GridColumn
+                  computer={5}
+                  mobile={5}
+                  tablet={12}
+                  verticalAlignContent="middle"
+                >
+                  <Paragraph size="tiny" weight="heavy">
+                    View Availability For:
+                  </Paragraph>
+                </GridColumn>
+                <GridColumn computer={7} mobile={7} tablet={12}>
+                  <Dropdown
+                    icon={ICON_NAMES.MAP_PIN}
+                    label="Properties"
+                    onChange={this.reloadCalendarOnRoomSelection}
+                    options={roomOptionsWithImages}
+                  />
+                </GridColumn>
+              </Grid>
+            </GridColumn>
+            <GridColumn
+              only="tablet computer"
+              textAlign="right"
+              verticalAlignContent="middle"
+              width={5}
+            >
+              <Icon
+                color="light grey"
+                isLabelLeft
+                labelText="Unavailable"
+                name={ICON_NAMES.SQUARE}
+              />
+            </GridColumn>
+          </GridRow>
+        </Grid>
+        <Card fluid>
+          <Grid padded>
             <GridRow>
-              <GridColumn
-                computer={7}
-                mobile={12}
-                tablet={6}
-                verticalAlignContent="middle"
-              >
-                <Grid>
+              {getMonthsToDisplay(startDate, isUserOnMobile).map(
+                (month, index) => (
                   <GridColumn
-                    computer={5}
-                    mobile={5}
-                    tablet={12}
-                    verticalAlignContent="middle"
+                    className="availability-calendar-wrapper"
+                    computer={6}
+                    key={buildKeyFromStrings('month-column', index)}
+                    mobile={12}
+                    tablet={6}
                   >
-                    <Paragraph size="tiny" weight="heavy">
-                      View Availability For:
-                    </Paragraph>
-                  </GridColumn>
-                  <GridColumn computer={7} mobile={7} tablet={12}>
-                    <Dropdown
-                      icon={ICON_NAMES.MAP_PIN}
-                      label="Properties"
-                      onChange={this.reloadCalendarOnRoomSelection}
-                      options={roomOptionsWithImages}
+                    <CalendarMonth
+                      isVisible
+                      month={month}
+                      renderCalendarDay={this.renderCalendarDay}
+                      renderMonthElement={renderMonthHeader}
                     />
                   </GridColumn>
-                </Grid>
-              </GridColumn>
-              <GridColumn
-                only="tablet computer"
-                textAlign="right"
-                verticalAlignContent="middle"
-                width={5}
-              >
+                )
+              )}
+            </GridRow>
+            <GridRow>
+              <GridColumn width={6}>
                 <Icon
-                  color="light grey"
+                  labelText="Previous"
+                  name={ICON_NAMES.ARROW_LEFT}
+                  onClick={this.handleClickPreviousMonth}
+                />
+              </GridColumn>
+              <GridColumn textAlign="right" width={6}>
+                <Icon
                   isLabelLeft
-                  labelText="Unavailable"
-                  name={ICON_NAMES.SQUARE}
+                  labelText="Next"
+                  name={ICON_NAMES.ARROW_RIGHT}
+                  onClick={this.handleClickNextMonth}
                 />
               </GridColumn>
             </GridRow>
           </Grid>
-          <Card fluid>
-            <Grid padded>
-              <GridRow>
-                {getMonthsToDisplay(startDate, isUserOnMobile).map(
-                  (month, index) => (
-                    <GridColumn
-                      className="availability-calendar-wrapper"
-                      computer={6}
-                      key={buildKeyFromStrings('month-column', index)}
-                      mobile={12}
-                      tablet={6}
-                    >
-                      <CalendarMonth
-                        isVisible
-                        month={month}
-                        renderCalendarDay={this.renderCalendarDay}
-                        renderMonthElement={renderMonthHeader}
-                      />
-                    </GridColumn>
-                  )
-                )}
-              </GridRow>
-              <GridRow>
-                <GridColumn width={6}>
-                  <Icon
-                    labelText="Previous"
-                    name={ICON_NAMES.ARROW_LEFT}
-                    onClick={this.handleClickPreviousMonth}
-                  />
-                </GridColumn>
-                <GridColumn textAlign="right" width={6}>
-                  <Icon
-                    isLabelLeft
-                    labelText="Next"
-                    name={ICON_NAMES.ARROW_RIGHT}
-                    onClick={this.handleClickNextMonth}
-                  />
-                </GridColumn>
-              </GridRow>
-            </Grid>
-          </Card>
-          <Grid>
-            <GridColumn only="mobile" textAlign="right">
-              <GridColumn>
-                <Icon
-                  color="grey"
-                  isLabelLeft
-                  labelText="Unavailable"
-                  name={ICON_NAMES.SQUARE}
-                />
-              </GridColumn>
+        </Card>
+        <Grid>
+          <GridColumn only="mobile" textAlign="right">
+            <GridColumn>
+              <Icon
+                color="grey"
+                isLabelLeft
+                labelText="Unavailable"
+                name={ICON_NAMES.SQUARE}
+              />
             </GridColumn>
-          </Grid>
-        </div>
-      </VerticalGutters>
+          </GridColumn>
+        </Grid>
+      </div>
     );
   }
 }

--- a/src/components/property-page-widgets/Availability/component.spec.js
+++ b/src/components/property-page-widgets/Availability/component.spec.js
@@ -16,7 +16,6 @@ import { GridRow } from 'layout/GridRow';
 import { GridColumn } from 'layout/GridColumn';
 import { Icon } from 'elements/Icon';
 import { Dropdown } from 'inputs/Dropdown';
-import { VerticalGutters } from 'layout/VerticalGutters';
 
 import { ComponentWithResponsive as Availability } from './component';
 
@@ -40,18 +39,10 @@ describe('<Availability />', () => {
   });
 
   describe('the `Child` of the `Availability` component', () => {
-    it('should have `VerticalGutters` component as a wrapper', () => {
+    it('should have `div` component as a wrapper', () => {
       const wrapper = getWrappedAvailability();
 
-      expectComponentToBe(wrapper, VerticalGutters);
-    });
-  });
-
-  describe('the `VerticalGutters` component', () => {
-    it('should have `div` as its only children', () => {
-      const wrapper = getWrappedAvailability();
-
-      expectComponentToHaveChildren(wrapper, 'div');
+      expectComponentToBe(wrapper, 'div');
     });
   });
 

--- a/src/components/property-page-widgets/Description/component.js
+++ b/src/components/property-page-widgets/Description/component.js
@@ -12,7 +12,6 @@ import { Heading } from 'typography/Heading';
 import { Icon } from 'elements/Icon';
 import { Paragraph } from 'typography/Paragraph';
 import { Subheading } from 'typography/Subheading';
-import { VerticalGutters } from 'layout/VerticalGutters';
 import { ShowOnDesktop } from 'layout/ShowOnDesktop';
 import { ShowOnMobile } from 'layout/ShowOnMobile';
 
@@ -32,70 +31,68 @@ export const Component = ({
   propertyName,
   propertyType,
 }) => (
-  <VerticalGutters>
-    <Grid columns={1}>
-      <GridColumn>
-        <Subheading>{propertyType}</Subheading>
-        <Heading size="large">{propertyName}</Heading>
-      </GridColumn>
-      <GridColumn>
-        <ShowOnDesktop parent={List} parentProps={{ horizontal: true }}>
-          {getFirstFourItems(propertyMainCharacteristics).map(
-            ({ iconName, text }, index) => (
-              <List.Item key={buildKeyFromStrings(text, index)}>
-                <Icon labelText={text} name={iconName} />
-              </List.Item>
-            )
-          )}
-        </ShowOnDesktop>
-        <ShowOnMobile parent={Grid} parentProps={{ columns: 1 }}>
-          {getFirstFourItems(propertyMainCharacteristics).map(
-            ({ iconName, text }, index) => (
-              <GridColumn
-                computer={3}
-                key={buildKeyFromStrings(text, index)}
-                mobile={6}
-              >
-                <Icon labelText={text} name={iconName} />
-              </GridColumn>
-            )
-          )}
-        </ShowOnMobile>
-      </GridColumn>
-      <GridColumn>
-        {getParagraphsFromStrings(descriptionText).map(
-          (paragraphText, index, descriptionTextArray) => (
-            <Paragraph key={buildKeyFromStrings(paragraphText, index)}>
-              {isDescriptionDisplayingWithEllipsis(
-                index,
-                descriptionTextArray,
-                extraDescriptionText
-              )
-                ? formatParagraphWithModal(
-                    paragraphText,
-                    descriptionText,
-                    extraDescriptionText
-                  )
-                : paragraphText}
-            </Paragraph>
+  <Grid columns={1}>
+    <GridColumn>
+      <Subheading>{propertyType}</Subheading>
+      <Heading size="large">{propertyName}</Heading>
+    </GridColumn>
+    <GridColumn>
+      <ShowOnDesktop parent={List} parentProps={{ horizontal: true }}>
+        {getFirstFourItems(propertyMainCharacteristics).map(
+          ({ iconName, text }, index) => (
+            <List.Item key={buildKeyFromStrings(text, index)}>
+              <Icon labelText={text} name={iconName} />
+            </List.Item>
           )
         )}
-      </GridColumn>
-      <GridColumn>
-        <Subheading>{homeHighlightsHeadingText}</Subheading>
-      </GridColumn>
-      <GridColumn>
-        {homeHighlights.map(({ iconName, text }) => (
-          <Icon
-            hasBorder
-            key={buildKeyFromStrings(iconName, text)}
-            labelText={text}
-            name={iconName}
-          />
-        ))}
-      </GridColumn>
-    </Grid>
-  </VerticalGutters>
+      </ShowOnDesktop>
+      <ShowOnMobile parent={Grid} parentProps={{ columns: 1 }}>
+        {getFirstFourItems(propertyMainCharacteristics).map(
+          ({ iconName, text }, index) => (
+            <GridColumn
+              computer={3}
+              key={buildKeyFromStrings(text, index)}
+              mobile={6}
+            >
+              <Icon labelText={text} name={iconName} />
+            </GridColumn>
+          )
+        )}
+      </ShowOnMobile>
+    </GridColumn>
+    <GridColumn>
+      {getParagraphsFromStrings(descriptionText).map(
+        (paragraphText, index, descriptionTextArray) => (
+          <Paragraph key={buildKeyFromStrings(paragraphText, index)}>
+            {isDescriptionDisplayingWithEllipsis(
+              index,
+              descriptionTextArray,
+              extraDescriptionText
+            )
+              ? formatParagraphWithModal(
+                  paragraphText,
+                  descriptionText,
+                  extraDescriptionText
+                )
+              : paragraphText}
+          </Paragraph>
+        )
+      )}
+    </GridColumn>
+    <GridColumn>
+      <Subheading>{homeHighlightsHeadingText}</Subheading>
+    </GridColumn>
+    <GridColumn>
+      {homeHighlights.map(({ iconName, text }) => (
+        <Icon
+          hasBorder
+          key={buildKeyFromStrings(iconName, text)}
+          labelText={text}
+          name={iconName}
+        />
+      ))}
+    </GridColumn>
+  </Grid>
 );
 
 Component.displayName = 'Description';

--- a/src/components/property-page-widgets/Description/component.spec.js
+++ b/src/components/property-page-widgets/Description/component.spec.js
@@ -18,7 +18,6 @@ import { Icon } from 'elements/Icon';
 import { Modal } from 'elements/Modal';
 import { Paragraph } from 'typography/Paragraph';
 import { Subheading } from 'typography/Subheading';
-import { VerticalGutters } from 'layout/VerticalGutters';
 import { ShowOnDesktop } from 'layout/ShowOnDesktop';
 import { ShowOnMobile } from 'layout/ShowOnMobile';
 
@@ -61,25 +60,15 @@ const getDesktopMarkup = getDescription().find(ShowOnDesktop);
 const getMobileMarkup = getDescription().find(ShowOnMobile);
 
 describe('<Description />', () => {
-  it('should have `VerticalGutters` component as a wrapper', () => {
+  it('should have `Grid` component as a wrapper', () => {
     const wrapper = getDescription();
 
-    expectComponentToBe(wrapper, VerticalGutters);
-  });
-
-  describe('the `VerticalGutters` component', () => {
-    it('should have `Grid` as its only children', () => {
-      const wrapper = getDescription();
-
-      expectComponentToHaveChildren(wrapper, Grid);
-    });
+    expectComponentToBe(wrapper, Grid);
   });
 
   describe('the first `Grid` component', () => {
     it('should have the right props', () => {
-      const wrapper = getDescription()
-        .first()
-        .children();
+      const wrapper = getDescription().first();
 
       expectComponentToHaveProps(wrapper, {
         columns: 1,

--- a/src/components/property-page-widgets/HostProfile/component.js
+++ b/src/components/property-page-widgets/HostProfile/component.js
@@ -14,7 +14,6 @@ import { Grid } from 'layout/Grid';
 import { GridRow } from 'layout/GridRow';
 import { GridColumn } from 'layout/GridColumn';
 import { Paragraph } from 'typography/Paragraph';
-import { VerticalGutters } from 'layout/VerticalGutters';
 
 import { getStringWithColonSuffix } from './utils/getStringWithColonSuffix';
 
@@ -35,55 +34,53 @@ export const Component = ({
   phone,
   phoneLabel,
 }) => (
-  <VerticalGutters>
-    <Grid textAlign="left">
-      <GridRow>
-        <GridColumn width={12}>
-          <Heading>{headingText}</Heading>
-        </GridColumn>
-      </GridRow>
-      <GridRow>
-        <GridColumn width={12}>
-          <Item.Group unstackable>
-            <Item>
-              <Item.Image avatar size="tiny" src={avatarUrl} />
-              <Item.Header as="h4" verticalAlign="middle">
-                {name}
-              </Item.Header>
-            </Item>
-          </Item.Group>
-        </GridColumn>
-      </GridRow>
-      <GridRow verticalAlign="top">
-        <GridColumn computer={7} mobile={12} tablet={12}>
-          <Paragraph size="medium">{description}</Paragraph>
-        </GridColumn>
-        <GridColumn computer={5} mobile={12} tablet={12}>
-          <Heading size="small">{contactInformationHeadingText}</Heading>
-          <List relaxed size="medium">
-            {!!email && (
-              <List.Item>
-                <span>{getStringWithColonSuffix(emailLabel)}</span>
-                <span>{email}</span>
-              </List.Item>
-            )}
-            {!!phone && (
-              <List.Item>
-                <span>{getStringWithColonSuffix(phoneLabel)}</span>
-                <span>{phone}</span>
-              </List.Item>
-            )}
-            {!!languages && (
-              <List.Item>
-                <span>{getStringWithColonSuffix(languagesLabel)}</span>
-                <span>{languages.join(', ')}</span>
-              </List.Item>
-            )}
-          </List>
-        </GridColumn>
-      </GridRow>
-    </Grid>
-  </VerticalGutters>
+  <Grid textAlign="left">
+    <GridRow>
+      <GridColumn width={12}>
+        <Heading>{headingText}</Heading>
+      </GridColumn>
+    </GridRow>
+    <GridRow>
+      <GridColumn width={12}>
+        <Item.Group unstackable>
+          <Item>
+            <Item.Image avatar size="tiny" src={avatarUrl} />
+            <Item.Header as="h4" verticalAlign="middle">
+              {name}
+            </Item.Header>
+          </Item>
+        </Item.Group>
+      </GridColumn>
+    </GridRow>
+    <GridRow verticalAlign="top">
+      <GridColumn computer={7} mobile={12} tablet={12}>
+        <Paragraph size="medium">{description}</Paragraph>
+      </GridColumn>
+      <GridColumn computer={5} mobile={12} tablet={12}>
+        <Heading size="small">{contactInformationHeadingText}</Heading>
+        <List relaxed size="medium">
+          {!!email && (
+            <List.Item>
+              <span>{getStringWithColonSuffix(emailLabel)}</span>
+              <span>{email}</span>
+            </List.Item>
+          )}
+          {!!phone && (
+            <List.Item>
+              <span>{getStringWithColonSuffix(phoneLabel)}</span>
+              <span>{phone}</span>
+            </List.Item>
+          )}
+          {!!languages && (
+            <List.Item>
+              <span>{getStringWithColonSuffix(languagesLabel)}</span>
+              <span>{languages.join(', ')}</span>
+            </List.Item>
+          )}
+        </List>
+      </GridColumn>
+    </GridRow>
+  </Grid>
 );
 
 Component.displayName = 'HostProfile';

--- a/src/components/property-page-widgets/HostProfile/component.spec.js
+++ b/src/components/property-page-widgets/HostProfile/component.spec.js
@@ -20,7 +20,6 @@ import { Grid } from 'layout/Grid';
 import { GridRow } from 'layout/GridRow';
 import { GridColumn } from 'layout/GridColumn';
 import { Paragraph } from 'typography/Paragraph';
-import { VerticalGutters } from 'layout/VerticalGutters';
 
 import { Component as HostProfile } from './component';
 
@@ -50,18 +49,10 @@ const getGridRows = () => getHostProfile().find(GridRow);
 const getGridRowAt = at => getGridRows().at(at);
 
 describe('<HostProfile />', () => {
-  it('should have `VerticalGutters` component as a wrapper', () => {
+  it('should have `Grid` component as a wrapper', () => {
     const wrapper = getHostProfile();
 
-    expectComponentToBe(wrapper, VerticalGutters);
-  });
-
-  describe('the `VerticalGutters` component', () => {
-    it('should have `Grid` as its only children', () => {
-      const wrapper = getHostProfile();
-
-      expectComponentToHaveChildren(wrapper, Grid);
-    });
+    expectComponentToBe(wrapper, Grid);
   });
 
   describe('the `Grid` component', () => {

--- a/src/components/property-page-widgets/KeyFacts/component.js
+++ b/src/components/property-page-widgets/KeyFacts/component.js
@@ -8,33 +8,30 @@ import { Heading } from 'typography/Heading';
 import { Grid } from 'layout/Grid';
 import { GridColumn } from 'layout/GridColumn';
 import { IconCard } from 'elements/IconCard';
-import { VerticalGutters } from 'layout/VerticalGutters';
 
 /**
  * The standard widget for displaying key facts about a property.
  */
 // eslint-disable-next-line jsdoc/require-jsdoc
 export const Component = ({ keyFacts, headingText }) => (
-  <VerticalGutters>
-    <Grid>
-      <GridColumn width={12}>
-        <Heading>{headingText}</Heading>
-      </GridColumn>
-      <GridColumn width={12}>
-        <Label.Group>
-          {keyFacts.map(({ iconName, isDisabled, label }, index) => (
-            <IconCard
-              isDisabled={isDisabled}
-              isFilled
-              key={buildKeyFromStrings(label, index)}
-              label={label}
-              name={iconName}
-            />
-          ))}
-        </Label.Group>
-      </GridColumn>
-    </Grid>
-  </VerticalGutters>
+  <Grid>
+    <GridColumn width={12}>
+      <Heading>{headingText}</Heading>
+    </GridColumn>
+    <GridColumn width={12}>
+      <Label.Group>
+        {keyFacts.map(({ iconName, isDisabled, label }, index) => (
+          <IconCard
+            isDisabled={isDisabled}
+            isFilled
+            key={buildKeyFromStrings(label, index)}
+            label={label}
+            name={iconName}
+          />
+        ))}
+      </Label.Group>
+    </GridColumn>
+  </Grid>
 );
 
 Component.displayName = 'KeyFacts';

--- a/src/components/property-page-widgets/KeyFacts/component.spec.js
+++ b/src/components/property-page-widgets/KeyFacts/component.spec.js
@@ -14,7 +14,6 @@ import { Heading } from 'typography/Heading';
 import { IconCard } from 'elements/IconCard';
 import { Grid } from 'layout/Grid';
 import { GridColumn } from 'layout/GridColumn';
-import { VerticalGutters } from 'layout/VerticalGutters';
 
 import { keyFacts } from './mock-data/keyFacts';
 import { Component as KeyFacts } from './component';
@@ -22,17 +21,10 @@ import { Component as KeyFacts } from './component';
 const getKeyFacts = () => shallow(<KeyFacts keyFacts={keyFacts} />);
 
 describe('<KeyFacts />', () => {
-  it('should have `VerticalGutters` component as a wrapper', () => {
+  it('should have `Grid` component as a wrapper', () => {
     const wrapper = getKeyFacts();
 
-    expectComponentToBe(wrapper, VerticalGutters);
-  });
-  describe('the `VerticalGutters` component', () => {
-    it('should have `Grid` as its only children', () => {
-      const wrapper = getKeyFacts();
-
-      expectComponentToHaveChildren(wrapper, Grid);
-    });
+    expectComponentToBe(wrapper, Grid);
   });
 
   describe('the `Grid` component', () => {

--- a/src/components/property-page-widgets/Location/component.js
+++ b/src/components/property-page-widgets/Location/component.js
@@ -14,7 +14,6 @@ import { ShowOnMobile } from 'layout/ShowOnMobile';
 import { Heading } from 'typography/Heading';
 import { Paragraph } from 'typography/Paragraph';
 import { Subheading } from 'typography/Subheading';
-import { VerticalGutters } from 'layout/VerticalGutters';
 
 import { getTransportOptionsMarkup } from './utils/getTransportOptionsMarkup';
 import { getGoogleMapHeight } from './utils/getGoogleMapHeight';
@@ -34,42 +33,40 @@ const Component = ({
   longitude,
   transportOptions,
 }) => (
-  <VerticalGutters>
-    <Grid stackable>
-      <GridColumn width={12}>
-        <Heading>{headingText}</Heading>
-        <Subheading>{locationSummary}</Subheading>
-      </GridColumn>
-      <GridColumn computer={6} tablet={12}>
-        {getParagraphsFromStrings(locationDescription).map(
-          (paragraphText, index) => (
-            <Paragraph key={buildKeyFromStrings(paragraphText, index)}>
-              {paragraphText}
-            </Paragraph>
-          )
-        )}
-      </GridColumn>
-      <ShowOnDesktop
-        parent={GridColumn}
-        parentProps={{ computer: 6, tablet: 12 }}
-      >
-        {getTransportOptionsMarkup(transportOptions)}
-      </ShowOnDesktop>
-      <GridColumn width={12}>
-        <GoogleMap
-          height={getGoogleMapHeight(isUserOnMobile)}
-          isShowingApproximateLocation={isShowingApproximateLocation}
-          isShowingExactLocation={isShowingExactLocation}
-          latitude={latitude}
-          longitude={longitude}
-        />
-      </GridColumn>
-      <ShowOnMobile parent={GridColumn} parentProps={{ width: 12 }}>
-        <Divider />
-        {getTransportOptionsMarkup(transportOptions)}
-      </ShowOnMobile>
-    </Grid>
-  </VerticalGutters>
+  <Grid stackable>
+    <GridColumn width={12}>
+      <Heading>{headingText}</Heading>
+      <Subheading>{locationSummary}</Subheading>
+    </GridColumn>
+    <GridColumn computer={6} tablet={12}>
+      {getParagraphsFromStrings(locationDescription).map(
+        (paragraphText, index) => (
+          <Paragraph key={buildKeyFromStrings(paragraphText, index)}>
+            {paragraphText}
+          </Paragraph>
+        )
+      )}
+    </GridColumn>
+    <ShowOnDesktop
+      parent={GridColumn}
+      parentProps={{ computer: 6, tablet: 12 }}
+    >
+      {getTransportOptionsMarkup(transportOptions)}
+    </ShowOnDesktop>
+    <GridColumn width={12}>
+      <GoogleMap
+        height={getGoogleMapHeight(isUserOnMobile)}
+        isShowingApproximateLocation={isShowingApproximateLocation}
+        isShowingExactLocation={isShowingExactLocation}
+        latitude={latitude}
+        longitude={longitude}
+      />
+    </GridColumn>
+    <ShowOnMobile parent={GridColumn} parentProps={{ width: 12 }}>
+      <Divider />
+      {getTransportOptionsMarkup(transportOptions)}
+    </ShowOnMobile>
+  </Grid>
 );
 
 Component.displayName = 'Location';

--- a/src/components/property-page-widgets/Location/component.spec.js
+++ b/src/components/property-page-widgets/Location/component.spec.js
@@ -20,7 +20,6 @@ import { Heading } from 'typography/Heading';
 import { Subheading } from 'typography/Subheading';
 import { Paragraph } from 'typography/Paragraph';
 import { GoogleMap } from 'elements/GoogleMap';
-import { VerticalGutters } from 'layout/VerticalGutters';
 
 import {
   locationDescription,
@@ -52,18 +51,10 @@ describe('<Location />', () => {
   });
 
   describe('the `Child` of the `Location` component', () => {
-    it('should have `VerticalGutters` component as a wrapper', () => {
+    it('should have `Grid` component as a wrapper', () => {
       const wrapper = getWrappedLocation();
 
-      expectComponentToBe(wrapper, VerticalGutters);
-    });
-  });
-
-  describe('the `VerticalGutters` component', () => {
-    it('should have `Grid` as its only children', () => {
-      const wrapper = getWrappedLocation();
-
-      expectComponentToHaveChildren(wrapper, Grid);
+      expectComponentToBe(wrapper, Grid);
     });
   });
 

--- a/src/components/property-page-widgets/PaymentInformation/component.js
+++ b/src/components/property-page-widgets/PaymentInformation/component.js
@@ -21,7 +21,6 @@ import {
   NOTES,
   VIEW_MORE,
 } from 'utils/default-strings';
-import { VerticalGutters } from 'layout/VerticalGutters';
 
 /**
  * The standard widget for displaying the payment information of a property.
@@ -45,80 +44,78 @@ export const Component = ({
   taxesText,
   taxesHeadingText,
 }) => (
-  <VerticalGutters>
-    <Grid stackable>
+  <Grid stackable>
+    <GridRow>
+      <GridColumn width={12}>
+        <Heading>{headingText}</Heading>
+      </GridColumn>
+    </GridRow>
+    <GridRow>
+      {!!paymentScheduleText && (
+        <GridColumn width={6}>
+          <Heading size="small">{paymentScheduleHeadingText}</Heading>
+          <Paragraph size="medium">{paymentScheduleText}</Paragraph>
+        </GridColumn>
+      )}
+      {!!cancellationPolicyText && (
+        <GridColumn width={6}>
+          <Heading size="small">{cancellationPolicyHeadingText}</Heading>
+          <Paragraph size="medium">{cancellationPolicyText}</Paragraph>
+        </GridColumn>
+      )}
+    </GridRow>
+    <GridRow>
+      {!!cleaningCharge && (
+        <GridColumn width={6}>
+          <Heading size="small">{cleaningChargeHeadingText}</Heading>
+          <Statistic horizontal size="mini" text value={cleaningCharge} />
+        </GridColumn>
+      )}
+      {!!taxesText && (
+        <GridColumn width={6}>
+          <Heading size="small">{taxesHeadingText}</Heading>
+          <Statistic
+            horizontal
+            label={taxesDescriptionText}
+            size="tiny"
+            text
+            value={taxesText}
+          />
+        </GridColumn>
+      )}
+    </GridRow>
+    {!!damageDepositText && (
       <GridRow>
         <GridColumn width={12}>
-          <Heading>{headingText}</Heading>
+          <Heading size="small">{damageDepositHeadingText}</Heading>
+          <Paragraph size="medium">{damageDepositText}</Paragraph>
         </GridColumn>
       </GridRow>
+    )}
+    {!!notesText && (
       <GridRow>
-        {!!paymentScheduleText && (
-          <GridColumn width={6}>
-            <Heading size="small">{paymentScheduleHeadingText}</Heading>
-            <Paragraph size="medium">{paymentScheduleText}</Paragraph>
-          </GridColumn>
-        )}
-        {!!cancellationPolicyText && (
-          <GridColumn width={6}>
-            <Heading size="small">{cancellationPolicyHeadingText}</Heading>
-            <Paragraph size="medium">{cancellationPolicyText}</Paragraph>
-          </GridColumn>
-        )}
+        <GridColumn width={12}>
+          <Heading size="small">{notesHeadingText}</Heading>
+          <Paragraph size="medium">{notesText}</Paragraph>
+        </GridColumn>
       </GridRow>
+    )}
+    {!!extraNotesText && (
       <GridRow>
-        {!!cleaningCharge && (
-          <GridColumn width={6}>
-            <Heading size="small">{cleaningChargeHeadingText}</Heading>
-            <Statistic horizontal size="mini" text value={cleaningCharge} />
-          </GridColumn>
-        )}
-        {!!taxesText && (
-          <GridColumn width={6}>
-            <Heading size="small">{taxesHeadingText}</Heading>
-            <Statistic
-              horizontal
-              label={taxesDescriptionText}
-              size="tiny"
-              text
-              value={taxesText}
-            />
-          </GridColumn>
-        )}
+        <GridColumn width={12}>
+          <Modal trigger={<Link>{modalTriggerText}</Link>}>
+            {getParagraphsFromStrings(extraNotesText).map(
+              (paragraphText, index) => (
+                <Paragraph key={buildKeyFromStrings(paragraphText, index)}>
+                  {paragraphText}
+                </Paragraph>
+              )
+            )}
+          </Modal>
+        </GridColumn>
       </GridRow>
-      {!!damageDepositText && (
-        <GridRow>
-          <GridColumn width={12}>
-            <Heading size="small">{damageDepositHeadingText}</Heading>
-            <Paragraph size="medium">{damageDepositText}</Paragraph>
-          </GridColumn>
-        </GridRow>
-      )}
-      {!!notesText && (
-        <GridRow>
-          <GridColumn width={12}>
-            <Heading size="small">{notesHeadingText}</Heading>
-            <Paragraph size="medium">{notesText}</Paragraph>
-          </GridColumn>
-        </GridRow>
-      )}
-      {!!extraNotesText && (
-        <GridRow>
-          <GridColumn width={12}>
-            <Modal trigger={<Link>{modalTriggerText}</Link>}>
-              {getParagraphsFromStrings(extraNotesText).map(
-                (paragraphText, index) => (
-                  <Paragraph key={buildKeyFromStrings(paragraphText, index)}>
-                    {paragraphText}
-                  </Paragraph>
-                )
-              )}
-            </Modal>
-          </GridColumn>
-        </GridRow>
-      )}
-    </Grid>
-  </VerticalGutters>
+    )}
+  </Grid>
 );
 
 Component.displayName = 'PaymentInformation';

--- a/src/components/property-page-widgets/PaymentInformation/component.spec.js
+++ b/src/components/property-page-widgets/PaymentInformation/component.spec.js
@@ -26,7 +26,6 @@ import { Paragraph } from 'typography/Paragraph';
 import { Heading } from 'typography/Heading';
 import { Link } from 'elements/Link';
 import { Modal } from 'elements/Modal';
-import { VerticalGutters } from 'layout/VerticalGutters';
 
 import { Component as PaymentInformation } from './component';
 
@@ -57,17 +56,10 @@ const getPaymentInformation = extraProps =>
   shallow(<PaymentInformation {...props} {...extraProps} />);
 
 describe('<PaymentInformation />', () => {
-  it('should have `VerticalGutters` component as a wrapper', () => {
+  it('should have `Grid` component as a wrapper', () => {
     const wrapper = getPaymentInformation();
 
-    expectComponentToBe(wrapper, VerticalGutters);
-  });
-  describe('the `VerticalGutters` component', () => {
-    it('should have `Grid` as its only children', () => {
-      const wrapper = getPaymentInformation();
-
-      expectComponentToHaveChildren(wrapper, Grid);
-    });
+    expectComponentToBe(wrapper, Grid);
   });
 
   describe('the first `Grid` component', () => {

--- a/src/components/property-page-widgets/Pictures/component.js
+++ b/src/components/property-page-widgets/Pictures/component.js
@@ -10,39 +10,36 @@ import { ShowOnMobile } from 'layout/ShowOnMobile';
 import { Thumbnail } from 'media/Thumbnail';
 import { Heading } from 'typography/Heading';
 import { Link } from 'elements/Link';
-import { VerticalGutters } from 'layout/VerticalGutters';
 
 /**
  * The standard widget for displaying pictures of a property.
  */
 // eslint-disable-next-line jsdoc/require-jsdoc
 export const Component = ({ headingText, linkText, pictures }) => (
-  <VerticalGutters>
-    <Grid>
-      <GridColumn width={12}>
-        <Heading>{headingText}</Heading>
+  <Grid>
+    <GridColumn width={12}>
+      <Heading>{headingText}</Heading>
+    </GridColumn>
+    {pictures.map(({ imageUrl, label }, index) => (
+      <GridColumn key={buildKeyFromStrings(label, index)} width={4}>
+        <ShowOnDesktop>
+          <Thumbnail imageUrl={imageUrl} label={label} size="huge" />
+        </ShowOnDesktop>
+        <ShowOnMobile>
+          <Thumbnail
+            hasRoundedCorners
+            imageUrl={imageUrl}
+            isSquare
+            label={label}
+            size="large"
+          />
+        </ShowOnMobile>
       </GridColumn>
-      {pictures.map(({ imageUrl, label }, index) => (
-        <GridColumn key={buildKeyFromStrings(label, index)} width={4}>
-          <ShowOnDesktop>
-            <Thumbnail imageUrl={imageUrl} label={label} size="huge" />
-          </ShowOnDesktop>
-          <ShowOnMobile>
-            <Thumbnail
-              hasRoundedCorners
-              imageUrl={imageUrl}
-              isSquare
-              label={label}
-              size="large"
-            />
-          </ShowOnMobile>
-        </GridColumn>
-      ))}
-      <GridColumn width={12}>
-        <Link>{linkText}</Link>
-      </GridColumn>
-    </Grid>
-  </VerticalGutters>
+    ))}
+    <GridColumn width={12}>
+      <Link>{linkText}</Link>
+    </GridColumn>
+  </Grid>
 );
 
 Component.displayName = 'Pictures';

--- a/src/components/property-page-widgets/Pictures/component.spec.js
+++ b/src/components/property-page-widgets/Pictures/component.spec.js
@@ -16,7 +16,6 @@ import { ShowOnDesktop } from 'layout/ShowOnDesktop';
 import { Heading } from 'typography/Heading';
 import { Link } from 'elements/Link';
 import { Thumbnail } from 'media/Thumbnail';
-import { VerticalGutters } from 'layout/VerticalGutters';
 
 import { pictures } from './mock-data/pictures';
 import { Component as Pictures } from './component';
@@ -24,17 +23,10 @@ import { Component as Pictures } from './component';
 const getPictures = () => shallow(<Pictures pictures={pictures} />);
 
 describe('<Pictures />', () => {
-  it('should have `VerticalGutters` component as a wrapper', () => {
+  it('should have `Grid` component as a wrapper', () => {
     const wrapper = getPictures();
 
-    expectComponentToBe(wrapper, VerticalGutters);
-  });
-  describe('the `VerticalGutters` component', () => {
-    it('should have `Grid` as its only children', () => {
-      const wrapper = getPictures();
-
-      expectComponentToHaveChildren(wrapper, Grid);
-    });
+    expectComponentToBe(wrapper, Grid);
   });
 
   describe('the `Grid` component', () => {

--- a/src/components/property-page-widgets/Rates/component.js
+++ b/src/components/property-page-widgets/Rates/component.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { Card } from 'semantic-ui-react';
 
@@ -14,7 +14,6 @@ import { GridRow } from 'layout/GridRow';
 import { ShowOnDesktop } from 'layout/ShowOnDesktop';
 import { ShowOnMobile } from 'layout/ShowOnMobile';
 import { Table } from 'collections/Table';
-import { VerticalGutters } from 'layout/VerticalGutters';
 
 import { getMobileRateRowMarkup } from './utils/getMobileRateRowMarkup';
 import { getRateCategoryHeadingMarkup } from './utils/getRateCategoryHeadingMarkup';
@@ -34,7 +33,7 @@ export const Component = ({
   roomTypeInputLabel,
   roomTypes,
 }) => (
-  <VerticalGutters>
+  <Fragment>
     <Grid padded>
       {roomTypes &&
         getRoomTypeDropdownMarkup(
@@ -84,7 +83,7 @@ export const Component = ({
         ]}
       />
     </ShowOnDesktop>
-  </VerticalGutters>
+  </Fragment>
 );
 
 Component.defaultProps = {

--- a/src/components/property-page-widgets/Rates/component.spec.js
+++ b/src/components/property-page-widgets/Rates/component.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import { shallow } from 'enzyme';
 import {
   expectComponentToBe,
@@ -17,7 +17,6 @@ import { ShowOnDesktop } from 'layout/ShowOnDesktop';
 import { ShowOnMobile } from 'layout/ShowOnMobile';
 import { Table } from 'collections/Table';
 import { PRICE_PER_EXTRA_PER } from 'utils/default-strings';
-import { VerticalGutters } from 'layout/VerticalGutters';
 
 import { Component as Rates } from './component';
 import { getRateCategoryHeadingMarkup } from './utils/getRateCategoryHeadingMarkup';
@@ -98,13 +97,13 @@ const getRatesWidget = props =>
   );
 
 describe('<Rates />', () => {
-  it('should have `VerticalGutters` component as a wrapper', () => {
+  it('should have `Fragment` component as a wrapper', () => {
     const wrapper = getRatesWidget();
 
-    expectComponentToBe(wrapper, VerticalGutters);
+    expectComponentToBe(wrapper, Fragment);
   });
 
-  describe('the `VerticalGutters` component', () => {
+  describe('the `Fragment` component', () => {
     it('should have the right children', () => {
       const wrapper = getRatesWidget();
 

--- a/src/components/property-page-widgets/Reviews/component.js
+++ b/src/components/property-page-widgets/Reviews/component.js
@@ -11,7 +11,6 @@ import { GridRow } from 'layout/GridRow';
 import { GridColumn } from 'layout/GridColumn';
 import { Review } from 'general-widgets/Review';
 import { REVIEWS, SUBMIT_REVIEW } from 'utils/default-strings';
-import { VerticalGutters } from 'layout/VerticalGutters';
 
 /**
  * The standard widget for displaying a collection of reviews.
@@ -23,52 +22,50 @@ export const Component = ({
   ratingAverage,
   submitButtonText,
 }) => (
-  <VerticalGutters>
-    <Grid>
-      <GridRow>
+  <Grid>
+    <GridRow>
+      <GridColumn width={12}>
+        <Heading>{headingText}</Heading>
+      </GridColumn>
+    </GridRow>
+    <GridRow verticalAlign="middle">
+      <GridColumn
+        computer={6}
+        floated="left"
+        mobile={5}
+        tablet={5}
+        textAlign="left"
+        verticalAlign="middle"
+      >
+        <Rating
+          disabled
+          maxRating={5}
+          rating={Math.round(ratingAverage)}
+          size="small"
+        />
+        <span>{Math.round(ratingAverage)}</span>
+      </GridColumn>
+      <GridColumn
+        computer={6}
+        floated="right"
+        mobile={7}
+        tablet={7}
+        verticalAlign="middle"
+      >
+        <Button isCompact isPositionedRight isRounded size="medium">
+          {submitButtonText}
+        </Button>
+      </GridColumn>
+    </GridRow>
+    {reviews.map((review, index) => (
+      <GridRow key={buildKeyFromStrings(review.reviewText, index)}>
         <GridColumn width={12}>
-          <Heading>{headingText}</Heading>
+          <Review {...review} />
+          <Divider />
         </GridColumn>
       </GridRow>
-      <GridRow verticalAlign="middle">
-        <GridColumn
-          computer={6}
-          floated="left"
-          mobile={5}
-          tablet={5}
-          textAlign="left"
-          verticalAlign="middle"
-        >
-          <Rating
-            disabled
-            maxRating={5}
-            rating={Math.round(ratingAverage)}
-            size="small"
-          />
-          <span>{Math.round(ratingAverage)}</span>
-        </GridColumn>
-        <GridColumn
-          computer={6}
-          floated="right"
-          mobile={7}
-          tablet={7}
-          verticalAlign="middle"
-        >
-          <Button isCompact isPositionedRight isRounded size="medium">
-            {submitButtonText}
-          </Button>
-        </GridColumn>
-      </GridRow>
-      {reviews.map((review, index) => (
-        <GridRow key={buildKeyFromStrings(review.reviewText, index)}>
-          <GridColumn width={12}>
-            <Review {...review} />
-            <Divider />
-          </GridColumn>
-        </GridRow>
-      ))}
-    </Grid>
-  </VerticalGutters>
+    ))}
+  </Grid>
 );
 
 Component.displayName = 'Reviews';

--- a/src/components/property-page-widgets/Reviews/component.spec.js
+++ b/src/components/property-page-widgets/Reviews/component.spec.js
@@ -15,7 +15,6 @@ import { GridColumn } from 'layout/GridColumn';
 import { Button } from 'elements/Button';
 import { Divider } from 'elements/Divider';
 import { Review } from 'general-widgets/Review';
-import { VerticalGutters } from 'layout/VerticalGutters';
 
 import { Component as Reviews } from './component';
 
@@ -59,17 +58,10 @@ const getReviews = additionalProps =>
   shallow(<Reviews {...requiredProps} {...additionalProps} />);
 
 describe('<Reviews />', () => {
-  it('should have `VerticalGutters` component as a wrapper', () => {
+  it('should have `Grid` component as a wrapper', () => {
     const wrapper = getReviews();
 
-    expectComponentToBe(wrapper, VerticalGutters);
-  });
-  describe('the `VerticalGutters` component', () => {
-    it('should have `Grid` as its only children', () => {
-      const wrapper = getReviews();
-
-      expectComponentToHaveChildren(wrapper, Grid);
-    });
+    expectComponentToBe(wrapper, Grid);
   });
 
   describe('the first `GridRow` component', () => {

--- a/src/components/property-page-widgets/RoomType/component.js
+++ b/src/components/property-page-widgets/RoomType/component.js
@@ -15,7 +15,6 @@ import { Heading } from 'typography/Heading';
 import { Slideshow } from 'media/Slideshow';
 import { withResponsive } from 'utils/with-responsive';
 import { getNightPriceMarkup } from 'utils/get-night-price-markup';
-import { VerticalGutters } from 'layout/VerticalGutters';
 
 import { getRoomFeaturesMarkup } from './utils/getRoomFeaturesMarkup';
 import { getModalContentMarkup } from './utils/getModalContentMarkup';
@@ -36,41 +35,61 @@ const Component = ({
   ratingNumber,
   slideShowImages,
 }) => (
-  <VerticalGutters>
-    <Card fluid>
-      <Grid>
-        <GridRow>
-          <GridColumn computer={4} mobile={12} verticalAlignContent={null}>
-            <Slideshow
-              hasShadow={false}
-              images={slideShowImages}
-              isRounded={false}
-              isShowingBulletNavigation={false}
-              isStretched
-            />
-          </GridColumn>
-          <GridColumn computer={8} mobile={12}>
-            <Grid padded>
-              <GridColumn computer={12} floated="left" mobile={10}>
-                <Heading>{name}</Heading>
-              </GridColumn>
-              <GridColumn
-                only="mobile"
-                textAlign="right"
-                verticalAlignContent="middle"
-                width={2}
+  <Card fluid>
+    <Grid>
+      <GridRow>
+        <GridColumn computer={4} mobile={12} verticalAlignContent={null}>
+          <Slideshow
+            hasShadow={false}
+            images={slideShowImages}
+            isRounded={false}
+            isShowingBulletNavigation={false}
+            isStretched
+          />
+        </GridColumn>
+        <GridColumn computer={8} mobile={12}>
+          <Grid padded>
+            <GridColumn computer={12} floated="left" mobile={10}>
+              <Heading>{name}</Heading>
+            </GridColumn>
+            <GridColumn
+              only="mobile"
+              textAlign="right"
+              verticalAlignContent="middle"
+              width={2}
+            >
+              <Modal
+                trigger={
+                  <Icon
+                    color="yellow"
+                    isCircular
+                    isColorInverted
+                    name={ICON_NAMES.INFO}
+                    size="small"
+                  />
+                }
               >
-                <Modal
-                  trigger={
-                    <Icon
-                      color="yellow"
-                      isCircular
-                      isColorInverted
-                      name={ICON_NAMES.INFO}
-                      size="small"
-                    />
-                  }
-                >
+                {getModalContentMarkup(
+                  amenities,
+                  onClickCheckAvailability,
+                  description,
+                  extraFeatures,
+                  features,
+                  name,
+                  nightPrice,
+                  ratingNumber,
+                  slideShowImages
+                )}
+              </Modal>
+            </GridColumn>
+            {getRoomFeaturesMarkup(isUserOnMobile, features)}
+            <GridRow>
+              <GridColumn
+                only="tablet computer"
+                verticalAlignContent="bottom"
+                width={4}
+              >
+                <Modal size="small" trigger={<Link>More Info</Link>}>
                   {getModalContentMarkup(
                     amenities,
                     onClickCheckAvailability,
@@ -84,52 +103,30 @@ const Component = ({
                   )}
                 </Modal>
               </GridColumn>
-              {getRoomFeaturesMarkup(isUserOnMobile, features)}
-              <GridRow>
-                <GridColumn
-                  only="tablet computer"
-                  verticalAlignContent="bottom"
-                  width={4}
+              <GridColumn
+                textAlign={isUserOnMobile ? 'left' : 'right'}
+                width={8}
+              >
+                <Card.Description>
+                  {getNightPriceMarkup(nightPrice)}
+                </Card.Description>
+                <ShowOnMobile>
+                  <Divider />
+                </ShowOnMobile>
+                <Button
+                  isPositionedRight={isUserOnMobile === false}
+                  isRounded
+                  onClick={onClickCheckAvailability}
                 >
-                  <Modal size="small" trigger={<Link>More Info</Link>}>
-                    {getModalContentMarkup(
-                      amenities,
-                      onClickCheckAvailability,
-                      description,
-                      extraFeatures,
-                      features,
-                      name,
-                      nightPrice,
-                      ratingNumber,
-                      slideShowImages
-                    )}
-                  </Modal>
-                </GridColumn>
-                <GridColumn
-                  textAlign={isUserOnMobile ? 'left' : 'right'}
-                  width={8}
-                >
-                  <Card.Description>
-                    {getNightPriceMarkup(nightPrice)}
-                  </Card.Description>
-                  <ShowOnMobile>
-                    <Divider />
-                  </ShowOnMobile>
-                  <Button
-                    isPositionedRight={isUserOnMobile === false}
-                    isRounded
-                    onClick={onClickCheckAvailability}
-                  >
-                    Check Availability
-                  </Button>
-                </GridColumn>
-              </GridRow>
-            </Grid>
-          </GridColumn>
-        </GridRow>
-      </Grid>
-    </Card>
-  </VerticalGutters>
+                  Check Availability
+                </Button>
+              </GridColumn>
+            </GridRow>
+          </Grid>
+        </GridColumn>
+      </GridRow>
+    </Grid>
+  </Card>
 );
 
 Component.displayName = 'RoomType';

--- a/src/components/property-page-widgets/RoomType/component.spec.js
+++ b/src/components/property-page-widgets/RoomType/component.spec.js
@@ -19,7 +19,6 @@ import { Link } from 'elements/Link';
 import { Modal } from 'elements/Modal';
 import { ShowOnMobile } from 'layout/ShowOnMobile';
 import { Slideshow } from 'media/Slideshow';
-import { VerticalGutters } from 'layout/VerticalGutters';
 
 import { ComponentWithResponsive as RoomType } from './component';
 
@@ -83,18 +82,10 @@ describe('<RoomType />', () => {
   });
 
   describe('the `Child` of the `RoomType` component', () => {
-    it('should have `VerticalGutters` component as a wrapper', () => {
+    it('should have `Card` component as a wrapper', () => {
       const wrapper = getWrappedRoomType();
 
-      expectComponentToBe(wrapper, VerticalGutters);
-    });
-  });
-
-  describe('the `VerticalGutters` component', () => {
-    it('should have `Card` as its only children', () => {
-      const wrapper = getWrappedRoomType();
-
-      expectComponentToHaveChildren(wrapper, Card);
+      expectComponentToBe(wrapper, Card);
     });
   });
 

--- a/src/components/property-page-widgets/Rules/component.js
+++ b/src/components/property-page-widgets/Rules/component.js
@@ -9,7 +9,6 @@ import { Divider } from 'elements/Divider';
 import { Heading } from 'typography/Heading';
 import { Paragraph } from 'typography/Paragraph';
 import { Icon, ICON_NAMES } from 'elements/Icon';
-import { VerticalGutters } from 'layout/VerticalGutters';
 
 import { getLabelAndValueString } from './utils/getLabelAndValueString';
 
@@ -25,31 +24,29 @@ export const Component = ({
   headingText,
   rules,
 }) => (
-  <VerticalGutters>
-    <Grid stackable>
-      <GridColumn width={12}>
-        <Heading>{headingText}</Heading>
-      </GridColumn>
-      <GridColumn computer={3} tablet={5}>
-        <List
-          items={rules.map(rule => (
-            <Paragraph>{rule}</Paragraph>
-          ))}
-        />
-      </GridColumn>
-      <GridColumn computer={9} tablet={7}>
-        <Icon
-          labelText={getLabelAndValueString(checkInTimeLabel, checkInTime)}
-          name={ICON_NAMES.QUESTION_MARK}
-        />
-        <Divider />
-        <Icon
-          labelText={getLabelAndValueString(checkOutTimeLabel, checkOutTime)}
-          name={ICON_NAMES.QUESTION_MARK}
-        />
-      </GridColumn>
-    </Grid>
-  </VerticalGutters>
+  <Grid stackable>
+    <GridColumn width={12}>
+      <Heading>{headingText}</Heading>
+    </GridColumn>
+    <GridColumn computer={3} tablet={5}>
+      <List
+        items={rules.map(rule => (
+          <Paragraph>{rule}</Paragraph>
+        ))}
+      />
+    </GridColumn>
+    <GridColumn computer={9} tablet={7}>
+      <Icon
+        labelText={getLabelAndValueString(checkInTimeLabel, checkInTime)}
+        name={ICON_NAMES.QUESTION_MARK}
+      />
+      <Divider />
+      <Icon
+        labelText={getLabelAndValueString(checkOutTimeLabel, checkOutTime)}
+        name={ICON_NAMES.QUESTION_MARK}
+      />
+    </GridColumn>
+  </Grid>
 );
 
 Component.displayName = 'Rules';

--- a/src/components/property-page-widgets/Rules/component.spec.js
+++ b/src/components/property-page-widgets/Rules/component.spec.js
@@ -15,7 +15,6 @@ import { GridColumn } from 'layout/GridColumn';
 import { Divider } from 'elements/Divider';
 import { Heading } from 'typography/Heading';
 import { Icon } from 'elements/Icon';
-import { VerticalGutters } from 'layout/VerticalGutters';
 
 import { Component as Rules } from './component';
 
@@ -36,18 +35,10 @@ const props = {
 const getRules = otherProps => shallow(<Rules {...props} {...otherProps} />);
 
 describe('<Rules />', () => {
-  it('should have `VerticalGutters` component as a wrapper', () => {
+  it('should have `Grid` component as a wrapper', () => {
     const wrapper = getRules();
 
-    expectComponentToBe(wrapper, VerticalGutters);
-  });
-
-  describe('the `VerticalGutters` component', () => {
-    it('should have `Grid` as its only children', () => {
-      const wrapper = getRules();
-
-      expectComponentToHaveChildren(wrapper, Grid);
-    });
+    expectComponentToBe(wrapper, Grid);
   });
 
   describe('the Grid component', () => {

--- a/src/components/property-page-widgets/SleepingArrangements/component.js
+++ b/src/components/property-page-widgets/SleepingArrangements/component.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 
 import { SLEEPING_ARRANGEMENTS } from 'utils/default-strings';
@@ -7,14 +7,13 @@ import { Heading } from 'typography/Heading';
 import { Grid } from 'layout/Grid';
 import { GridColumn } from 'layout/GridColumn';
 import { IconCard } from 'elements/IconCard';
-import { VerticalGutters } from 'layout/VerticalGutters';
 
 /**
  * The standard widget for displaying the sleeping arrangments for a property.
  */
 // eslint-disable-next-line jsdoc/require-jsdoc
 export const Component = ({ headingText, sleepingArrangements }) => (
-  <VerticalGutters>
+  <Fragment>
     <Heading>{headingText}</Heading>
     <Grid>
       {sleepingArrangements.map(({ iconName, label }, index) => (
@@ -28,7 +27,7 @@ export const Component = ({ headingText, sleepingArrangements }) => (
         </GridColumn>
       ))}
     </Grid>
-  </VerticalGutters>
+  </Fragment>
 );
 
 Component.displayName = 'SleepingArrangements';

--- a/src/components/property-page-widgets/SleepingArrangements/component.spec.js
+++ b/src/components/property-page-widgets/SleepingArrangements/component.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import { shallow } from 'enzyme';
 import {
   expectComponentToBe,
@@ -12,7 +12,6 @@ import { Grid } from 'layout/Grid';
 import { GridColumn } from 'layout/GridColumn';
 import { Heading } from 'typography/Heading';
 import { IconCard } from 'elements/IconCard';
-import { VerticalGutters } from 'layout/VerticalGutters';
 
 import { Component as SleepingArrangements } from './component';
 
@@ -26,13 +25,13 @@ const getSleepingArrangements = () =>
   shallow(<SleepingArrangements sleepingArrangements={sleepingArrangements} />);
 
 describe('<SleepingArrangements />', () => {
-  it('should have `VerticalGutters` component as a wrapper', () => {
+  it('should have `Fragment` component as a wrapper', () => {
     const wrapper = getSleepingArrangements();
 
-    expectComponentToBe(wrapper, VerticalGutters);
+    expectComponentToBe(wrapper, Fragment);
   });
 
-  describe('the `VerticalGutters` component', () => {
+  describe('the `Fragment` component', () => {
     it('should have the right children', () => {
       const wrapper = getSleepingArrangements();
 


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-X)

### What **one** thing does this PR do?
Removes the `VerticalGutters` from components

### Any other notes
- The `VerticalGutters` will be applied in TemplatesSSR when the components are being rendered
- The `Amenities` component has been changed the most since it had an optional `VerticalGutter`

__Before__
<img width="696" alt="screen shot 2018-09-25 at 17 35 43" src="https://user-images.githubusercontent.com/25742275/46025547-7bb25d80-c0e9-11e8-9bee-1f936e635978.png">

__After__
<img width="691" alt="screen shot 2018-09-25 at 17 35 49" src="https://user-images.githubusercontent.com/25742275/46025550-80771180-c0e9-11e8-9fa8-e93bbb9a9d12.png">
