### PR TITLE
TE-1105: if phone is empty string, do not show icon in Footer

### DIFF
--- a/src/components/collections/Footer/component.js
+++ b/src/components/collections/Footer/component.js
@@ -66,9 +66,11 @@ export const Component = ({
             willOpenAbove
           />
         </Menu.Item>
-        <Menu.Item className="is-selectable">
-          <Icon labelText={phoneNumber} name={ICON_NAMES.PHONE} />
-        </Menu.Item>
+        {!!phoneNumber && (
+          <Menu.Item className="is-selectable">
+            <Icon labelText={phoneNumber} name={ICON_NAMES.PHONE} />
+          </Menu.Item>
+        )}
         {size(socialMediaLinks) && (
           <Menu.Menu position="right">
             {socialMediaLinks.map(({ href, iconName, iconPath }, index) => (

--- a/src/components/collections/Footer/component.spec.js
+++ b/src/components/collections/Footer/component.spec.js
@@ -313,6 +313,14 @@ describe('<Footer />', () => {
         name: 'phone',
       });
     });
+
+    it('should hide the icon if the phone number is an empty string', () => {
+      const actual = getFooter({
+        phoneNumber: '',
+      }).find(Icon);
+
+      expect(actual).toHaveLength(0);
+    });
   });
 
   const getSocialMediaMenuMenu = () =>


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1105)

### What **one** thing does this PR do?
Hide phone icon if phone string is empty

__Before__
<img width="686" alt="screen shot 2018-09-26 at 15 03 33" src="https://user-images.githubusercontent.com/25742275/46081662-5b43db00-c19d-11e8-83ae-cc5ae697c0aa.png">

__After__
<img width="716" alt="screen shot 2018-09-26 at 15 03 19" src="https://user-images.githubusercontent.com/25742275/46081670-60088f00-c19d-11e8-83b6-4c942643dd72.png">

