### PR TITLE
TE-1283 Add theming to menu item underlines

### DIFF
--- a/src/styles/semantic/themes/livingstone/collections/menu.overrides
+++ b/src/styles/semantic/themes/livingstone/collections/menu.overrides
@@ -123,6 +123,7 @@
 
         &.active {
           border-bottom: @activeItemUnderlineBorder;
+          border-bottom-color: var(@themeActionColorIdentifier, @themeActionColorDefault);
         }
       }
     }
@@ -291,6 +292,7 @@ header {
 
       > .item:not(.no-underline):after {
         border-bottom: @activeItemUnderlineBorder;
+        border-bottom-color: var(@themeActionColorIdentifier, @themeActionColorDefault);
         bottom: @activeItemUnderlineBottomPosition;
         content: '';
         left: 0;


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1283)

### What **one** thing does this PR do?
The menu items underline is determined by the theme's primary colour.

### Any other notes
![kapture 2018-10-22 at 16 07 24](https://user-images.githubusercontent.com/10498995/47348310-78db6600-d6b1-11e8-99c3-8dbdc5a70be3.gif)

![kapture 2018-10-23 at 11 47 27](https://user-images.githubusercontent.com/10498995/47352071-7d0b8180-d6b9-11e8-81f3-722fcca6ef76.gif)

