### PR TITLE
TE-1209 ShowOn`Device` PR response

### DIFF
--- a/src/components/layout/ShowOnDesktop/component.js
+++ b/src/components/layout/ShowOnDesktop/component.js
@@ -19,6 +19,7 @@ export const Component = ({ children, parent, parentProps }) =>
 
 Component.defaultProps = {
   children: null,
+  parent: 'div',
   parentProps: {},
 };
 
@@ -28,7 +29,7 @@ Component.propTypes = {
   /** The child components only to be rendered on desktop  */
   children: PropTypes.node,
   /** The parent component that will be rendered. */
-  parent: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
+  parent: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
   /** The props to be passed to the parent component. */
   // eslint-disable-next-line react/forbid-prop-types
   parentProps: PropTypes.object,

--- a/src/components/layout/ShowOnMobile/component.js
+++ b/src/components/layout/ShowOnMobile/component.js
@@ -19,6 +19,7 @@ export const Component = ({ children, parent, parentProps }) =>
 
 Component.defaultProps = {
   children: null,
+  parent: 'div',
   parentProps: {},
 };
 
@@ -28,7 +29,7 @@ Component.propTypes = {
   /** The child components only to be rendered on mobile  */
   children: PropTypes.node,
   /** The parent component that will be rendered. */
-  parent: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
+  parent: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
   /** The props to be passed to the parent component. */
   // eslint-disable-next-line react/forbid-prop-types
   parentProps: PropTypes.object,

--- a/src/components/property-page-widgets/PropertyPageSearchBar/component.js
+++ b/src/components/property-page-widgets/PropertyPageSearchBar/component.js
@@ -17,7 +17,7 @@ export const Component = ({
   searchButton,
 }) => (
   <div className="property-page-searchbar">
-    <ShowOnDesktop parent="div">
+    <ShowOnDesktop>
       <SearchBar
         guestsOptions={guestsOptions}
         isFixed={isFixed}
@@ -25,7 +25,7 @@ export const Component = ({
         summaryElement={summaryElement}
       />
     </ShowOnDesktop>
-    <ShowOnMobile parent="div">
+    <ShowOnMobile>
       <SearchBar
         guestsOptions={guestsOptions}
         isDisplayedAsModal

--- a/src/components/property-page-widgets/Rates/component.js
+++ b/src/components/property-page-widgets/Rates/component.js
@@ -41,7 +41,7 @@ export const Component = ({
           onChangeRoomType,
           roomTypeInputLabel
         )}
-      <ShowOnMobile parent="div">
+      <ShowOnMobile>
         <Dropdown onChange={onChangeCurrency} options={currencyOptions} />
         {rateCategories.map((rateCategory, rateCategoryIndex) => (
           <Card
@@ -71,7 +71,7 @@ export const Component = ({
         ))}
       </ShowOnMobile>
     </Grid>
-    <ShowOnDesktop parent="div">
+    <ShowOnDesktop>
       <Table
         tableBody={rateCategories.map(rateCategory => [
           getRateCategoryHeadingMarkup(rateCategory, costPerExtraGuestLabel),

--- a/src/styles/semantic/themes/livingstone/globals/site.overrides
+++ b/src/styles/semantic/themes/livingstone/globals/site.overrides
@@ -428,7 +428,7 @@ blockquote.ui.quote .row {
 -----------------------*/
 
 /* Hide on mobile screens */
-@media only screen and (min-width: @smallestComputerBreakpoint) {
+@media @computerScreen {
 
   .show-on-mobile {
     display: none !important;
@@ -436,7 +436,7 @@ blockquote.ui.quote .row {
 }
 
 /* Hide on desktop screens */
-@media only screen and (max-width: @tabletBreakpoint) {
+@media @tabletScreen {
 
   .show-on-desktop {
     display: none !important;

--- a/src/styles/semantic/themes/livingstone/globals/site.variables
+++ b/src/styles/semantic/themes/livingstone/globals/site.variables
@@ -168,6 +168,7 @@
 @tinyScreen: ~"only screen and (max-width: @{largestTinyScreen})";
 @mobileScreen: ~"only screen and (max-width: @{largestMobileScreen})";
 @tabletScreen: ~"only screen and (max-width: @{tabletBreakpoint})";
+@computerScreen: ~"only screen and (min-width: @{smallestComputerBreakpoint})";
 
 /*-------------------
       Site Colors


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1209)

### What **one** thing does this PR do?
Responds to the comments in a closed PR

### Any other notes
Comments left over slack message: 

[Here](https://github.com/lodgify/lodgify-ui/pull/391/commits/a4f3eaee71b131339f8a5bc53bdb287ad2c2148d#diff-9db5ca13d272f5d2fb6018e39a280aa5R439) you can use `@media @tabletScreen`

And would be good to use a similar pattern [here](https://github.com/lodgify/lodgify-ui/pull/391/commits/a4f3eaee71b131339f8a5bc53bdb287ad2c2148d#diff-9db5ca13d272f5d2fb6018e39a280aa5R431)

So.. define a `@computerScreen: only screen and (min-width: @smallestComputerBreakpoint);`
and use it as `@media @computerScreen`

[Here](https://github.com/lodgify/lodgify-ui/pull/391/commits/a20261712971871a8e0f84b8a32f60d244371cc8#diff-4010bda9d045c2b812a8fa90b381336dR44) i suggest we use a default `parent` prop of `div` rather than pass it as a string here