### PR TITLE
TE-1128: Fix the Submenu click style in the Header

### DIFF
--- a/src/components/collections/Header/utils/getDesktopMenuMarkup.js
+++ b/src/components/collections/Header/utils/getDesktopMenuMarkup.js
@@ -29,6 +29,7 @@ export const getDesktopMenuMarkup = ({
         size(subItems) > 0 ? (
           <Submenu
             isMenuItem
+            isSelectedDisabled
             isSimple
             isTriggerUnderlined={index === activeNavigationItemIndex}
             isTriggeredOnHover

--- a/src/components/elements/Submenu/component.js
+++ b/src/components/elements/Submenu/component.js
@@ -7,6 +7,7 @@ import { Icon, ICON_NAMES } from 'elements/Icon';
 import { getDefaultValue } from './utils/getDefaultValue';
 import { adaptOnChange } from './utils/adaptOnChange';
 import { adaptOptions } from './utils/adaptOptions';
+import { getValueProperty } from './utils/getValueProperty';
 
 /**
  * A submenu displays grouped navigation items.
@@ -15,6 +16,7 @@ import { adaptOptions } from './utils/adaptOptions';
 export const Component = ({
   children,
   isMenuItem,
+  isSelectedDisabled,
   isTriggeredOnHover,
   isTriggerUnderlined,
   items,
@@ -35,6 +37,7 @@ export const Component = ({
     simple={isTriggeredOnHover}
     trigger={children}
     upward={willOpenAbove}
+    {...getValueProperty(isSelectedDisabled)}
   />
 );
 
@@ -43,6 +46,7 @@ Component.displayName = 'Submenu';
 Component.defaultProps = {
   children: null,
   isMenuItem: false,
+  isSelectedDisabled: false,
   isTriggeredOnHover: false,
   isTriggerUnderlined: false,
   name: null,
@@ -56,6 +60,8 @@ Component.propTypes = {
   children: PropTypes.string,
   /** Is it an item in a Semantic UI Menu.  */
   isMenuItem: PropTypes.bool,
+  /** Is the selected state disabled */
+  isSelectedDisabled: PropTypes.bool,
   /** Is the trigger underlined for emphasis.  */
   isTriggerUnderlined: PropTypes.bool,
   /** Is it triggered on hover rather than click.  */

--- a/src/components/elements/Submenu/component.spec.js
+++ b/src/components/elements/Submenu/component.spec.js
@@ -47,6 +47,16 @@ describe('<Submenu />', () => {
       });
     });
 
+    it('should get `isSelectedDisabled` to set the `value` to `-999`', () => {
+      const wrapper = getSubmenuDropdown({
+        isSelectedDisabled: true,
+      });
+
+      expectComponentToHaveProps(wrapper, {
+        value: -999,
+      });
+    });
+
     it('should get `props.className` `underlined` if required', () => {
       const wrapper = getSubmenuDropdown({ isTriggerUnderlined: true });
 

--- a/src/components/elements/Submenu/utils/getValueProp.js
+++ b/src/components/elements/Submenu/utils/getValueProp.js
@@ -1,0 +1,9 @@
+/**
+ * @param {boolean} isSelectedDisabled
+ */
+export const getValueProp = isSelectedDisabled =>
+  isSelectedDisabled
+    ? {
+        value: -999,
+      }
+    : {};

--- a/src/components/elements/Submenu/utils/getValueProperty.js
+++ b/src/components/elements/Submenu/utils/getValueProperty.js
@@ -1,7 +1,7 @@
 /**
  * @param {boolean} isSelectedDisabled
  */
-export const getValueProp = isSelectedDisabled =>
+export const getValueProperty = isSelectedDisabled =>
   isSelectedDisabled
     ? {
         value: -999,

--- a/src/components/elements/Submenu/utils/getValueProperty.spec.js
+++ b/src/components/elements/Submenu/utils/getValueProperty.spec.js
@@ -1,0 +1,19 @@
+import { getValueProperty } from './getValueProperty';
+
+describe('getValueProperty', () => {
+  describe('`isSelectedDisabled`', () => {
+    it('is true then return an object with value', () => {
+      const actual = getValueProperty(true);
+
+      expect(actual).toEqual({
+        value: -999,
+      });
+    });
+
+    it('is false then return an empty object', () => {
+      const actual = getValueProperty(false);
+
+      expect(actual).toEqual({});
+    });
+  });
+});

--- a/src/components/elements/Submenu/utils/getValueProperty.spec.js
+++ b/src/components/elements/Submenu/utils/getValueProperty.spec.js
@@ -2,7 +2,7 @@ import { getValueProperty } from './getValueProperty';
 
 describe('getValueProperty', () => {
   describe('`isSelectedDisabled`', () => {
-    it('is true then return an object with value', () => {
+    it('should return an object with value if isSelectedDisabled is true', () => {
       const actual = getValueProperty(true);
 
       expect(actual).toEqual({
@@ -10,7 +10,7 @@ describe('getValueProperty', () => {
       });
     });
 
-    it('is false then return an empty object', () => {
+    it('should return an empty object if isSelectedDisabled is false', () => {
       const actual = getValueProperty(false);
 
       expect(actual).toEqual({});


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1128)

### What **one** thing does this PR do?
Fixes the selected state being applied when a link is clicked in the `Dropdown` menu in the `Header`

### Any other notes
- The `Dropdown` component is meant to return with a selected value, it is not meant to contain a link
- The solution was to add an option to set the value of the dropdown and to ensure the value never changed, to achieve this, I just set a numeric value that wouldn't match the existing options
- Another important rule to follow here was to only apply the value prop if the value prop was to be set to disable the options, this introduced the get value property utility in the `Submenu`

### Previews

*Please note that the white page is displayed after the click because the page does not exist

__Before__
![kapture 2018-10-02 at 12 16 43](https://user-images.githubusercontent.com/25742275/46343165-2de3ab00-c63d-11e8-83e2-839b7463c76d.gif)

__After__
![kapture 2018-10-02 at 12 15 56](https://user-images.githubusercontent.com/25742275/46343176-3340f580-c63d-11e8-92ad-b68375b3f182.gif)

