### PR TITLE
TE-1111: textAlign value default to null for Heading

### DIFF
--- a/src/components/typography/Heading/component.js
+++ b/src/components/typography/Heading/component.js
@@ -24,7 +24,7 @@ Component.displayName = 'Heading';
 
 Component.defaultProps = {
   isColorInverted: false,
-  textAlign: 'left',
+  textAlign: null,
   size: 'medium',
 };
 


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1111)

### What **one** thing does this PR do?
Set the default value for textAlign to null

### Previews on where the default was being applied

__Before__
![screen shot 2018-10-03 at 15 19 55](https://user-images.githubusercontent.com/25742275/46412855-f699fa80-c71f-11e8-9736-bfa098564ab5.png)

__After__
![screen shot 2018-10-03 at 15 19 31](https://user-images.githubusercontent.com/25742275/46412865-fbf74500-c71f-11e8-9400-01dd5bf24d36.png)
