### PR TITLE
TE-1081: support no padding for the GridColumn

### DIFF
--- a/src/components/layout/GridColumn/Readme.md
+++ b/src/components/layout/GridColumn/Readme.md
@@ -12,3 +12,20 @@
  </GridRow>
 </Grid>
 ```
+
+### Variations
+
+#### Has no padding
+
+```jsx
+<Grid>
+   <GridColumn width={6} hasNoPadding>
+     🔴 🔴 ⚪️ ⚪️<br />
+     🔴 🔴 ⚪️ ⚪️<br />
+   </GridColumn>
+   <GridColumn width={6}>
+     ⚪️ ⚪️ 🔴 🔴<br />
+     ⚪️ ⚪️ 🔴 🔴<br />
+   </GridColumn>
+</Grid>
+```

--- a/src/components/layout/GridColumn/component.js
+++ b/src/components/layout/GridColumn/component.js
@@ -1,24 +1,34 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Grid } from 'semantic-ui-react';
+import getClassNames from 'classnames';
 
 /**
  * GridColumn is the Lodgify UI interface for the
  * Semantic UI Grid.Column.
  */
 // eslint-disable-next-line jsdoc/require-jsdoc
-export const Component = ({ verticalAlignContent, ...props }) => (
-  <Grid.Column {...props} verticalAlign={verticalAlignContent} />
+export const Component = ({ hasNoPadding, verticalAlignContent, ...props }) => (
+  <Grid.Column
+    {...props}
+    className={getClassNames({
+      'has-no-padding': hasNoPadding,
+    })}
+    verticalAlign={verticalAlignContent}
+  />
 );
 
 Component.displayName = 'GridColumn';
 
 Component.defaultProps = {
+  hasNoPadding: false,
   verticalAlignContent: 'top',
   width: null,
 };
 
 Component.propTypes = {
+  /** Does the column have no padding */
+  hasNoPadding: PropTypes.bool,
   /** Vertically align the content of the column to the bottom, middle or top. */
   verticalAlignContent: PropTypes.oneOf(['bottom', 'middle', 'top']),
   /** The width of the column */

--- a/src/components/layout/GridColumn/component.spec.js
+++ b/src/components/layout/GridColumn/component.spec.js
@@ -29,6 +29,20 @@ describe('<GridColumn />', () => {
     });
   });
 
+  describe('when the `hasNoPadding` prop is passed', () => {
+    it('should get the right props', () => {
+      const wrapper = getGridColumn({
+        hasNoPadding: true,
+      });
+
+      expectComponentToHaveProps(wrapper, {
+        className: 'has-no-padding',
+        verticalAlign: expect.any(String),
+        width: null,
+      });
+    });
+  });
+
   it('should have displayName `GridColumn`', () => {
     expectComponentToHaveDisplayName(GridColumn, 'GridColumn');
   });

--- a/src/styles/semantic/themes/livingstone/collections/grid.overrides
+++ b/src/styles/semantic/themes/livingstone/collections/grid.overrides
@@ -15,3 +15,15 @@
     padding: (@gutterWidth / 2);
   }
 }
+
+/*******************************
+           Variations
+*******************************/
+
+/*--------------
+  Has no padding
+---------------*/
+.grid > .column.has-no-padding,
+.grid > .row > .column.has-no-padding {
+  padding: 0;
+}


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1081)

### What **one** thing does this PR do?
Adds the option to remove the GridColumn padding

### Any other notes
- The use case is for the root GridColumn in `TemplatesSSR`
-- we wrap the rows with a GridColumn to prevent the rows from being inline
-- the issue is a padding of `1rem` is applied to the top and bottom of the page
-- this update will remove this.

- This change is under `TE-1081` since it affects the work on VerticalPadding in `TemplatesSSR`