### PR TITLE
TE-1170: Move the close icon in the Gallery

### DIFF
--- a/src/components/media/Gallery/component.js
+++ b/src/components/media/Gallery/component.js
@@ -1,5 +1,6 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
+import getClassNames from 'classnames';
 
 import { Modal } from 'elements/Modal';
 import { HorizontalGutters } from 'layout/HorizontalGutters';
@@ -16,7 +17,13 @@ import { ResponsiveImage } from 'media/ResponsiveImage';
  */
 // eslint-disable-next-line jsdoc/require-jsdoc
 export const Component = ({ heading, images, trigger }) => (
-  <Modal isFullscreen trigger={trigger}>
+  <Modal
+    className={getClassNames('with-horizontal-gutters', {
+      'with-heading': !!heading,
+    })}
+    isFullscreen
+    trigger={trigger}
+  >
     <HorizontalGutters>
       <Divider />
       {heading && (
@@ -28,7 +35,10 @@ export const Component = ({ heading, images, trigger }) => (
       <Grid columns={2} stackable>
         <GridRow>
           {images.map(({ label, ...otherImageProps }, index) => (
-            <GridColumn key={buildKeyFromStrings(label, index)}>
+            <GridColumn
+              className={`grid-column-${index}`}
+              key={buildKeyFromStrings(label, index)}
+            >
               <Heading size="small">{label}</Heading>
               <ResponsiveImage {...otherImageProps} />
               <Divider />

--- a/src/components/media/Gallery/component.js
+++ b/src/components/media/Gallery/component.js
@@ -1,6 +1,5 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
-import getClassNames from 'classnames';
 
 import { Modal } from 'elements/Modal';
 import { HorizontalGutters } from 'layout/HorizontalGutters';
@@ -17,13 +16,7 @@ import { ResponsiveImage } from 'media/ResponsiveImage';
  */
 // eslint-disable-next-line jsdoc/require-jsdoc
 export const Component = ({ heading, images, trigger }) => (
-  <Modal
-    className={getClassNames('with-horizontal-gutters', {
-      'with-heading': !!heading,
-    })}
-    isFullscreen
-    trigger={trigger}
-  >
+  <Modal isFullscreen trigger={trigger}>
     <HorizontalGutters>
       <Divider />
       {heading && (

--- a/src/components/property-page-widgets/Pictures/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Pictures/__snapshots__/component.spec.js.snap
@@ -831,6 +831,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                             horizontalAlignContent="left"
                           >
                             <GridColumn
+                              className="grid-column-0"
                               verticalAlignContent="top"
                               width={null}
                             >
@@ -860,6 +861,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                               />
                             </GridColumn>
                             <GridColumn
+                              className="grid-column-1"
                               verticalAlignContent="top"
                               width={null}
                             >
@@ -889,6 +891,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                               />
                             </GridColumn>
                             <GridColumn
+                              className="grid-column-2"
                               verticalAlignContent="top"
                               width={null}
                             >
@@ -918,6 +921,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                               />
                             </GridColumn>
                             <GridColumn
+                              className="grid-column-3"
                               verticalAlignContent="top"
                               width={null}
                             >
@@ -947,6 +951,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                               />
                             </GridColumn>
                             <GridColumn
+                              className="grid-column-4"
                               verticalAlignContent="top"
                               width={null}
                             >

--- a/src/styles/semantic/themes/livingstone/elements/container.variables
+++ b/src/styles/semantic/themes/livingstone/elements/container.variables
@@ -8,7 +8,7 @@
 
 /* Minimum Gutter is used to determine  the maximum container width for a given device */
 
-@maxWidth: 1120px;
+@maxWidth: @horizontalGutterMaxWidth;
 
 /* Devices */
 @mobileMinimumGutter: 0;

--- a/src/styles/semantic/themes/livingstone/elements/container.variables
+++ b/src/styles/semantic/themes/livingstone/elements/container.variables
@@ -23,7 +23,7 @@
 
 @computerWidth: 100%;
 @computerGutter: auto;
-@computerPadding: 0 @40px;
+@computerPadding: 0 @horizontalGutterLeftRightPadding;
 
 @largeMonitorWidth: 100%;
 @largeMonitorGutter: auto;

--- a/src/styles/semantic/themes/livingstone/globals/site.variables
+++ b/src/styles/semantic/themes/livingstone/globals/site.variables
@@ -429,3 +429,11 @@
 @searchBarFixedZIndex: 999;
 @searchBarFixedPadding: @20px 0;
 @searchBarFixedBoxShadow: 0 -(@4px) @9px -(@6px) rgba(0, 0, 0, 0.29);
+
+/*-------------------
+   Horizontal Gutter
+--------------------*/
+
+/* Minimum Gutter is used to determine  the maximum container width for a given device */
+
+@horizontalGutterMaxWidth: 1120px;

--- a/src/styles/semantic/themes/livingstone/globals/site.variables
+++ b/src/styles/semantic/themes/livingstone/globals/site.variables
@@ -434,6 +434,8 @@
    Horizontal Gutter
 --------------------*/
 
-/* Minimum Gutter is used to determine  the maximum container width for a given device */
+/* Minimum Gutter is used to determine the maximum container width for a given device */
 
 @horizontalGutterMaxWidth: 1120px;
+// Must be defined in pixels for accuracy
+@horizontalGutterLeftRightPadding: 40px;

--- a/src/styles/semantic/themes/livingstone/modules/modal.overrides
+++ b/src/styles/semantic/themes/livingstone/modules/modal.overrides
@@ -65,14 +65,14 @@
     }
 
     .ui.divider:first-child + .grid {
-      @media (max-width: (@tabletBreakpoint - 1)) {
+      @media only screen and (max-width: (@tabletBreakpoint - 1)) {
 
         .grid-column-0 .ui.header {
           width: @reducedHeadingWidth;
         }
       }
 
-      @media (min-width: @tabletBreakpoint) {
+      @media only screen and (min-width: @tabletBreakpoint) {
 
         .grid-column-1 .ui.header {
           width: @reducedHeadingWidth;
@@ -82,16 +82,16 @@
   }
 
   > i.icon {
-    @media (min-width: @tabletBreakpoint) {
+    @media only screen and (min-width: @tabletBreakpoint) {
       top: @withHorizontalCloseIconTop;
     }
 
-    @media (min-width: (@horizontalGutterMaxWidth + 1)) {
+    @media only screen and (min-width: (@horizontalGutterMaxWidth + 1)) {
       left: @withHorizontalCloseIconLeft;
       right: auto;
     }
 
-    @media (min-width: @tabletBreakpoint) and (max-width: @horizontalGutterMaxWidth) {
+    @media only screen and (min-width: @tabletBreakpoint) and (max-width: @horizontalGutterMaxWidth) {
       right: @withHorizontalCloseIconRight;
     }
   }

--- a/src/styles/semantic/themes/livingstone/modules/modal.overrides
+++ b/src/styles/semantic/themes/livingstone/modules/modal.overrides
@@ -24,35 +24,35 @@
 .ui.fullscreen.modal.with-horizontal-gutters {
 
   .ui.container > .ui.header {
-    width: ~"calc(100% - 30px)";
+    width: @reducedHeadingWidth;
   }
 
   &:not(.with-heading) {
-    @media (max-width: 599px) {
+    @media (max-width: (@tabletBreakpoint - 1)) {
 
       .grid-column-0 .ui.header {
-        width: ~"calc(100% - 30px)";
+        width: @reducedHeadingWidth;
       }
     }
 
-    @media (min-width: 600px) {
+    @media (min-width: @tabletBreakpoint) {
 
       .grid-column-1 .ui.header {
-        width: ~"calc(100% - 30px)";
+        width: @reducedHeadingWidth;
       }
     }
   }
 
   > i.icon {
-    top: 25px;
+    top: @withHorizontalCloseIconTop;
 
-    @media (min-width: 1121px) {
-      left: ~"calc(50% + 480px)";
+    @media (min-width: (@horizontalGutterMaxWidth + 1)) {
+      left: @withHorizontalCloseIconLeft;
       right: auto;
     }
 
-    @media (max-width: 1120px) {
-      right: 25px;
+    @media (max-width: @horizontalGutterMaxWidth) {
+      right: @withHorizontalCloseIconRight;
     }
   }
 }

--- a/src/styles/semantic/themes/livingstone/modules/modal.overrides
+++ b/src/styles/semantic/themes/livingstone/modules/modal.overrides
@@ -20,6 +20,43 @@
   padding: @closePadding;
 }
 
+/* With Horizontal gutters */
+.ui.fullscreen.modal.with-horizontal-gutters {
+
+  .ui.container > .ui.header {
+    width: ~"calc(100% - 30px)";
+  }
+
+  &:not(.with-heading) {
+    @media (max-width: 599px) {
+
+      .grid-column-0 .ui.header {
+        width: ~"calc(100% - 30px)";
+      }
+    }
+
+    @media (min-width: 600px) {
+
+      .grid-column-1 .ui.header {
+        width: ~"calc(100% - 30px)";
+      }
+    }
+  }
+
+  > i.icon {
+    top: 25px;
+
+    @media (min-width: 1121px) {
+      left: ~"calc(50% + 480px)";
+      right: auto;
+    }
+
+    @media (max-width: 1120px) {
+      right: 25px;
+    }
+  }
+}
+
 /* Header */
 
 /* Content */

--- a/src/styles/semantic/themes/livingstone/modules/modal.overrides
+++ b/src/styles/semantic/themes/livingstone/modules/modal.overrides
@@ -20,43 +20,6 @@
   padding: @closePadding;
 }
 
-/* With Horizontal gutters */
-.ui.fullscreen.modal.with-horizontal-gutters {
-
-  .ui.container > .ui.header {
-    width: @reducedHeadingWidth;
-  }
-
-  &:not(.with-heading) {
-    @media (max-width: (@tabletBreakpoint - 1)) {
-
-      .grid-column-0 .ui.header {
-        width: @reducedHeadingWidth;
-      }
-    }
-
-    @media (min-width: @tabletBreakpoint) {
-
-      .grid-column-1 .ui.header {
-        width: @reducedHeadingWidth;
-      }
-    }
-  }
-
-  > i.icon {
-    top: @withHorizontalCloseIconTop;
-
-    @media (min-width: (@horizontalGutterMaxWidth + 1)) {
-      left: @withHorizontalCloseIconLeft;
-      right: auto;
-    }
-
-    @media (max-width: @horizontalGutterMaxWidth) {
-      right: @withHorizontalCloseIconRight;
-    }
-  }
-}
-
 /* Header */
 
 /* Content */
@@ -93,6 +56,44 @@
   .content {
     height: 100%;
     overflow: auto;
+  }
+
+  .ui.container {
+
+    > .ui.header {
+      width: @reducedHeadingWidth;
+    }
+
+    .ui.divider:first-child + .grid {
+      @media (max-width: (@tabletBreakpoint - 1)) {
+
+        .grid-column-0 .ui.header {
+          width: @reducedHeadingWidth;
+        }
+      }
+
+      @media (min-width: @tabletBreakpoint) {
+
+        .grid-column-1 .ui.header {
+          width: @reducedHeadingWidth;
+        }
+      }
+    }
+  }
+
+  > i.icon {
+    @media (min-width: @tabletBreakpoint) {
+      top: @withHorizontalCloseIconTop;
+    }
+
+    @media (min-width: (@horizontalGutterMaxWidth + 1)) {
+      left: @withHorizontalCloseIconLeft;
+      right: auto;
+    }
+
+    @media (min-width: @tabletBreakpoint) and (max-width: @horizontalGutterMaxWidth) {
+      right: @withHorizontalCloseIconRight;
+    }
   }
 }
 

--- a/src/styles/semantic/themes/livingstone/modules/modal.variables
+++ b/src/styles/semantic/themes/livingstone/modules/modal.variables
@@ -55,7 +55,7 @@
 /* Derived Responsive Sizes */
 
 /* With the horizontal gutters */
-@reducedHeadingWidth: ~"calc(100% - 30px)";
+@reducedHeadingWidth: ~"calc(100% - @{30px})";
 @withHorizontalCloseIconTop: @25px;
 @withHorizontalCloseIconRight: @25px;
 

--- a/src/styles/semantic/themes/livingstone/modules/modal.variables
+++ b/src/styles/semantic/themes/livingstone/modules/modal.variables
@@ -55,11 +55,9 @@
 /* Derived Responsive Sizes */
 
 /* With the horizontal gutters */
-@reducedHeadingWidth:  ~"calc(100% - 30px)";
+@reducedHeadingWidth: ~"calc(100% - 30px)";
 @withHorizontalCloseIconTop: @25px;
 @withHorizontalCloseIconRight: @25px;
 
-/*
-  480px = (ContainerWidth / 2) - Padding width
-*/
-@withHorizontalCloseIconLeft: ~"calc(50% + 480px)";
+@halfContainerWidthWithPadding: (@horizontalGutterMaxWidth / 2) - (@horizontalGutterLeftRightPadding * 2);
+@withHorizontalCloseIconLeft: ~"calc(50% + @{halfContainerWidthWithPadding})";

--- a/src/styles/semantic/themes/livingstone/modules/modal.variables
+++ b/src/styles/semantic/themes/livingstone/modules/modal.variables
@@ -53,3 +53,13 @@
 /* Size Widths */
 
 /* Derived Responsive Sizes */
+
+/* With the horizontal gutters */
+@reducedHeadingWidth:  ~"calc(100% - 30px)";
+@withHorizontalCloseIconTop: @25px;
+@withHorizontalCloseIconRight: @25px;
+
+/*
+  480px = (ContainerWidth / 2) - Padding width
+*/
+@withHorizontalCloseIconLeft: ~"calc(50% + 480px)";


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1170)

### What **one** thing does this PR do?
Places the close icon on the right side of the modal in the `Gallery` to align with the horizontal gutter

### Other info
- Extracted out the horizontal gutter max width since it is needed in the Modal styles
- Discussed with Julio, if `isFullscreen` is true, we can assume the `HorizontalGutters` are being applied.
- The mobile version should keep the icon in the same position, the top right
- This has been tested with the  `Header` and `SearchForm` fullscreen modals

### Before
<img width="456" alt="screen shot 2018-10-11 at 14 34 00" src="https://user-images.githubusercontent.com/25742275/46804379-bca1a780-cd62-11e8-9893-7d84a265ef34.png">
<img width="1064" alt="screen shot 2018-10-11 at 14 33 38" src="https://user-images.githubusercontent.com/25742275/46804380-bca1a780-cd62-11e8-9902-c9dcd23ecd4d.png">

### After
![kapture 2018-10-15 at 12 43 17](https://user-images.githubusercontent.com/25742275/46946413-ef57e280-d077-11e8-8148-c1e69927800d.gif)


