### PR TITLE
TE-1106: ensure 0 is not rendered in the social menu for the Footer

### DIFF
--- a/src/components/collections/Footer/component.js
+++ b/src/components/collections/Footer/component.js
@@ -69,7 +69,7 @@ export const Component = ({
         <Menu.Item className="is-selectable">
           <Icon labelText={phoneNumber} name={ICON_NAMES.PHONE} />
         </Menu.Item>
-        {size(socialMediaLinks) && (
+        {size(socialMediaLinks) > 0 && (
           <Menu.Menu position="right">
             {socialMediaLinks.map(({ href, iconName, iconPath }, index) => (
               <Menu.Item


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1106)

### What **one** thing does this PR do?
Ensure 0 is not rendered in the Footer if no social items exist

__Before__
<img width="710" alt="screen shot 2018-09-26 at 14 52 31" src="https://user-images.githubusercontent.com/25742275/46081095-f045d480-c19b-11e8-8bf2-69e4f46f4688.png">

__After__
<img width="720" alt="screen shot 2018-09-26 at 14 52 47" src="https://user-images.githubusercontent.com/25742275/46081102-f471f200-c19b-11e8-86f4-ef0c095b0e8d.png">
