### PR TITLE
TE-1205 Refactor out className

### DIFF
--- a/src/components/collections/Hero/__snapshots__/component.spec.js.snap
+++ b/src/components/collections/Hero/__snapshots__/component.spec.js.snap
@@ -1,0 +1,694 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Hero /> by default should render the right structure 1`] = `
+<Hero
+  activeNavigationItemIndex={1}
+  backgroundImageUrl="https://darkpurple.com"
+  headerLogoSrc="https://darkgreen.com"
+  headerLogoText="Livingstone Cottage"
+  headerNavigationItems={
+    Array [
+      Object {
+        "href": "/",
+        "text": "Home",
+      },
+    ]
+  }
+  headerPrimaryCTA={
+    Object {
+      "onClick": [Function],
+      "text": "Book now",
+    }
+  }
+  headerSearchBarGuestsOptions={
+    Array [
+      Object {
+        "href": "someHref",
+        "text": "someText",
+      },
+    ]
+  }
+  headerSearchBarLocationOptions={
+    Array [
+      Object {
+        "href": "anotherHref",
+        "text": "anotherText",
+      },
+    ]
+  }
+  headerSearchBarModalHeadingText="Heading"
+  searchBarOnSubmit={[Function]}
+>
+  <FullBleed
+    hasGradient={true}
+    imageUrl="https://darkpurple.com"
+  >
+    <Segment
+      className="full-bleed has-gradient has-children"
+      style={
+        Object {
+          "backgroundImage": "url(https://darkpurple.com)",
+        }
+      }
+      vertical={true}
+    >
+      <div
+        className="ui vertical segment full-bleed has-gradient has-children"
+        style={
+          Object {
+            "backgroundImage": "url(https://darkpurple.com)",
+          }
+        }
+      >
+        <Header
+          activeNavigationItemIndex={1}
+          isBackgroundFilled={false}
+          logoSrc="https://darkgreen.com"
+          logoText="Livingstone Cottage"
+          navigationItems={
+            Array [
+              Object {
+                "href": "/",
+                "text": "Home",
+              },
+            ]
+          }
+          primaryCTA={
+            Object {
+              "onClick": [Function],
+              "text": "Book now",
+            }
+          }
+          searchBarGetIsDayBlocked={[Function]}
+          searchBarGuestsOptions={
+            Array [
+              Object {
+                "href": "someHref",
+                "text": "someText",
+              },
+            ]
+          }
+          searchBarLocationOptions={
+            Array [
+              Object {
+                "href": "anotherHref",
+                "text": "anotherText",
+              },
+            ]
+          }
+          searchBarModalHeadingText="Heading"
+          searchBarOnSubmit={[Function]}
+        >
+          <header
+            className=""
+          >
+            <HorizontalGutters
+              as={[Function]}
+              borderless={true}
+              text={true}
+            >
+              <Container
+                as={[Function]}
+                borderless={true}
+                text={true}
+              >
+                <Menu
+                  borderless={true}
+                  className="ui text container"
+                >
+                  <div
+                    className="ui borderless ui text container menu"
+                  >
+                    <MenuItem
+                      href="/"
+                      link={true}
+                    >
+                      <a
+                        className="link item"
+                        href="/"
+                        onClick={[Function]}
+                      >
+                        <Image
+                          alt="Livingstone Cottage"
+                          as="img"
+                          src="https://darkgreen.com"
+                          ui={true}
+                        >
+                          <img
+                            alt="Livingstone Cottage"
+                            className="ui image"
+                            src="https://darkgreen.com"
+                          />
+                        </Image>
+                      </a>
+                    </MenuItem>
+                    <ShowOnMobile
+                      parent={[Function]}
+                      parentProps={
+                        Object {
+                          "position": "right",
+                        }
+                      }
+                    >
+                      <MenuMenu
+                        className="show-on-mobile"
+                        position="right"
+                      >
+                        <div
+                          className="right menu show-on-mobile"
+                        >
+                          <MenuItem>
+                            <div
+                              className="item"
+                              onClick={[Function]}
+                            >
+                              <SearchBar
+                                getIsDayBlocked={[Function]}
+                                guestsOptions={
+                                  Array [
+                                    Object {
+                                      "href": "someHref",
+                                      "text": "someText",
+                                    },
+                                  ]
+                                }
+                                isDisplayedAsModal={true}
+                                isFixed={false}
+                                isShowingSummary={false}
+                                locationOptions={
+                                  Array [
+                                    Object {
+                                      "href": "anotherHref",
+                                      "text": "anotherText",
+                                    },
+                                  ]
+                                }
+                                modalHeadingText="Heading"
+                                modalSummaryElement={null}
+                                modalTrigger={
+                                  <Icon
+                                    color={null}
+                                    hasBorder={false}
+                                    isCircular={false}
+                                    isColorInverted={false}
+                                    isDisabled={false}
+                                    isLabelLeft={false}
+                                    labelText={null}
+                                    labelWeight={null}
+                                    name="search"
+                                    path={null}
+                                    size={null}
+                                  />
+                                }
+                                onSubmit={[Function]}
+                                searchButton={
+                                  <Button
+                                    hasShadow={false}
+                                    icon="search"
+                                    isCompact={false}
+                                    isDisabled={false}
+                                    isLoading={false}
+                                    isPositionedRight={true}
+                                    isRounded={true}
+                                    isSecondary={false}
+                                    onClick={[Function]}
+                                    size={null}
+                                  >
+                                    Search
+                                  </Button>
+                                }
+                                summaryElement={null}
+                                willDropdownsOpenAbove={false}
+                              >
+                                <Modal
+                                  isFullscreen={true}
+                                  size="tiny"
+                                  trigger={
+                                    <Icon
+                                      color={null}
+                                      hasBorder={false}
+                                      isCircular={false}
+                                      isColorInverted={false}
+                                      isDisabled={false}
+                                      isLabelLeft={false}
+                                      labelText={null}
+                                      labelWeight={null}
+                                      name="search"
+                                      path={null}
+                                      size={null}
+                                    />
+                                  }
+                                >
+                                  <Modal
+                                    closeIcon={
+                                      <Icon
+                                        color={null}
+                                        hasBorder={false}
+                                        isCircular={false}
+                                        isColorInverted={false}
+                                        isDisabled={false}
+                                        isLabelLeft={false}
+                                        labelText={null}
+                                        labelWeight={null}
+                                        name="close"
+                                        path={null}
+                                        size={null}
+                                      />
+                                    }
+                                    closeOnDimmerClick={true}
+                                    closeOnDocumentClick={false}
+                                    content={
+                                      <ModalContent>
+                                        <Heading
+                                          isColorInverted={false}
+                                          size="small"
+                                          textAlign={null}
+                                        >
+                                          Heading
+                                        </Heading>
+                                        <Form
+                                          as="form"
+                                          onSubmit={[Function]}
+                                        >
+                                          <React.Fragment>
+                                            <FormField
+                                              width="twelve"
+                                            >
+                                              <Dropdown
+                                                error={false}
+                                                icon="map pin"
+                                                isDisabled={false}
+                                                isValid={false}
+                                                label="Location"
+                                                name="location"
+                                                onBlur={[Function]}
+                                                onChange={[Function]}
+                                                options={
+                                                  Array [
+                                                    Object {
+                                                      "href": "anotherHref",
+                                                      "text": "anotherText",
+                                                    },
+                                                  ]
+                                                }
+                                                willOpenAbove={false}
+                                              />
+                                            </FormField>
+                                            <FormField
+                                              width="twelve"
+                                            >
+                                              <WithResponsive(DateRangePicker)
+                                                endDatePlaceholderText="Check-out"
+                                                getIsDayBlocked={[Function]}
+                                                name="dates"
+                                                onChange={[Function]}
+                                                startDatePlaceholderText="Check-in"
+                                                willOpenAbove={false}
+                                              />
+                                            </FormField>
+                                            <FormField
+                                              width="twelve"
+                                            >
+                                              <Dropdown
+                                                error={false}
+                                                icon="users"
+                                                isDisabled={false}
+                                                isValid={false}
+                                                label="Guests"
+                                                name="guests"
+                                                onBlur={[Function]}
+                                                onChange={[Function]}
+                                                options={
+                                                  Array [
+                                                    Object {
+                                                      "href": "someHref",
+                                                      "text": "someText",
+                                                    },
+                                                  ]
+                                                }
+                                                willOpenAbove={false}
+                                              />
+                                            </FormField>
+                                            <FormField
+                                              width="twelve"
+                                            >
+                                              <Button
+                                                hasShadow={false}
+                                                icon="search"
+                                                isCompact={false}
+                                                isDisabled={false}
+                                                isLoading={false}
+                                                isPositionedRight={true}
+                                                isRounded={true}
+                                                isSecondary={false}
+                                                onClick={[Function]}
+                                                size={null}
+                                              >
+                                                Search
+                                              </Button>
+                                            </FormField>
+                                          </React.Fragment>
+                                        </Form>
+                                      </ModalContent>
+                                    }
+                                    dimmer="inverted"
+                                    eventPool="Modal"
+                                    size="fullscreen"
+                                    trigger={
+                                      <Icon
+                                        color={null}
+                                        hasBorder={false}
+                                        isCircular={false}
+                                        isColorInverted={false}
+                                        isDisabled={false}
+                                        isLabelLeft={false}
+                                        labelText={null}
+                                        labelWeight={null}
+                                        name="search"
+                                        path={null}
+                                        size={null}
+                                      />
+                                    }
+                                  >
+                                    <Portal
+                                      className="ui inverted page modals dimmer transition visible active"
+                                      closeOnDocumentClick={false}
+                                      closeOnEscape={true}
+                                      closeOnRootNodeClick={true}
+                                      eventPool="Modal"
+                                      mountNode={<body />}
+                                      onClose={[Function]}
+                                      onMount={[Function]}
+                                      onOpen={[Function]}
+                                      onUnmount={[Function]}
+                                      openOnTriggerClick={true}
+                                      trigger={
+                                        <Icon
+                                          color={null}
+                                          hasBorder={false}
+                                          isCircular={false}
+                                          isColorInverted={false}
+                                          isDisabled={false}
+                                          isLabelLeft={false}
+                                          labelText={null}
+                                          labelWeight={null}
+                                          name="search"
+                                          path={null}
+                                          size={null}
+                                        />
+                                      }
+                                    >
+                                      <Ref
+                                        innerRef={[Function]}
+                                      >
+                                        <Icon
+                                          color={null}
+                                          hasBorder={false}
+                                          isCircular={false}
+                                          isColorInverted={false}
+                                          isDisabled={false}
+                                          isLabelLeft={false}
+                                          labelText={null}
+                                          labelWeight={null}
+                                          name="search"
+                                          onBlur={[Function]}
+                                          onClick={[Function]}
+                                          onFocus={[Function]}
+                                          onMouseEnter={[Function]}
+                                          onMouseLeave={[Function]}
+                                          path={null}
+                                          size={null}
+                                        >
+                                          <i
+                                            className="icon"
+                                            onBlur={[Function]}
+                                            onClick={[Function]}
+                                            onFocus={[Function]}
+                                            onMouseEnter={[Function]}
+                                            onMouseLeave={[Function]}
+                                          >
+                                            <svg
+                                              viewBox="0 0 24 24"
+                                            >
+                                              <path
+                                                d="M20.22,4.14a6.38,6.38,0,0,0-9.75,8.2l-1.8,1.74a1.77,1.77,0,0,0-2,.31l-4.14,4a1.77,1.77,0,0,0,0,2.49l.37.39a1.77,1.77,0,0,0,2.5,0l4.15-4a1.79,1.79,0,0,0,.38-2l1.8-1.73a6.39,6.39,0,0,0,8.54-9.46ZM8.69,16.48l-4.15,4a.6.6,0,0,1-.85,0l-.37-.38a.62.62,0,0,1,0-.86l4.15-4a.61.61,0,0,1,.84,0l.2.2.19.21A.61.61,0,0,1,8.69,16.48Zm2.13-3.67h0L11,13Zm.41.41L11,13l.2.18Zm8-.88a5.23,5.23,0,1,1,.13-7.4A5.24,5.24,0,0,1,19.25,12.34Z"
+                                                fill="currentColor"
+                                              />
+                                            </svg>
+                                          </i>
+                                        </Icon>
+                                      </Ref>
+                                    </Portal>
+                                  </Modal>
+                                </Modal>
+                              </SearchBar>
+                            </div>
+                          </MenuItem>
+                          <MenuItem>
+                            <div
+                              className="item"
+                              onClick={[Function]}
+                            >
+                              <Modal
+                                isFullscreen={true}
+                                size="tiny"
+                                trigger={
+                                  <Icon
+                                    color={null}
+                                    hasBorder={false}
+                                    isCircular={false}
+                                    isColorInverted={false}
+                                    isDisabled={false}
+                                    isLabelLeft={false}
+                                    labelText={null}
+                                    labelWeight={null}
+                                    name="bars"
+                                    path={null}
+                                    size={null}
+                                  />
+                                }
+                              >
+                                <Modal
+                                  closeIcon={
+                                    <Icon
+                                      color={null}
+                                      hasBorder={false}
+                                      isCircular={false}
+                                      isColorInverted={false}
+                                      isDisabled={false}
+                                      isLabelLeft={false}
+                                      labelText={null}
+                                      labelWeight={null}
+                                      name="close"
+                                      path={null}
+                                      size={null}
+                                    />
+                                  }
+                                  closeOnDimmerClick={true}
+                                  closeOnDocumentClick={false}
+                                  content={
+                                    <Menu
+                                      text={true}
+                                      vertical={true}
+                                    >
+                                      <MenuItem
+                                        href="/"
+                                        link={true}
+                                      >
+                                        <Image
+                                          alt="Livingstone Cottage"
+                                          as="img"
+                                          src="https://darkgreen.com"
+                                          ui={true}
+                                        />
+                                      </MenuItem>
+                                      <MenuItem
+                                        active={false}
+                                        href="/"
+                                        link={true}
+                                      >
+                                        Home
+                                      </MenuItem>
+                                    </Menu>
+                                  }
+                                  dimmer="inverted"
+                                  eventPool="Modal"
+                                  size="fullscreen"
+                                  trigger={
+                                    <Icon
+                                      color={null}
+                                      hasBorder={false}
+                                      isCircular={false}
+                                      isColorInverted={false}
+                                      isDisabled={false}
+                                      isLabelLeft={false}
+                                      labelText={null}
+                                      labelWeight={null}
+                                      name="bars"
+                                      path={null}
+                                      size={null}
+                                    />
+                                  }
+                                >
+                                  <Portal
+                                    className="ui inverted page modals dimmer transition visible active"
+                                    closeOnDocumentClick={false}
+                                    closeOnEscape={true}
+                                    closeOnRootNodeClick={true}
+                                    eventPool="Modal"
+                                    mountNode={<body />}
+                                    onClose={[Function]}
+                                    onMount={[Function]}
+                                    onOpen={[Function]}
+                                    onUnmount={[Function]}
+                                    openOnTriggerClick={true}
+                                    trigger={
+                                      <Icon
+                                        color={null}
+                                        hasBorder={false}
+                                        isCircular={false}
+                                        isColorInverted={false}
+                                        isDisabled={false}
+                                        isLabelLeft={false}
+                                        labelText={null}
+                                        labelWeight={null}
+                                        name="bars"
+                                        path={null}
+                                        size={null}
+                                      />
+                                    }
+                                  >
+                                    <Ref
+                                      innerRef={[Function]}
+                                    >
+                                      <Icon
+                                        color={null}
+                                        hasBorder={false}
+                                        isCircular={false}
+                                        isColorInverted={false}
+                                        isDisabled={false}
+                                        isLabelLeft={false}
+                                        labelText={null}
+                                        labelWeight={null}
+                                        name="bars"
+                                        onBlur={[Function]}
+                                        onClick={[Function]}
+                                        onFocus={[Function]}
+                                        onMouseEnter={[Function]}
+                                        onMouseLeave={[Function]}
+                                        path={null}
+                                        size={null}
+                                      >
+                                        <i
+                                          className="icon"
+                                          onBlur={[Function]}
+                                          onClick={[Function]}
+                                          onFocus={[Function]}
+                                          onMouseEnter={[Function]}
+                                          onMouseLeave={[Function]}
+                                        >
+                                          <svg
+                                            viewBox="0 0 24 24"
+                                          >
+                                            <path
+                                              d="M20.5,5.06H3.5a.23.23,0,0,0-.24.23V6.64a.24.24,0,0,0,.24.24h17a.24.24,0,0,0,.24-.24V5.29a.23.23,0,0,0-.24-.23Zm0,6H3.5a.24.24,0,0,0-.24.24v1.34a.24.24,0,0,0,.24.24h17a.24.24,0,0,0,.24-.24V11.33a.24.24,0,0,0-.24-.24Zm0,6H3.5a.24.24,0,0,0-.24.24v1.35a.23.23,0,0,0,.24.23h17a.23.23,0,0,0,.24-.23V17.36a.24.24,0,0,0-.24-.24Z"
+                                              fill="currentColor"
+                                            />
+                                          </svg>
+                                        </i>
+                                      </Icon>
+                                    </Ref>
+                                  </Portal>
+                                </Modal>
+                              </Modal>
+                            </div>
+                          </MenuItem>
+                        </div>
+                      </MenuMenu>
+                    </ShowOnMobile>
+                    <ShowOnDesktop
+                      parent={[Function]}
+                      parentProps={
+                        Object {
+                          "position": "right",
+                        }
+                      }
+                    >
+                      <MenuMenu
+                        className="show-on-desktop"
+                        position="right"
+                      >
+                        <div
+                          className="right menu show-on-desktop"
+                        >
+                          <MenuItem
+                            active={false}
+                            href="/"
+                            key="Home0"
+                            link={true}
+                          >
+                            <a
+                              className="link item"
+                              href="/"
+                              onClick={[Function]}
+                            >
+                              Home
+                            </a>
+                          </MenuItem>
+                          <MenuItem
+                            className="no-underline"
+                            link={true}
+                          >
+                            <div
+                              className="link item no-underline"
+                              onClick={[Function]}
+                            >
+                              <Button
+                                hasShadow={false}
+                                icon={null}
+                                isCompact={false}
+                                isDisabled={false}
+                                isLoading={false}
+                                isPositionedRight={false}
+                                isRounded={true}
+                                isSecondary={false}
+                                onClick={[Function]}
+                                size={null}
+                              >
+                                <Button
+                                  as="button"
+                                  circular={true}
+                                  className=""
+                                  compact={false}
+                                  disabled={false}
+                                  floated="left"
+                                  loading={false}
+                                  onClick={[Function]}
+                                  secondary={false}
+                                  size={null}
+                                >
+                                  <button
+                                    className="ui circular left floated button"
+                                    onClick={[Function]}
+                                    role="button"
+                                  >
+                                    Book now
+                                  </button>
+                                </Button>
+                              </Button>
+                            </div>
+                          </MenuItem>
+                        </div>
+                      </MenuMenu>
+                    </ShowOnDesktop>
+                  </div>
+                </Menu>
+              </Container>
+            </HorizontalGutters>
+          </header>
+        </Header>
+      </div>
+    </Segment>
+  </FullBleed>
+</Hero>
+`;

--- a/src/components/collections/Hero/component.js
+++ b/src/components/collections/Hero/component.js
@@ -23,7 +23,7 @@ export const Component = ({
   searchBarGetIsDayBlocked,
   searchBarOnSubmit,
 }) => (
-  <FullBleed className="is-hero" hasGradient imageUrl={backgroundImageUrl}>
+  <FullBleed hasGradient imageUrl={backgroundImageUrl}>
     <Header
       activeNavigationItemIndex={activeNavigationItemIndex}
       logoSrc={headerLogoSrc}

--- a/src/components/collections/Hero/component.spec.js
+++ b/src/components/collections/Hero/component.spec.js
@@ -1,21 +1,12 @@
 import React from 'react';
-import { shallow } from 'enzyme';
-import {
-  expectComponentToBe,
-  expectComponentToHaveChildren,
-  expectComponentToHaveProps,
-  expectComponentToHaveDisplayName,
-} from '@lodgify/enzyme-jest-expect-helpers';
-
-import { Header } from 'collections/Header';
-import { FullBleed } from 'media/FullBleed';
+import { mount } from 'enzyme';
+import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
 
 import { Component as Hero } from './component';
 
 const props = {
   activeNavigationItemIndex: 1,
   backgroundImageUrl: 'https://darkpurple.com',
-  heading: 'Heading',
   headerLogoSrc: 'https://darkgreen.com',
   headerLogoText: 'Livingstone Cottage',
   headerNavigationItems: [{ text: 'Home', href: '/' }],
@@ -24,60 +15,19 @@ const props = {
   headerSearchBarLocationOptions: [
     { href: 'anotherHref', text: 'anotherText' },
   ],
+  headerSearchBarModalHeadingText: 'Heading',
   searchBarOnSubmit: Function.prototype,
 };
 
 const getHeroComponent = extraProps =>
-  shallow(<Hero {...props} {...extraProps} />);
+  mount(<Hero {...props} {...extraProps} />);
 
 describe('<Hero />', () => {
-  it('should render a single `FullBleed` component', () => {
-    const wrapper = getHeroComponent();
+  describe('by default', () => {
+    it('should render the right structure', () => {
+      const actual = getHeroComponent();
 
-    expectComponentToBe(wrapper, FullBleed);
-  });
-
-  it('should have the right props', () => {
-    const wrapper = getHeroComponent();
-
-    expectComponentToHaveProps(wrapper, {
-      className: 'is-hero',
-      hasGradient: true,
-      imageUrl: 'https://darkpurple.com',
-    });
-  });
-
-  it('should have the right children', () => {
-    const wrapper = getHeroComponent();
-
-    expectComponentToHaveChildren(wrapper, Header);
-  });
-
-  describe('the `Header` component', () => {
-    it('should have the right props', () => {
-      const wrapper = getHeroComponent().find(Header);
-
-      expectComponentToHaveProps(wrapper, {
-        activeNavigationItemIndex: props.activeNavigationItemIndex,
-        logoSrc: props.headerLogoSrc,
-        logoText: props.headerLogoText,
-        navigationItems: props.headerNavigationItems,
-        primaryCTA: props.headerPrimaryCTA,
-        searchBarGuestsOptions: props.headerSearchBarGuestsOptions,
-        searchBarLocationOptions: props.headerSearchBarLocationOptions,
-        searchBarOnSubmit: props.searchBarOnSubmit,
-      });
-    });
-  });
-
-  describe('if `props.children` is passed', () => {
-    it('should render the right children', () => {
-      const children = '👶👶';
-      const wrapper = getHeroComponent({
-        children,
-      });
-
-      expectComponentToHaveChildren(wrapper, Header, children);
+      expect(actual).toMatchSnapshot();
     });
   });
 

--- a/src/components/collections/Table/component.js
+++ b/src/components/collections/Table/component.js
@@ -10,8 +10,8 @@ import { getTextAlign } from './utils/getTextAlign';
  * Table is the Lodgify UI interface for the Semantic UI Table.
  */
 // eslint-disable-next-line jsdoc/require-jsdoc
-export const Component = ({ className, tableHeadings, tableBody, tableId }) => (
-  <Table basic="very" className={className} padded striped>
+export const Component = ({ tableHeadings, tableBody, tableId }) => (
+  <Table basic="very" padded striped>
     <Table.Header>
       <Table.Row>
         {tableHeadings.map((heading, index) => (
@@ -46,15 +46,12 @@ export const Component = ({ className, tableHeadings, tableBody, tableId }) => (
 );
 
 Component.defaultProps = {
-  className: '',
   tableId: '',
 };
 
 Component.displayName = 'Table';
 
 Component.propTypes = {
-  /** Custom class name string to customize the resulting table. */
-  className: PropTypes.string,
   /** The data making up the body of the table */
   tableBody: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.node)).isRequired,
   /** The column heading represented in the table */

--- a/src/components/elements/Divider/component.js
+++ b/src/components/elements/Divider/component.js
@@ -28,7 +28,11 @@ Component.defaultProps = {
 };
 
 Component.propTypes = {
-  /** Custom class name string to customize the resulting divider. */
+  /**
+   * Custom class name.
+   * Provided by `ShowOnMobile` and `ShowOnDesktop` so ignored in the styleguide.
+   * @ignore
+   */
   className: PropTypes.string,
   /** Does the divider have a visible line. */
   hasLine: PropTypes.bool,

--- a/src/components/general-widgets/HomepageHero/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/HomepageHero/__snapshots__/component.spec.js.snap
@@ -91,12 +91,11 @@ exports[`HomepageHero by default should render the right structure 1`] = `
     searchBarOnSubmit={[Function]}
   >
     <FullBleed
-      className="is-hero"
       hasGradient={true}
       imageUrl="url"
     >
       <Segment
-        className="full-bleed is-hero has-gradient"
+        className="full-bleed has-gradient has-children"
         style={
           Object {
             "backgroundImage": "url(url)",
@@ -105,7 +104,7 @@ exports[`HomepageHero by default should render the right structure 1`] = `
         vertical={true}
       >
         <div
-          className="ui vertical segment full-bleed is-hero has-gradient"
+          className="ui vertical segment full-bleed has-gradient has-children"
           style={
             Object {
               "backgroundImage": "url(url)",

--- a/src/components/media/FullBleed/__snapshots__/component.spec.js.snap
+++ b/src/components/media/FullBleed/__snapshots__/component.spec.js.snap
@@ -1,0 +1,81 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<FullBleed /> by default should have the right structure 1`] = `
+<FullBleed
+  hasGradient={false}
+  imageUrl="🐱🐱"
+>
+  <Segment
+    className="full-bleed"
+    style={
+      Object {
+        "backgroundImage": "url(🐱🐱)",
+      }
+    }
+    vertical={true}
+  >
+    <div
+      className="ui vertical segment full-bleed"
+      style={
+        Object {
+          "backgroundImage": "url(🐱🐱)",
+        }
+      }
+    />
+  </Segment>
+</FullBleed>
+`;
+
+exports[`<FullBleed /> if \`hasGradient\` is passed should have the right structure 1`] = `
+<FullBleed
+  hasGradient={true}
+  imageUrl="🐱🐱"
+>
+  <Segment
+    className="full-bleed has-gradient"
+    style={
+      Object {
+        "backgroundImage": "url(🐱🐱)",
+      }
+    }
+    vertical={true}
+  >
+    <div
+      className="ui vertical segment full-bleed has-gradient"
+      style={
+        Object {
+          "backgroundImage": "url(🐱🐱)",
+        }
+      }
+    />
+  </Segment>
+</FullBleed>
+`;
+
+exports[`<FullBleed /> if \`props.children > 0\` should have the right structure 1`] = `
+<FullBleed
+  hasGradient={false}
+  imageUrl="🐱🐱"
+>
+  <Segment
+    className="full-bleed has-children"
+    style={
+      Object {
+        "backgroundImage": "url(🐱🐱)",
+      }
+    }
+    vertical={true}
+  >
+    <div
+      className="ui vertical segment full-bleed has-children"
+      style={
+        Object {
+          "backgroundImage": "url(🐱🐱)",
+        }
+      }
+    >
+      🏛
+    </div>
+  </Segment>
+</FullBleed>
+`;

--- a/src/components/media/FullBleed/component.js
+++ b/src/components/media/FullBleed/component.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import getClassNames from 'classnames';
 import { Segment } from 'semantic-ui-react';
+import { size } from 'lodash';
 
 import { getBackgroundImageUrl } from 'utils/get-background-image-url';
 
@@ -10,10 +11,11 @@ import { getBackgroundImageUrl } from 'utils/get-background-image-url';
  * and the height of the viewport.
  */
 // eslint-disable-next-line jsdoc/require-jsdoc
-export const Component = ({ children, hasGradient, imageUrl, className }) => (
+export const Component = ({ children, hasGradient, imageUrl }) => (
   <Segment
-    className={getClassNames('full-bleed', className, {
+    className={getClassNames('full-bleed', {
       'has-gradient': hasGradient,
+      'has-children': size(children) > 0,
     })}
     style={{
       backgroundImage: getBackgroundImageUrl(imageUrl),
@@ -28,7 +30,6 @@ Component.displayName = 'FullBleed';
 
 Component.defaultProps = {
   children: null,
-  className: null,
   hasGradient: false,
   imageUrl: null,
 };
@@ -36,8 +37,6 @@ Component.defaultProps = {
 Component.propTypes = {
   /** The children to render inside the full bleed. */
   children: PropTypes.node,
-  /** Custom class name string to customize the full bleed. */
-  className: PropTypes.string,
   /** Is there a gradient overlaying the full bleed.  */
   hasGradient: PropTypes.bool,
   /** URL pointing to the image to render. */

--- a/src/components/media/FullBleed/component.spec.js
+++ b/src/components/media/FullBleed/component.spec.js
@@ -1,62 +1,38 @@
 import React from 'react';
-import { shallow } from 'enzyme';
-import { Segment } from 'semantic-ui-react';
-import {
-  expectComponentToBe,
-  expectComponentToHaveDisplayName,
-  expectComponentToHaveProps,
-} from '@lodgify/enzyme-jest-expect-helpers';
-
-import { getBackgroundImageUrl } from 'utils/get-background-image-url';
+import { mount } from 'enzyme';
+import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
 
 import { Component as FullBleed } from './component';
 
 const props = {
-  children: '🚸',
   imageUrl: '🐱🐱',
 };
 
 const getFullBleed = extraProps =>
-  shallow(<FullBleed {...props} {...extraProps} />);
-const getSegment = extraProps => getFullBleed(extraProps).find(Segment);
+  mount(<FullBleed {...props} {...extraProps} />);
 
 describe('<FullBleed />', () => {
-  it('should render a single Semantic UI `Segment` component', () => {
-    const wrapper = getFullBleed();
+  describe('by default', () => {
+    it('should have the right structure', () => {
+      const actual = getFullBleed();
 
-    expectComponentToBe(wrapper, Segment);
-  });
-
-  describe('the `Segment` component', () => {
-    it('should have the right props', () => {
-      const wrapper = getSegment();
-
-      expectComponentToHaveProps(wrapper, {
-        children: props.children,
-        className: 'full-bleed',
-        style: { backgroundImage: getBackgroundImageUrl(props.imageUrl) },
-        vertical: true,
-      });
+      expect(actual).toMatchSnapshot();
     });
   });
 
   describe('if `hasGradient` is passed', () => {
-    it('should have the correct `props.className`', () => {
-      const wrapper = getSegment({ hasGradient: true });
+    it('should have the right structure', () => {
+      const actual = getFullBleed({ hasGradient: true });
 
-      expectComponentToHaveProps(wrapper, {
-        className: 'full-bleed has-gradient',
-      });
+      expect(actual).toMatchSnapshot();
     });
   });
 
-  describe('if `props.className` is passed', () => {
-    it('should have the correct `props.className`', () => {
-      const wrapper = getSegment({ className: '🏛' });
+  describe('if `props.children > 0`', () => {
+    it('should have the right structure', () => {
+      const actual = getFullBleed({ children: '🏛' });
 
-      expectComponentToHaveProps(wrapper, {
-        className: 'full-bleed 🏛',
-      });
+      expect(actual).toMatchSnapshot();
     });
   });
 

--- a/src/components/media/ResponsiveImage/__snapshots__/component.spec.js.snap
+++ b/src/components/media/ResponsiveImage/__snapshots__/component.spec.js.snap
@@ -1,0 +1,261 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ResponsiveImage /> by default should have the right structure 1`] = `
+<ResponsiveImage
+  alternativeText="Alternative Text 😝"
+  imageNotFoundLabelText="Image not found!"
+  imageTitle="ResponsiveImage title"
+  imageUrl=""
+  isAvatar={false}
+  isFluid={true}
+  label={null}
+  onLoad={[Function]}
+  sources={Array []}
+>
+  <picture
+    role="figure"
+  >
+    <Image
+      alt="Alternative Text 😝"
+      as="img"
+      avatar={false}
+      fluid={true}
+      onLoad={[Function]}
+      src=""
+      title="ResponsiveImage title"
+      ui={true}
+    >
+      <div
+        alt="Alternative Text 😝"
+        className="ui fluid image"
+        onLoad={[Function]}
+        src=""
+        title="ResponsiveImage title"
+      >
+        <Label
+          content="Image not found!"
+        >
+          <div
+            className="ui label"
+            onClick={[Function]}
+          >
+            Image not found!
+          </div>
+        </Label>
+      </div>
+    </Image>
+  </picture>
+</ResponsiveImage>
+`;
+
+exports[`<ResponsiveImage /> if \`props.imageNotFoundLabelText\` is passed should have the right structure 1`] = `
+<ResponsiveImage
+  alternativeText="Alternative Text 😝"
+  imageNotFoundLabelText="ayyy"
+  imageTitle="ResponsiveImage title"
+  imageUrl=""
+  isAvatar={false}
+  isFluid={true}
+  label={null}
+  onLoad={[Function]}
+  sources={Array []}
+>
+  <picture
+    role="figure"
+  >
+    <Image
+      alt="Alternative Text 😝"
+      as="img"
+      avatar={false}
+      fluid={true}
+      onLoad={[Function]}
+      src=""
+      title="ResponsiveImage title"
+      ui={true}
+    >
+      <div
+        alt="Alternative Text 😝"
+        className="ui fluid image"
+        onLoad={[Function]}
+        src=""
+        title="ResponsiveImage title"
+      >
+        <Label
+          content="ayyy"
+        >
+          <div
+            className="ui label"
+            onClick={[Function]}
+          >
+            ayyy
+          </div>
+        </Label>
+      </div>
+    </Image>
+  </picture>
+</ResponsiveImage>
+`;
+
+exports[`<ResponsiveImage /> if \`props.imageUrl\` is passed should have the right structure 1`] = `
+<ResponsiveImage
+  alternativeText="Alternative Text 😝"
+  imageNotFoundLabelText="Image not found!"
+  imageTitle="ResponsiveImage title"
+  imageUrl="Dummy URL 🙄"
+  isAvatar={false}
+  isFluid={true}
+  label={null}
+  onLoad={[Function]}
+  sources={Array []}
+>
+  <picture
+    role="figure"
+  >
+    <Image
+      alt="Alternative Text 😝"
+      as="img"
+      avatar={false}
+      fluid={true}
+      onLoad={[Function]}
+      src="Dummy URL 🙄"
+      title="ResponsiveImage title"
+      ui={true}
+    >
+      <img
+        alt="Alternative Text 😝"
+        className="ui fluid image"
+        onLoad={[Function]}
+        src="Dummy URL 🙄"
+        title="ResponsiveImage title"
+      />
+    </Image>
+  </picture>
+</ResponsiveImage>
+`;
+
+exports[`<ResponsiveImage /> if \`props.label\` is passed should have the right structure 1`] = `
+<ResponsiveImage
+  alternativeText="Alternative Text 😝"
+  imageNotFoundLabelText="Image not found!"
+  imageTitle="ResponsiveImage title"
+  imageUrl=""
+  isAvatar={false}
+  isFluid={true}
+  label="🔷"
+  onLoad={[Function]}
+  sources={Array []}
+>
+  <picture
+    role="figure"
+  >
+    <Image
+      alt="Alternative Text 😝"
+      as="img"
+      avatar={false}
+      fluid={true}
+      onLoad={[Function]}
+      src=""
+      title="ResponsiveImage title"
+      ui={true}
+    >
+      <div
+        alt="Alternative Text 😝"
+        className="ui fluid image"
+        onLoad={[Function]}
+        src=""
+        title="ResponsiveImage title"
+      >
+        <Label
+          content="Image not found!"
+        >
+          <div
+            className="ui label"
+            onClick={[Function]}
+          >
+            Image not found!
+          </div>
+        </Label>
+      </div>
+    </Image>
+    <Paragraph
+      size="medium"
+      weight={null}
+    >
+      <p
+        className=""
+      >
+        🔷
+      </p>
+    </Paragraph>
+  </picture>
+</ResponsiveImage>
+`;
+
+exports[`<ResponsiveImage /> if \`props.sources\` is passed should have the right structure 1`] = `
+<ResponsiveImage
+  alternativeText="Alternative Text 😝"
+  imageNotFoundLabelText="Image not found!"
+  imageTitle="ResponsiveImage title"
+  imageUrl=""
+  isAvatar={false}
+  isFluid={true}
+  label={null}
+  onLoad={[Function]}
+  sources={
+    Array [
+      Object {
+        "media": "(min-width: 1200px)",
+        "srcset": "https://si5.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=2400&mode=max",
+      },
+      Object {
+        "media": "(min-width: 1024px)",
+        "srcset": "https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max",
+      },
+    ]
+  }
+>
+  <picture
+    role="figure"
+  >
+    <source
+      key="https://si5.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=2400&mode=max0"
+      media="(min-width: 1200px)"
+      srcSet="https://si5.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=2400&mode=max"
+    />
+    <source
+      key="https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max1"
+      media="(min-width: 1024px)"
+      srcSet="https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max"
+    />
+    <Image
+      alt="Alternative Text 😝"
+      as="img"
+      avatar={false}
+      fluid={true}
+      onLoad={[Function]}
+      src=""
+      title="ResponsiveImage title"
+      ui={true}
+    >
+      <div
+        alt="Alternative Text 😝"
+        className="ui fluid image"
+        onLoad={[Function]}
+        src=""
+        title="ResponsiveImage title"
+      >
+        <Label
+          content="Image not found!"
+        >
+          <div
+            className="ui label"
+            onClick={[Function]}
+          >
+            Image not found!
+          </div>
+        </Label>
+      </div>
+    </Image>
+  </picture>
+</ResponsiveImage>
+`;

--- a/src/components/media/ResponsiveImage/component.js
+++ b/src/components/media/ResponsiveImage/component.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import cx from 'classnames';
 import { Image, Label } from 'semantic-ui-react';
 
 import {
@@ -17,7 +16,6 @@ import { Paragraph } from 'typography/Paragraph';
 // eslint-disable-next-line jsdoc/require-jsdoc
 export const Component = ({
   alternativeText,
-  className,
   imageNotFoundLabelText,
   imageTitle,
   imageUrl,
@@ -38,7 +36,6 @@ export const Component = ({
     <Image
       alt={alternativeText}
       avatar={isAvatar}
-      className={cx(className)}
       fluid={isFluid}
       onLoad={onLoad}
       src={imageUrl}
@@ -54,7 +51,6 @@ Component.displayName = 'ResponsiveImage';
 
 Component.defaultProps = {
   alternativeText: IMAGE_WIDGET,
-  className: null,
   imageNotFoundLabelText: IMAGE_NOT_FOUND,
   imageTitle: IMAGE_TITLE,
   imageUrl: '',
@@ -68,8 +64,6 @@ Component.defaultProps = {
 Component.propTypes = {
   /** Alternative text to show if the image can't be loaded by the browser */
   alternativeText: PropTypes.string,
-  /** Custom class name string to customize the resulting img */
-  className: PropTypes.string,
   /** The label text for the when the image is not found. */
   imageNotFoundLabelText: PropTypes.string,
   /** Title of the image to show when hovering it on desktop browsers */

--- a/src/components/media/ResponsiveImage/component.spec.js
+++ b/src/components/media/ResponsiveImage/component.spec.js
@@ -1,87 +1,56 @@
 import React from 'react';
-import { shallow } from 'enzyme';
-import { Image as SemanticImage, Label } from 'semantic-ui-react';
-import { expectComponentToBe } from '@lodgify/enzyme-jest-expect-helpers';
-
-import { Paragraph } from 'typography/Paragraph';
-import { IMAGE_NOT_FOUND } from 'utils/default-strings';
-
-import { expectComponentToHaveProps } from '../../../../node_modules/@lodgify/enzyme-jest-expect-helpers/lib/expectComponentToHaveProps';
+import { mount } from 'enzyme';
+import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
 
 import { Component as ResponsiveImage } from './component';
 
-const getResponsiveImage = props => shallow(<ResponsiveImage {...props} />);
+const props = {
+  sources: [],
+  alternativeText: 'Alternative Text 😝',
+  isAvatar: false,
+  isFluid: true,
+  onLoad: Function.prototype,
+  imageTitle: 'ResponsiveImage title',
+};
+
+const getResponsiveImage = extraProps =>
+  mount(<ResponsiveImage {...props} {...extraProps} />);
 
 describe('<ResponsiveImage />', () => {
-  it('should have `picture` component as a wrapper', () => {
-    const wrapper = getResponsiveImage();
+  describe('by default', () => {
+    it('should have the right structure', () => {
+      const actual = getResponsiveImage();
 
-    expectComponentToBe(wrapper, 'picture');
+      expect(actual).toMatchSnapshot();
+    });
   });
 
-  describe('the `ResponsiveImage` component', () => {
-    const props = {
-      imageUrl: 'Dummy URL 🙄',
-      sources: [],
-      alternativeText: 'Alternative Text 😝',
-      className: null,
-      isAvatar: false,
-      isFluid: true,
-      onLoad: Function.prototype,
-      imageTitle: 'ResponsiveImage title',
-    };
+  describe('if `props.imageNotFoundLabelText` is passed', () => {
+    it('should have the right structure', () => {
+      const actual = getResponsiveImage({ imageNotFoundLabelText: 'ayyy' });
 
-    it('should have a <Label> when no imageUrl is provided', () => {
-      const actual = getResponsiveImage().find(Label);
-
-      expect(actual).toHaveLength(1);
+      expect(actual).toMatchSnapshot();
     });
+  });
 
-    describe('the `Label`', () => {
-      const getLabel = props => getResponsiveImage(props).find(Label);
+  describe('if `props.imageUrl` is passed', () => {
+    it('should have the right structure', () => {
+      const actual = getResponsiveImage({ imageUrl: 'Dummy URL 🙄' });
 
-      it('should have the right props', () => {
-        const wrapper = getLabel();
-
-        expectComponentToHaveProps(wrapper, { content: IMAGE_NOT_FOUND });
-      });
-
-      describe('if `props.imageNotFoundLabelText` is passed', () => {
-        it('should have the right props', () => {
-          const wrapper = getLabel({ imageNotFoundLabelText: 'ayyy' });
-
-          expectComponentToHaveProps(wrapper, { content: 'ayyy' });
-        });
-      });
+      expect(actual).toMatchSnapshot();
     });
+  });
 
-    it('should contain a Semantic UI <Image> with the right props', () => {
-      const semanticImage = getResponsiveImage(props).find(SemanticImage);
+  describe('if `props.label` is passed', () => {
+    it('should have the right structure', () => {
+      const actual = getResponsiveImage({ label: '🔷' });
 
-      const actual = semanticImage.props();
-
-      expect(actual).toEqual(
-        expect.objectContaining({
-          src: props.imageUrl,
-          alt: props.alternativeText,
-          avatar: props.isAvatar,
-          className: String.prototype,
-          fluid: props.isFluid,
-          onLoad: props.onLoad,
-          title: props.imageTitle,
-          as: 'img',
-          ui: true,
-        })
-      );
+      expect(actual).toMatchSnapshot();
     });
+  });
 
-    it('should not have any <source> when no imageUrl is provided', () => {
-      const sources = getResponsiveImage(props).find('source');
-
-      expect(sources).toHaveLength(0);
-    });
-
-    it('should have defined the right <source>s when provided', () => {
+  describe('if `props.sources` is passed', () => {
+    it('should have the right structure', () => {
       const sources = [
         {
           srcset:
@@ -94,27 +63,13 @@ describe('<ResponsiveImage />', () => {
           media: '(min-width: 1024px)',
         },
       ];
-      const actual = getResponsiveImage({ ...props, sources }).find('source');
+      const actual = getResponsiveImage({ sources });
 
-      expect(actual).toHaveLength(2);
+      expect(actual).toMatchSnapshot();
     });
   });
 
-  it('should render a single Lodgify UI `Paragraph` component when passed a label prop', () => {
-    const label = '🔷';
-    const wrapper = getResponsiveImage({ label });
-    const actual = wrapper.find(Paragraph);
-
-    expect(actual).toHaveLength(1);
-  });
-
-  describe('the `Paragraph` component', () => {
-    it('should get `props.label` as its children', () => {
-      const label = '🔷';
-      const wrapper = getResponsiveImage({ label });
-      const actual = wrapper.find(Paragraph).prop('children');
-
-      expect(actual).toBe(label);
-    });
+  it('should have `displayName` `ResponsiveImage`', () => {
+    expectComponentToHaveDisplayName(ResponsiveImage, 'ResponsiveImage');
   });
 });

--- a/src/components/media/Thumbnail/component.js
+++ b/src/components/media/Thumbnail/component.js
@@ -49,7 +49,11 @@ Component.defaultProps = {
 Component.propTypes = {
   /** Text to help visually impaired users understand the content of the image. */
   alternativeText: PropTypes.string,
-  /** Custom class name string to customize the resulting thumbnail. */
+  /**
+   * Custom class name.
+   * Provided by `ShowOnMobile` and `ShowOnDesktop` so ignored in the styleguide.
+   * @ignore
+   */
   className: PropTypes.string,
   /** Is the thumbnail rounded on the corners */
   hasRoundedCorners: PropTypes.bool,

--- a/src/components/property-page-widgets/Pictures/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Pictures/__snapshots__/component.spec.js.snap
@@ -844,7 +844,6 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                               </Heading>
                               <ResponsiveImage
                                 alternativeText="Image Widget"
-                                className={null}
                                 imageNotFoundLabelText="Image not found!"
                                 imageTitle="Image Title"
                                 imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
@@ -874,7 +873,6 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                               </Heading>
                               <ResponsiveImage
                                 alternativeText="Image Widget"
-                                className={null}
                                 imageNotFoundLabelText="Image not found!"
                                 imageTitle="Image Title"
                                 imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
@@ -904,7 +902,6 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                               </Heading>
                               <ResponsiveImage
                                 alternativeText="Image Widget"
-                                className={null}
                                 imageNotFoundLabelText="Image not found!"
                                 imageTitle="Image Title"
                                 imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
@@ -934,7 +931,6 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                               </Heading>
                               <ResponsiveImage
                                 alternativeText="Image Widget"
-                                className={null}
                                 imageNotFoundLabelText="Image not found!"
                                 imageTitle="Image Title"
                                 imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
@@ -964,7 +960,6 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                               </Heading>
                               <ResponsiveImage
                                 alternativeText="Image Widget"
-                                className={null}
                                 imageNotFoundLabelText="Image not found!"
                                 imageTitle="Image Title"
                                 imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"

--- a/src/components/property-page-widgets/Rates/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Rates/__snapshots__/component.spec.js.snap
@@ -1388,7 +1388,6 @@ exports[`<Rates /> by default should have the right structure 1`] = `
       className="show-on-desktop"
     >
       <Table
-        className=""
         tableBody={
           Array [
             Array [
@@ -1544,7 +1543,6 @@ exports[`<Rates /> by default should have the right structure 1`] = `
         <Table
           as="table"
           basic="very"
-          className=""
           padded={true}
           striped={true}
         >
@@ -4161,7 +4159,6 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
       className="show-on-desktop"
     >
       <Table
-        className=""
         tableBody={
           Array [
             Array [
@@ -4317,7 +4314,6 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
         <Table
           as="table"
           basic="very"
-          className=""
           padded={true}
           striped={true}
         >

--- a/src/styles/semantic/themes/livingstone/elements/segment.overrides
+++ b/src/styles/semantic/themes/livingstone/elements/segment.overrides
@@ -86,7 +86,7 @@
     }
   }
 
-  &.is-hero {
+  &.has-children {
     flex-direction: column;
 
     > * {


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1205)

### What **one** thing does this PR do?
Removes className prop from FullBleed, Hero, ResponsiveImage and Table components because lodgify-ui doesn't support this functionality.

### Any other notes
- Thumbnail and Divider need the className prop so they can use the responsive wrappers `ShowOnMobile` and `ShowOnDesktop` but they have been removed from the documentation.