### PR TITLE
TE-1260: set the line height for the Headings

### DIFF
--- a/src/styles/semantic/themes/livingstone/globals/site.overrides
+++ b/src/styles/semantic/themes/livingstone/globals/site.overrides
@@ -29,6 +29,21 @@
 /*--------------
   Page Heading
 ---------------*/
+h1.ui.header {
+  line-height: @h1LineHeight;
+}
+
+h2.ui.header {
+  line-height: @h2LineHeight;
+}
+
+h3.ui.header {
+  line-height: @h3LineHeight;
+}
+
+h4.ui.header {
+  line-height: @h4LineHeight;
+}
 
 /*--------------
    Form Input

--- a/src/styles/semantic/themes/livingstone/globals/site.variables
+++ b/src/styles/semantic/themes/livingstone/globals/site.variables
@@ -62,9 +62,16 @@
 @headerLineHeight: 36px;
 
 @h1: 48px;
+@h1LineHeight: @50px;
+
 @h2: 40px;
+@h2LineHeight: @42px;
+
 @h3: 24px;
+@h3LineHeight: @36px;
+
 @h4: 16px;
+@h4LineHeight: @24px;
 
 /*--------------
    Form Input


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1260)

### What **one** thing does this PR do?
Set the line height for each of the Headings, sizes are listed in the ticket

### Previews

__Before__
<img width="408" alt="screen shot 2018-10-23 at 15 51 37" src="https://user-images.githubusercontent.com/25742275/47365517-0af86400-d6dc-11e8-9f71-47247c97b05b.png">

__After__
<img width="409" alt="screen shot 2018-10-23 at 15 49 35" src="https://user-images.githubusercontent.com/25742275/47365525-0fbd1800-d6dc-11e8-93fa-5581f36f0f2a.png">

### The property page hero title

__Before__
<img width="898" alt="screen shot 2018-10-23 at 15 54 13" src="https://user-images.githubusercontent.com/25742275/47365561-1cda0700-d6dc-11e8-9cd3-04c18b2485cb.png">

__After__
<img width="898" alt="screen shot 2018-10-23 at 15 53 42" src="https://user-images.githubusercontent.com/25742275/47365566-219ebb00-d6dc-11e8-8150-c4b09dbc5042.png">
