### PR TITLE
TE-1164: Cleanup the mobile version of `RoomType`

### DIFF
--- a/src/components/elements/Icon/component.js
+++ b/src/components/elements/Icon/component.js
@@ -30,6 +30,7 @@ export const Component = ({
       circular: isCircular,
       'has-border': hasBorder,
       'inverted grey': isDisabled,
+      'has-label': !!labelText,
       inverted: isColorInverted,
     })}
     // Passing through props is required for

--- a/src/components/elements/Icon/component.spec.js
+++ b/src/components/elements/Icon/component.spec.js
@@ -41,6 +41,18 @@ describe('<Icon />', () => {
       });
     });
 
+    it('should get the right props if `labelText` is passed', () => {
+      const wrapper = getIcon({
+        labelText: 'hello world',
+      });
+      const { color, size } = props;
+
+      expectComponentToHaveProps(wrapper, {
+        className: `icon ${color} ${size} circular has-border inverted grey has-label inverted`,
+        some: 'otherProps',
+      });
+    });
+
     it('should have the right children', () => {
       const wrapper = getIcon();
 

--- a/src/components/property-page-widgets/RoomType/component.js
+++ b/src/components/property-page-widgets/RoomType/component.js
@@ -75,7 +75,8 @@ const Component = ({
                   name,
                   nightPrice,
                   ratingNumber,
-                  slideShowImages
+                  slideShowImages,
+                  isUserOnMobile
                 )}
               </Modal>
             </GridColumn>
@@ -95,7 +96,8 @@ const Component = ({
                     name,
                     nightPrice,
                     ratingNumber,
-                    slideShowImages
+                    slideShowImages,
+                    isUserOnMobile
                   )}
                 </Modal>
               </GridColumn>

--- a/src/components/property-page-widgets/RoomType/component.spec.js
+++ b/src/components/property-page-widgets/RoomType/component.spec.js
@@ -205,7 +205,7 @@ describe('<RoomType />', () => {
         wrapper,
         GridColumn,
         GridColumn,
-        List,
+        GridColumn,
         GridRow
       );
     });
@@ -288,6 +288,23 @@ describe('<RoomType />', () => {
       const wrapper = getFifthGridColumn();
 
       expectComponentToHaveProps(wrapper, {
+        floated: 'left',
+        horizontal: true,
+        as: List,
+      });
+    });
+  });
+
+  describe('the sixth `GridColumn`', () => {
+    const getSixthGridColumn = () =>
+      getWrappedRoomType()
+        .find(GridColumn)
+        .at(6);
+
+    it('should have the right props', () => {
+      const wrapper = getSixthGridColumn();
+
+      expectComponentToHaveProps(wrapper, {
         only: 'tablet computer',
         verticalAlignContent: 'bottom',
         width: 4,
@@ -295,7 +312,7 @@ describe('<RoomType />', () => {
     });
 
     it('should have the right children', () => {
-      const wrapper = getFifthGridColumn();
+      const wrapper = getSixthGridColumn();
 
       expectComponentToHaveChildren(wrapper, Modal);
     });
@@ -314,20 +331,20 @@ describe('<RoomType />', () => {
     });
   });
 
-  describe('the sixth `GridColumn`', () => {
-    const getSixthGridColumn = () =>
+  describe('the seventh `GridColumn`', () => {
+    const getSeventhGridColumn = () =>
       getWrappedRoomType()
         .find(GridColumn)
-        .at(7);
+        .at(8);
 
     it('should have the right props', () => {
-      const wrapper = getSixthGridColumn();
+      const wrapper = getSeventhGridColumn();
 
       expectComponentToHaveProps(wrapper, { textAlign: 'right' });
     });
 
     it('should render the right children', () => {
-      const wrapper = getSixthGridColumn();
+      const wrapper = getSeventhGridColumn();
 
       expectComponentToHaveChildren(wrapper, Card.Description, ShowOnMobile);
     });

--- a/src/components/property-page-widgets/RoomType/utils/getModalContentMarkup.js
+++ b/src/components/property-page-widgets/RoomType/utils/getModalContentMarkup.js
@@ -20,6 +20,7 @@ import { Slideshow } from 'media/Slideshow';
  * @param  {string}      nightPrice
  * @param  {number}      ratingNumber
  * @param  {Object[]}    slideShowImages
+ * @param  {boolean}     isUserOnMobile
  * @return {Object}
  */
 export const getModalContentMarkup = (
@@ -30,7 +31,8 @@ export const getModalContentMarkup = (
   name,
   nightPrice,
   ratingNumber,
-  slideShowImages
+  slideShowImages,
+  isUserOnMobile
 ) => (
   <Modal.Content>
     <Heading>{name}</Heading>
@@ -46,7 +48,11 @@ export const getModalContentMarkup = (
       ))}
     </List>
     <Divider hasLine />
-    <Amenities amenities={amenities} headingText="Room Amenities" />
+    <Amenities
+      amenities={amenities}
+      headingText="Room Amenities"
+      isStacked={isUserOnMobile}
+    />
     <Grid>
       <GridColumn verticalAlignContent="bottom" width={12}>
         <Paragraph>

--- a/src/components/property-page-widgets/RoomType/utils/getRoomFeaturesMarkup.js
+++ b/src/components/property-page-widgets/RoomType/utils/getRoomFeaturesMarkup.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { List } from 'semantic-ui-react';
 
+import { GridColumn } from 'layout/GridColumn';
 import { Icon } from 'elements/Icon';
 import { Paragraph } from 'typography/Paragraph';
 
@@ -10,7 +11,12 @@ import { Paragraph } from 'typography/Paragraph';
  * @return {Object}
  */
 export const getRoomFeaturesMarkup = (showIcons, features) => (
-  <List floated="left" horizontal>
+  <GridColumn
+    as={List}
+    className="only-horizontal-padding"
+    floated="left"
+    horizontal
+  >
     {features.map((infoItem, index) => (
       <List.Item key={index}>
         {showIcons ? (
@@ -24,5 +30,5 @@ export const getRoomFeaturesMarkup = (showIcons, features) => (
         )}
       </List.Item>
     ))}
-  </List>
+  </GridColumn>
 );

--- a/src/components/property-page-widgets/RoomType/utils/getRoomFeaturesMarkup.spec.js
+++ b/src/components/property-page-widgets/RoomType/utils/getRoomFeaturesMarkup.spec.js
@@ -7,6 +7,7 @@ import {
 } from '@lodgify/enzyme-jest-expect-helpers';
 import { List } from 'semantic-ui-react';
 
+import { GridColumn } from 'layout/GridColumn';
 import { getArrayOfLengthOfItem } from 'utils/get-array-of-length-of-item';
 import { Paragraph } from 'typography/Paragraph';
 import { Icon } from 'elements/Icon';
@@ -23,7 +24,7 @@ const getMarkup = (isUserOnMobile = false) =>
   shallow(<div>{getRoomFeaturesMarkup(isUserOnMobile, features)}</div>);
 
 describe('`getRoomFeaturesMarkup`', () => {
-  const getList = () => getMarkup().find(List);
+  const getList = () => getMarkup().find(GridColumn);
 
   it('should return a single wrapping `div`', () => {
     const wrapper = getMarkup();
@@ -37,6 +38,8 @@ describe('`getRoomFeaturesMarkup`', () => {
     expectComponentToHaveProps(wrapper, {
       floated: 'left',
       horizontal: true,
+      as: List,
+      className: 'only-horizontal-padding',
     });
   });
 

--- a/src/styles/semantic/themes/livingstone/collections/grid.overrides
+++ b/src/styles/semantic/themes/livingstone/collections/grid.overrides
@@ -15,3 +15,14 @@
     padding: (@gutterWidth / 2);
   }
 }
+
+/*--------------
+   Variations
+---------------*/
+
+/*
+  Column with only horizontal padding
+*/
+.ui.grid > .column.only-horizontal-padding {
+  padding: 0 (@gutterWidth / 2);
+}

--- a/src/styles/semantic/themes/livingstone/elements/icon.overrides
+++ b/src/styles/semantic/themes/livingstone/elements/icon.overrides
@@ -52,6 +52,15 @@ i.icon {
     }
   }
 
+  &.has-label {
+    height: auto;
+    min-height: @height;
+
+    p {
+      display: inline;
+    }
+  }
+
   /*-------------------
         Colors
   --------------------*/


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1164)

### What **one** thing does this PR do?
Cleans up the mobile appearance of the `RoomType`

__Ideally review commit by commit__

### Any other notes
- Stacks the GridColumns for Amenities on mobile
- Improves the padding around the list items
- Allows for content in the icon to expand

### Previews

#### Before
<img width="522" alt="screen shot 2018-10-08 at 10 55 27" src="https://user-images.githubusercontent.com/25742275/46604909-0d619800-caf8-11e8-8f32-da97a46edcc4.png">
<img width="692" alt="screen shot 2018-10-08 at 11 50 47" src="https://user-images.githubusercontent.com/25742275/46604916-105c8880-caf8-11e8-99f7-1bad91784653.png">

#### After
<img width="638" alt="screen shot 2018-10-08 at 12 46 54" src="https://user-images.githubusercontent.com/25742275/46604990-469a0800-caf8-11e8-98f4-898acb79e008.png">
<img width="667" alt="screen shot 2018-10-08 at 12 46 35" src="https://user-images.githubusercontent.com/25742275/46604991-469a0800-caf8-11e8-9c04-67814728bc41.png">
<img width="473" alt="screen shot 2018-10-08 at 12 46 16" src="https://user-images.githubusercontent.com/25742275/46604992-47329e80-caf8-11e8-8475-deb9fcc845dc.png">

