### PR TITLE
TE-1168: Add the `RoomTypes` component

### DIFF
--- a/src/components/collections/Footer/component.js
+++ b/src/components/collections/Footer/component.js
@@ -167,11 +167,11 @@ Component.propTypes = {
     PropTypes.shape({
       /** The href url pointing to the social media account. */
       href: PropTypes.string,
-      /** The name of the icon to display. Can be any allowed name for the [`Icon` element](/#!/Icon)
+      /** The name of the icon to display. Can be any allowed name for the [`Icon` element](#/Icon)
        * [See here for the full list of valid icon names](https://github.com/lodgify/lodgify-ui/blob/production/src/components/elements/Icon/constants.js)
        */
       iconName: PropTypes.string,
-      /** The path of the icon to display. See [`Icon` props](/#!/Icon) for guidance. */
+      /** The path of the icon to display. See [`Icon` props](#/Icon) for guidance. */
       iconPath: PropTypes.string,
     })
   ),

--- a/src/components/general-widgets/FeaturedProperties/component.js
+++ b/src/components/general-widgets/FeaturedProperties/component.js
@@ -38,7 +38,7 @@ Component.defaultProps = {
 };
 
 Component.propTypes = {
-  /** An array of [`FeaturedProperty`](/#!/FeaturedProperty) props objects. */
+  /** An array of [`FeaturedProperty`](#/FeaturedProperty) props objects. */
   featuredProperties: PropTypes.arrayOf(PropTypes.object).isRequired,
   /** The text to display as a heading at the top of the widget. */
   headingText: PropTypes.string,

--- a/src/components/general-widgets/FeaturedRoomTypes/component.js
+++ b/src/components/general-widgets/FeaturedRoomTypes/component.js
@@ -38,7 +38,7 @@ Component.defaultProps = {
 };
 
 Component.propTypes = {
-  /** An array of [`FeaturedRoomType`](/#!/FeaturedRoomType) props objects. */
+  /** An array of [`FeaturedRoomType`](#/FeaturedRoomType) props objects. */
   featuredRoomTypes: PropTypes.arrayOf(PropTypes.object).isRequired,
   /** The text to display as a heading at the top of the widget. */
   headingText: PropTypes.string,

--- a/src/components/property-page-widgets/RoomTypes/Readme.md
+++ b/src/components/property-page-widgets/RoomTypes/Readme.md
@@ -1,0 +1,7 @@
+```jsx
+const { roomTypes } = require('./mock-data/roomTypes');
+
+<RoomTypes
+  roomTypes={roomTypes}
+/>
+```

--- a/src/components/property-page-widgets/RoomTypes/component.js
+++ b/src/components/property-page-widgets/RoomTypes/component.js
@@ -19,6 +19,6 @@ export const Component = ({ roomTypes }) => (
 Component.displayName = 'RoomTypes';
 
 Component.propTypes = {
-  /** An array of [`RoomType`](#/Property%20page%20widgets/RoomType) props objects */
+  /** An array of [`RoomType`](#/RoomType) props objects */
   roomTypes: PropTypes.arrayOf(PropTypes.object).isRequired,
 };

--- a/src/components/property-page-widgets/RoomTypes/component.js
+++ b/src/components/property-page-widgets/RoomTypes/component.js
@@ -1,0 +1,24 @@
+import React, { Fragment } from 'react';
+import PropTypes from 'prop-types';
+
+import { RoomType } from 'property-page-widgets/RoomType';
+import { buildKeyFromStrings } from 'utils/build-key-from-strings';
+
+/**
+ * The standard widget for displaying a list of room types.
+ */
+// eslint-disable-next-line jsdoc/require-jsdoc
+export const Component = ({ roomTypes }) => (
+  <Fragment>
+    {roomTypes.map((roomType, index) => (
+      <RoomType key={buildKeyFromStrings(roomType.name, index)} {...roomType} />
+    ))}
+  </Fragment>
+);
+
+Component.displayName = 'RoomTypes';
+
+Component.propTypes = {
+  /** An array of [`RoomType`](#/Property%20page%20widgets/RoomType) props objects */
+  roomTypes: PropTypes.arrayOf(PropTypes.object).isRequired,
+};

--- a/src/components/property-page-widgets/RoomTypes/component.spec.js
+++ b/src/components/property-page-widgets/RoomTypes/component.spec.js
@@ -1,0 +1,36 @@
+import React, { Fragment } from 'react';
+import { shallow } from 'enzyme';
+import {
+  expectComponentToBe,
+  expectComponentToHaveChildren,
+  expectComponentToHaveDisplayName,
+} from '@lodgify/enzyme-jest-expect-helpers';
+
+import { RoomType } from 'property-page-widgets/RoomType';
+
+import { Component as RoomTypes } from './component';
+
+const { roomTypes } = require('./mock-data/roomTypes');
+
+const getRoomTypes = otherProps =>
+  shallow(<RoomTypes roomTypes={roomTypes} {...otherProps} />);
+
+describe('<FeaturedRoomTypes />', () => {
+  it('should have `Fragment` component as a wrapper', () => {
+    const wrapper = getRoomTypes();
+
+    expectComponentToBe(wrapper, Fragment);
+  });
+
+  describe('the wrapping `Fragment`', () => {
+    it('should render the right children', () => {
+      const wrapper = getRoomTypes();
+
+      expectComponentToHaveChildren(wrapper, RoomType, RoomType);
+    });
+  });
+
+  it('should have `displayName` `RoomTypes`', () => {
+    expectComponentToHaveDisplayName(RoomTypes, 'RoomTypes');
+  });
+});

--- a/src/components/property-page-widgets/RoomTypes/index.js
+++ b/src/components/property-page-widgets/RoomTypes/index.js
@@ -1,0 +1,1 @@
+export { Component as RoomTypes } from './component';

--- a/src/components/property-page-widgets/RoomTypes/mock-data/roomTypes.js
+++ b/src/components/property-page-widgets/RoomTypes/mock-data/roomTypes.js
@@ -1,0 +1,83 @@
+export const roomTypes = [
+  {
+    bathroomsNumber: 2,
+    bedsNumber: 3,
+    description: 'Description goes here',
+    guestsNumber: 3,
+    nightPrice: '$280',
+    name: 'The Cat House',
+    ratingNumber: 3.4,
+    onClickCheckAvailability: Function.prototype,
+    features: [
+      { iconName: 'double bed', labelText: '1 Bedroom' },
+      { iconName: 'guests', labelText: '2 Guests' },
+      { iconName: 'bathroom', labelText: '1 Bathroom' },
+    ],
+    extraFeatures: [],
+    slideShowImages: [
+      {
+        alternativeText: 'Two more cats',
+        url:
+          'https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg',
+        title: 'Two more cats',
+      },
+      {
+        alternativeText: 'Some cats',
+        url:
+          'https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg',
+        title: 'Some cats',
+      },
+    ],
+    checkAvailability: Function.prototype,
+    amenities: [
+      {
+        name: 'Cooking',
+        iconName: 'leaf',
+        items: ['Toaster', 'Microwave', 'Coffee Machine'],
+      },
+      {
+        name: 'Bathroom & Laundry',
+        iconName: 'paw',
+        items: ['Bidet', 'Hair Dryer', 'Iron & Board'],
+      },
+    ],
+  },
+  {
+    bathroomsNumber: 2,
+    bedsNumber: 3,
+    description: 'Description goes here',
+    guestsNumber: 3,
+    nightPrice: '$280',
+    name: 'The Other Cat House',
+    ratingNumber: 3.4,
+    onClickCheckAvailability: Function.prototype,
+    features: [
+      { iconName: 'double bed', labelText: '1 Bedroom' },
+      { iconName: 'guests', labelText: '2 Guests' },
+      { iconName: 'bathroom', labelText: '1 Bathroom' },
+    ],
+    extraFeatures: [],
+    slideShowImages: [
+      {
+        alternativeText: 'Two more cats',
+        url:
+          'https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg',
+        title: 'Two more cats',
+      },
+      {
+        alternativeText: 'Some cats',
+        url:
+          'https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg',
+        title: 'Some cats',
+      },
+    ],
+    checkAvailability: Function.prototype,
+    amenities: [
+      {
+        name: 'Cooking',
+        iconName: 'leaf',
+        items: ['Toaster', 'Microwave', 'Coffee Machine'],
+      },
+    ],
+  },
+];

--- a/src/index.js
+++ b/src/index.js
@@ -87,6 +87,7 @@ export {
 } from './components/property-page-widgets/PropertyPageHero';
 export { Pictures } from './components/property-page-widgets/Pictures';
 export { RoomType } from './components/property-page-widgets/RoomType';
+export { RoomTypes } from './components/property-page-widgets/RoomTypes';
 export { Rates } from './components/property-page-widgets/Rates';
 export { Reviews } from './components/property-page-widgets/Reviews';
 export { Rules } from './components/property-page-widgets/Rules';


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1168)

### What **one** thing does this PR do?
Adds the `RoomTypes` component to display a collection of `RoomType`

### Any other notes

__Preview__
<img width="697" alt="screen shot 2018-10-08 at 15 53 42" src="https://user-images.githubusercontent.com/25742275/46613091-a69da800-cb12-11e8-9313-f11e7fb7d29b.png">

