### PR TITLE
TE-1138: ensure the condition does not leak in the PropertyPageHero

### DIFF
--- a/src/utils/get-gallery-heading-markup/getGalleryHeadingMarkup.js
+++ b/src/utils/get-gallery-heading-markup/getGalleryHeadingMarkup.js
@@ -12,6 +12,6 @@ export const getGalleryHeadingMarkup = (propertyName, ratingNumber) =>
   propertyName && (
     <Fragment>
       <Heading>{propertyName}</Heading>
-      {ratingNumber && <Rating ratingNumber={ratingNumber} />}
+      {ratingNumber > 0 && <Rating ratingNumber={ratingNumber} />}
     </Fragment>
   );


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-X)

### What **one** thing does this PR do?
Ensure if the rating value is 0, the 0 does not appear in the `PropertyPageHero`

__Before__
<img width="914" alt="screen shot 2018-10-03 at 15 05 01" src="https://user-images.githubusercontent.com/25742275/46412209-221be580-c71e-11e8-97b1-b865ef50201f.png">

__After__
<img width="888" alt="screen shot 2018-10-03 at 15 05 27" src="https://user-images.githubusercontent.com/25742275/46412219-28aa5d00-c71e-11e8-8bf9-f2350704b926.png">

