### PR TITLE
TE-1224: stop items from being duplicated in the Amenities

### DIFF
--- a/src/components/property-page-widgets/Amenities/component.js
+++ b/src/components/property-page-widgets/Amenities/component.js
@@ -11,6 +11,7 @@ import { getDefaultItems } from './utils/getDefaultItems';
 import { hasExtraItems } from './utils/hasExtraItems';
 import { getCategoryMarkup } from './utils/getCategoryMarkup';
 import { getExtraItemsMarkup } from './utils/getExtraItemsMarkup';
+import { getExtraItems } from './utils/getExtraItems';
 
 /**
  * The standard widget for displaying the amenities of a property.
@@ -37,8 +38,7 @@ export const Component = ({
         getExtraItemsMarkup(
           hasExtraItemsInModal,
           modalTriggerText,
-          amenities,
-          isStacked
+          getExtraItems(amenities, isStacked)
         )}
     </GridRow>
   </Grid>

--- a/src/components/property-page-widgets/Amenities/component.spec.js
+++ b/src/components/property-page-widgets/Amenities/component.spec.js
@@ -208,7 +208,7 @@ describe('getAmenityMarkup', () => {
 
         expectComponentToHaveChildren(
           wrapper,
-          ...getArrayOfLengthOfItem(5, GridColumn)
+          ...getArrayOfLengthOfItem(2, GridColumn)
         );
       });
     });

--- a/src/components/property-page-widgets/Amenities/utils/getExtraItems.js
+++ b/src/components/property-page-widgets/Amenities/utils/getExtraItems.js
@@ -1,0 +1,10 @@
+/**
+ * @param  {any[]}    items
+ * @param  {boolean}  shouldGetThree
+ * @return {any[]}
+ */
+export const getExtraItems = (items, shouldGetThree) => {
+  const numberOfItems = shouldGetThree ? 3 : 5;
+
+  return items.slice(numberOfItems);
+};

--- a/src/components/property-page-widgets/Amenities/utils/getExtraItems.spec.js
+++ b/src/components/property-page-widgets/Amenities/utils/getExtraItems.spec.js
@@ -1,0 +1,23 @@
+import { getExtraItems } from './getExtraItems';
+
+describe('getExtraItems', () => {
+  const array = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+
+  describe('by default', () => {
+    it('should return the last seven items of an array', () => {
+      const actual = getExtraItems(array);
+
+      expect(actual).toHaveLength(7);
+      expect(actual).toEqual([6, 7, 8, 9, 10, 11, 12]);
+    });
+  });
+
+  describe('if `shouldGetThree` is true', () => {
+    it('should return the last nine items of an array', () => {
+      const actual = getExtraItems(array, true);
+
+      expect(actual).toHaveLength(9);
+      expect(actual).toEqual([4, 5, 6, 7, 8, 9, 10, 11, 12]);
+    });
+  });
+});


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1224)

### What **one** thing does this PR do?
Ensure items in Amenities are not being duplicated when applying extra items

### Before
<img width="699" alt="screen shot 2018-10-18 at 15 22 38" src="https://user-images.githubusercontent.com/25742275/47158313-ac9e4080-d2eb-11e8-87e4-0ff56aefd3d8.png">

### After
<img width="720" alt="screen shot 2018-10-18 at 15 22 21" src="https://user-images.githubusercontent.com/25742275/47158319-b162f480-d2eb-11e8-9b33-4f51b5e1b4a2.png">

