### PR TITLE
TE-1152: In Hero the Header dropdown should be above the content

### DIFF
--- a/src/styles/semantic/themes/livingstone/elements/segment.overrides
+++ b/src/styles/semantic/themes/livingstone/elements/segment.overrides
@@ -91,7 +91,11 @@
 
     > * {
       position: relative;
-      z-index: 1;
+      z-index: @heroContentZIndex;
+    }
+
+    > header {
+      z-index: @heroContentZIndex + 1;
     }
   }
 }

--- a/src/styles/semantic/themes/livingstone/elements/segment.variables
+++ b/src/styles/semantic/themes/livingstone/elements/segment.variables
@@ -77,3 +77,6 @@
 @promotionBeforeLayerZIndex: 1;
 @promotionAfterLayerZIndex: 2;
 @promotionContentLayerZIndex: 3;
+
+/* Is Hero */
+@heroContentZIndex: 1;


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1152)

### What **one** thing does this PR do?
Ensure the Header is above the content in the `Hero`

__Before__
![kapture 2018-10-04 at 15 34 48](https://user-images.githubusercontent.com/25742275/46477691-822c8d80-c7eb-11e8-92ec-c261e92a8873.gif)

__After__
![after](https://user-images.githubusercontent.com/25742275/46477719-95d7f400-c7eb-11e8-9d3f-b993a793aa40.gif)

