### PR TITLE
TE-1277 Add `transform-react-remove-prop-types`

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -22,6 +22,10 @@
         "typography": "./src/components/typography",
         "utils": "./src/utils"
       }
-    }]
+    }],
+    ["transform-react-remove-prop-types", {
+        "mode": "wrap"
+      }
+    ]
   ]
 }

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "babel-jest": "^23.4.2",
     "babel-loader": "^8.0.2",
     "babel-plugin-module-resolver": "^3.1.1",
+    "babel-plugin-transform-react-remove-prop-types": "^0.4.19",
     "commitizen": "^2.9.6",
     "css-loader": "^0.28.10",
     "cz-conventional-changelog": "^2.1.0",


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1277)

### What **one** thing does this PR do?
Add `transform-react-remove-prop-types`.

### Any other notes
This doesn't have a direct impact on library build size but allows consumers of the library to shave off ~4 KB.