### PR TITLE
TE-1275 Add `babel-plugin-lodash`

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -9,6 +9,7 @@
   "plugins": [
     "@babel/plugin-proposal-object-rest-spread",
     "@babel/plugin-proposal-class-properties",
+    "lodash",
     ["module-resolver", {
       "root": ["./src"],
       "alias": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "size-limit": [
     {
-      "limit": "350 KB",
+      "limit": "321 KB",
       "path": "lib/index.js"
     }
   ],

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "babel-eslint": "^8.2.3",
     "babel-jest": "^23.4.2",
     "babel-loader": "^8.0.2",
+    "babel-plugin-lodash": "^3.3.4",
     "babel-plugin-module-resolver": "^3.1.1",
     "commitizen": "^2.9.6",
     "css-loader": "^0.28.10",


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1275)

### What **one** thing does this PR do?
Adds `babel-plugin-lodash` which takes >23 KB off the library size.

### Before
```sh
  Package size: 343.32 KB
  Size limit:   350 KB
```
### After 
```sh
  Package size: 320.06 KB
  Size limit:   350 KB
```