### PR TITLE
TE-1171: use the responsive wrapper when rendering thumbnails in Pictures

### DIFF
--- a/src/components/property-page-widgets/Pictures/component.js
+++ b/src/components/property-page-widgets/Pictures/component.js
@@ -1,14 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { withResponsive } from 'utils/with-responsive';
 import { EXPLORE_ALL_PICTURES, PROPERTY_PICTURES } from 'utils/default-strings';
 import { getFirstSixItems } from 'utils/get-first-six-items';
 import { buildKeyFromStrings } from 'utils/build-key-from-strings';
 import { Grid } from 'layout/Grid';
 import { GridRow } from 'layout/GridRow';
 import { GridColumn } from 'layout/GridColumn';
-import { ShowOnDesktop } from 'layout/ShowOnDesktop';
-import { ShowOnMobile } from 'layout/ShowOnMobile';
 import { Divider } from 'elements/Divider';
 import { Thumbnail } from 'media/Thumbnail';
 import { Heading } from 'typography/Heading';
@@ -22,6 +21,7 @@ import { Link } from 'elements/Link';
 // eslint-disable-next-line jsdoc/require-jsdoc
 export const Component = ({
   headingText,
+  isUserOnMobile,
   linkText,
   pictures,
   propertyName,
@@ -34,18 +34,13 @@ export const Component = ({
     <GridRow>
       {getFirstSixItems(pictures).map(({ imageUrl, label }, index) => (
         <GridColumn key={buildKeyFromStrings(label, index)}>
-          <ShowOnDesktop>
-            <Thumbnail imageUrl={imageUrl} label={label} size="huge" />
-          </ShowOnDesktop>
-          <ShowOnMobile>
-            <Thumbnail
-              hasRoundedCorners
-              imageUrl={imageUrl}
-              isSquare
-              label={label}
-              size="large"
-            />
-          </ShowOnMobile>
+          <Thumbnail
+            hasRoundedCorners={isUserOnMobile}
+            imageUrl={imageUrl}
+            isSquare={isUserOnMobile}
+            label={label}
+            size={isUserOnMobile ? 'large' : 'huge'}
+          />
           <Divider size="small" />
         </GridColumn>
       ))}
@@ -72,6 +67,12 @@ Component.defaultProps = {
 Component.propTypes = {
   /** The text to display as a heading at the top of the widget. */
   headingText: PropTypes.string,
+  /**
+   * Is the user on a mobile device.
+   * Provided by `withResponsive` so ignored in the styleguide.
+   * @ignore
+   */
+  isUserOnMobile: PropTypes.bool.isRequired,
   /** The text to display on the link at the bottom of the widget. */
   linkText: PropTypes.string,
   /** The pictures to display as responsive images. */
@@ -88,3 +89,5 @@ Component.propTypes = {
   /** The numeral rating for the property, out of 5 */
   ratingNumber: PropTypes.number,
 };
+
+export const ComponentWithResponsive = withResponsive(Component);

--- a/src/components/property-page-widgets/Pictures/component.spec.js
+++ b/src/components/property-page-widgets/Pictures/component.spec.js
@@ -12,28 +12,36 @@ import { getArrayOfLengthOfItem } from 'utils/get-array-of-length-of-item';
 import { Grid } from 'layout/Grid';
 import { GridRow } from 'layout/GridRow';
 import { GridColumn } from 'layout/GridColumn';
-import { ShowOnMobile } from 'layout/ShowOnMobile';
 import { Divider } from 'elements/Divider';
-import { ShowOnDesktop } from 'layout/ShowOnDesktop';
 import { Heading } from 'typography/Heading';
 import { Gallery } from 'media/Gallery';
 import { Link } from 'elements/Link';
 import { Thumbnail } from 'media/Thumbnail';
 
 import { pictures } from './mock-data/pictures';
-import { Component as Pictures } from './component';
+import { ComponentWithResponsive as Pictures } from './component';
 
-const getPictures = () => shallow(<Pictures pictures={pictures} />);
+const props = {
+  pictures,
+};
+
+const getPictures = () => shallow(<Pictures {...props} />);
+
+const getWrappedPictures = extraProps => {
+  const Child = getPictures().prop('as');
+
+  return shallow(<Child isUserOnMobile={false} {...props} {...extraProps} />);
+};
 
 describe('<Pictures />', () => {
   it('should have `Grid` component as a wrapper', () => {
-    const wrapper = getPictures();
+    const wrapper = getWrappedPictures();
 
     expectComponentToBe(wrapper, Grid);
   });
 
   describe('the `Grid` component', () => {
-    const getGrid = () => getPictures().find(Grid);
+    const getGrid = () => getWrappedPictures().find(Grid);
 
     it('should have the right props', () => {
       const wrapper = getGrid();
@@ -50,7 +58,7 @@ describe('<Pictures />', () => {
 
   describe('the first `GridColumn` component', () => {
     const getFirstGridColumn = () =>
-      getPictures()
+      getWrappedPictures()
         .find(GridColumn)
         .first();
 
@@ -71,7 +79,7 @@ describe('<Pictures />', () => {
 
   describe('the `Heading` component', () => {
     it('should render the right children', () => {
-      const wrapper = getPictures().find(Heading);
+      const wrapper = getWrappedPictures().find(Heading);
 
       expectComponentToHaveChildren(wrapper, PROPERTY_PICTURES);
     });
@@ -79,7 +87,7 @@ describe('<Pictures />', () => {
 
   describe('the `GridRow`', () => {
     it('should have the right children', () => {
-      const wrapper = getPictures().find(GridRow);
+      const wrapper = getWrappedPictures().find(GridRow);
 
       expectComponentToHaveChildren(
         wrapper,
@@ -90,35 +98,17 @@ describe('<Pictures />', () => {
 
   describe('each of the array of `GridColumn`s', () => {
     it('should render the right children', () => {
-      const wrapper = getPictures()
+      const wrapper = getWrappedPictures()
         .find(GridColumn)
         .at(1);
 
-      expectComponentToHaveChildren(
-        wrapper,
-        ShowOnDesktop,
-        ShowOnMobile,
-        Divider
-      );
+      expectComponentToHaveChildren(wrapper, Thumbnail, Divider);
     });
   });
 
-  describe('each of the array of `ShowOnDesktop`s', () => {
-    const getShowOnDesktopInArray = () =>
-      getPictures()
-        .find(ShowOnDesktop)
-        .at(0);
-
-    it('should render the right children', () => {
-      const wrapper = getShowOnDesktopInArray();
-
-      expectComponentToHaveChildren(wrapper, Thumbnail);
-    });
-  });
-
-  describe('each `Thumbnail` component', () => {
+  describe('each `Thumbnail` component on desktop', () => {
     it('should get the right props', () => {
-      const wrapper = getPictures()
+      const wrapper = getWrappedPictures()
         .find(Thumbnail)
         .at(0);
       const { imageUrl, label } = pictures[0];
@@ -126,29 +116,20 @@ describe('<Pictures />', () => {
       expectComponentToHaveProps(wrapper, {
         imageUrl,
         label,
+        hasRoundedCorners: false,
+        isSquare: false,
         size: 'huge',
       });
     });
   });
 
-  describe('each of the array of `ShowOnMobile`s', () => {
-    const getShowOnMobileInArray = () =>
-      getPictures()
-        .find(ShowOnMobile)
-        .at(0);
-
-    it('should render the right children', () => {
-      const wrapper = getShowOnMobileInArray();
-
-      expectComponentToHaveChildren(wrapper, Thumbnail);
-    });
-  });
-
-  describe('each `Thumbnail` component', () => {
+  describe('each `Thumbnail` component on mobile', () => {
     it('should get the right props', () => {
-      const wrapper = getPictures()
+      const wrapper = getWrappedPictures({
+        isUserOnMobile: true,
+      })
         .find(Thumbnail)
-        .at(1);
+        .at(0);
       const { imageUrl, label } = pictures[0];
 
       expectComponentToHaveProps(wrapper, {
@@ -163,7 +144,7 @@ describe('<Pictures />', () => {
 
   describe('the `GridColumn` component wrapping the link', () => {
     const getGridColumnWithLink = () =>
-      getPictures()
+      getWrappedPictures()
         .find(GridColumn)
         .at(6);
 
@@ -184,7 +165,7 @@ describe('<Pictures />', () => {
 
   describe('the `Gallery` component', () => {
     it('should have the right props', () => {
-      const wrapper = getPictures().find(Gallery);
+      const wrapper = getWrappedPictures().find(Gallery);
 
       expectComponentToHaveProps(wrapper, {
         heading: expect.any(Object),
@@ -195,6 +176,8 @@ describe('<Pictures />', () => {
   });
 
   it('should have `displayName` `Pictures`', () => {
-    expectComponentToHaveDisplayName(Pictures, 'Pictures');
+    const component = getPictures().prop('as');
+
+    expectComponentToHaveDisplayName(component, 'Pictures');
   });
 });

--- a/src/components/property-page-widgets/Pictures/index.js
+++ b/src/components/property-page-widgets/Pictures/index.js
@@ -1,1 +1,1 @@
-export { Component as Pictures } from './component';
+export { ComponentWithResponsive as Pictures } from './component';


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1171)

### What **one** thing does this PR do?
Refactor the `Pictures` component to use the `withResponsive` wrapper

### Any other notes
This update should fix an issue we are having in `templatesSSR`
- When the page is rendered we are getting the mobile version of the component instead of the desktop version.
- From looking into the SemanticUI `Responsive` component, I can see the correct component being returned when the desktop version is to be shown.
- But React does not render the desktop version, instead, it keeps the mobile version in the DOM.
- So i think using the `withResponsive` to replace the attributes in the `Thumbnail` should trigger the DOM to update these components.
- I have tested this as much as I could using TemplatesSSR, but I won't be sure until this has been published.

__Before__
We get the mobile version of `Pictures` when the desktop version is rendered.

__After__
We get the correct version depending on the viewport size
