### PR TITLE
TE-1236: Fix the promotion code button when displayed as stacked

### DIFF
--- a/src/styles/semantic/themes/livingstone/elements/segment.overrides
+++ b/src/styles/semantic/themes/livingstone/elements/segment.overrides
@@ -120,6 +120,8 @@
 
     p + .button {
       float: none;
+      margin-left: auto;
+      margin-right: auto;
     }
 
     .content-section {


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1236)

### What **one** thing does this PR do?
Update the promotion code button to display centered when the `Promotion` component is to be displayed as stacked

### Before
<img width="702" alt="screen shot 2018-10-22 at 09 30 59" src="https://user-images.githubusercontent.com/25742275/47283910-888d7880-d5e5-11e8-8ad4-f5410b5eff24.png">

### After
<img width="757" alt="screen shot 2018-10-22 at 09 50 47" src="https://user-images.githubusercontent.com/25742275/47283917-8deac300-d5e5-11e8-9f4d-ff15fd3de118.png">
