### PR TITLE
TE-1170: Update the CSS selectors in the gallery modal

### DIFF
--- a/src/components/media/Gallery/component.js
+++ b/src/components/media/Gallery/component.js
@@ -28,10 +28,7 @@ export const Component = ({ heading, images, trigger }) => (
       <Grid columns={2} stackable>
         <GridRow>
           {images.map(({ label, ...otherImageProps }, index) => (
-            <GridColumn
-              className={`grid-column-${index}`}
-              key={buildKeyFromStrings(label, index)}
-            >
+            <GridColumn key={buildKeyFromStrings(label, index)}>
               <Heading size="small">{label}</Heading>
               <ResponsiveImage {...otherImageProps} />
               <Divider />

--- a/src/components/property-page-widgets/Pictures/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Pictures/__snapshots__/component.spec.js.snap
@@ -831,7 +831,6 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                             horizontalAlignContent="left"
                           >
                             <GridColumn
-                              className="grid-column-0"
                               verticalAlignContent="top"
                               width={null}
                             >
@@ -860,7 +859,6 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                               />
                             </GridColumn>
                             <GridColumn
-                              className="grid-column-1"
                               verticalAlignContent="top"
                               width={null}
                             >
@@ -889,7 +887,6 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                               />
                             </GridColumn>
                             <GridColumn
-                              className="grid-column-2"
                               verticalAlignContent="top"
                               width={null}
                             >
@@ -918,7 +915,6 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                               />
                             </GridColumn>
                             <GridColumn
-                              className="grid-column-3"
                               verticalAlignContent="top"
                               width={null}
                             >
@@ -947,7 +943,6 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                               />
                             </GridColumn>
                             <GridColumn
-                              className="grid-column-4"
                               verticalAlignContent="top"
                               width={null}
                             >

--- a/src/styles/semantic/themes/livingstone/modules/modal.overrides
+++ b/src/styles/semantic/themes/livingstone/modules/modal.overrides
@@ -64,17 +64,10 @@
       width: @reducedHeadingWidth;
     }
 
-    .ui.divider:first-child + .grid {
-      @media only screen and (max-width: (@tabletBreakpoint - 1)) {
-
-        .grid-column-0 .ui.header {
-          width: @reducedHeadingWidth;
-        }
-      }
-
+    .ui.divider:first-child + .grid .top.column {
       @media only screen and (min-width: @tabletBreakpoint) {
 
-        .grid-column-1 .ui.header {
+        &:nth-child(2) .ui.header {
           width: @reducedHeadingWidth;
         }
       }


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1170)

### What **one** thing does this PR do?
Cleans up the selectors for the headings in the `Gallery` modal

### Preview
- There is no visual difference with this change
- In the previews below, only the highlighted headings are reduced

__Previews of reduce headings__
<img width="925" alt="screen shot 2018-10-23 at 15 02 59" src="https://user-images.githubusercontent.com/25742275/47362498-cfa66700-d6d4-11e8-870b-8047a0ad9d24.png">
<img width="943" alt="screen shot 2018-10-23 at 15 01 10" src="https://user-images.githubusercontent.com/25742275/47362500-d03efd80-d6d4-11e8-8af2-c49a39f035ae.png">

__Responsive preview__
- No need to reduce the heading width because of where the close icon is positioned
<img width="440" alt="screen shot 2018-10-23 at 15 08 43" src="https://user-images.githubusercontent.com/25742275/47362810-93bfd180-d6d5-11e8-804f-55c1620d27f8.png">

