### PR TITLE
TE-1109: children should have a higher z-index in the Hero

### DIFF
--- a/src/styles/semantic/themes/livingstone/elements/segment.overrides
+++ b/src/styles/semantic/themes/livingstone/elements/segment.overrides
@@ -88,6 +88,11 @@
 
   &.is-hero {
     flex-direction: column;
+
+    > * {
+      position: relative;
+      z-index: 1;
+    }
   }
 }
 


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1109)

### What **one** thing does this PR do?
The children in the `Hero` should appear above the background shadow

__Before__
<img width="756" alt="screen shot 2018-10-01 at 14 51 06" src="https://user-images.githubusercontent.com/25742275/46289484-822d5300-c589-11e8-851c-631c7a20a9be.png">

__After__
<img width="747" alt="screen shot 2018-10-01 at 14 51 27" src="https://user-images.githubusercontent.com/25742275/46289489-86f20700-c589-11e8-9197-f82e67c7fa37.png">

