### PR TITLE
TE-1276: Import Semantic components by path

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "size-limit": [
     {
-      "limit": "321 KB",
+      "limit": "319 KB",
       "path": "lib/index.js"
     }
   ],

--- a/src/components/collections/Footer/component.js
+++ b/src/components/collections/Footer/component.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Menu } from 'semantic-ui-react';
+import Menu from 'semantic-ui-react/dist/commonjs/collections/Menu';
 import { toUpper, size } from 'lodash';
 
 import { buildKeyFromStrings } from 'utils/build-key-from-strings';

--- a/src/components/collections/Footer/component.spec.js
+++ b/src/components/collections/Footer/component.spec.js
@@ -6,7 +6,7 @@ import {
   expectComponentToHaveChildren,
   expectComponentToHaveDisplayName,
 } from '@lodgify/enzyme-jest-expect-helpers';
-import { Menu } from 'semantic-ui-react';
+import Menu from 'semantic-ui-react/dist/commonjs/collections/Menu';
 
 import { HorizontalGutters } from 'layout/HorizontalGutters';
 import { getArrayOfLengthOfItem } from 'utils/get-array-of-length-of-item';

--- a/src/components/collections/Footer/utils/getMenuItemMarkup.js
+++ b/src/components/collections/Footer/utils/getMenuItemMarkup.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Menu } from 'semantic-ui-react';
+import Menu from 'semantic-ui-react/dist/commonjs/collections/Menu';
 
 import { buildKeyFromStrings } from 'utils/build-key-from-strings';
 

--- a/src/components/collections/Form/component.js
+++ b/src/components/collections/Form/component.js
@@ -1,6 +1,7 @@
 import React, { PureComponent, Children } from 'react';
 import PropTypes from 'prop-types';
-import { Card, Form } from 'semantic-ui-react';
+import Card from 'semantic-ui-react/dist/commonjs/views/Card';
+import Form from 'semantic-ui-react/dist/commonjs/collections/Form';
 import { size, forEach } from 'lodash';
 
 import { Button } from 'elements/Button';

--- a/src/components/collections/Form/component.spec.js
+++ b/src/components/collections/Form/component.spec.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Card, Form as SemanticForm, FormField } from 'semantic-ui-react';
+import Card from 'semantic-ui-react/dist/commonjs/views/Card';
+import FormField from 'semantic-ui-react/dist/commonjs/collections/Form/FormField';
+import { default as SemanticForm } from 'semantic-ui-react/dist/commonjs/collections/Form';
 import {
   expectComponentToBe,
   expectComponentToHaveChildren,

--- a/src/components/collections/Form/utils/getClonedInput.js
+++ b/src/components/collections/Form/utils/getClonedInput.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Form } from 'semantic-ui-react';
+import Form from 'semantic-ui-react/dist/commonjs/collections/Form';
 
 import { getInputWidth } from './getInputWidth';
 

--- a/src/components/collections/Form/utils/getClonedInput.spec.js
+++ b/src/components/collections/Form/utils/getClonedInput.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { FormField } from 'semantic-ui-react';
+import FormField from 'semantic-ui-react/dist/commonjs/collections/Form/FormField';
 import {
   expectComponentToHaveChildren,
   expectComponentToHaveProps,

--- a/src/components/collections/Form/utils/getFormChild.js
+++ b/src/components/collections/Form/utils/getFormChild.js
@@ -1,5 +1,5 @@
 import React, { Children } from 'react';
-import { Form } from 'semantic-ui-react';
+import Form from 'semantic-ui-react/dist/commonjs/collections/Form';
 
 import { getClonedInput } from './getClonedInput';
 

--- a/src/components/collections/Form/utils/getFormChild.spec.js
+++ b/src/components/collections/Form/utils/getFormChild.spec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { FormField, FormGroup } from 'semantic-ui-react';
+import FormField from 'semantic-ui-react/dist/commonjs/collections/Form/FormField';
+import FormGroup from 'semantic-ui-react/dist/commonjs/collections/Form/FormGroup';
 import {
   expectComponentToHaveChildren,
   expectComponentToHaveProps,

--- a/src/components/collections/Header/component.js
+++ b/src/components/collections/Header/component.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import getClassNames from 'classnames';
-import { Menu } from 'semantic-ui-react';
+import Menu from 'semantic-ui-react/dist/commonjs/collections/Menu';
 
 import { HorizontalGutters } from 'layout/HorizontalGutters';
 

--- a/src/components/collections/Header/utils/getDesktopMenuMarkup.js
+++ b/src/components/collections/Header/utils/getDesktopMenuMarkup.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Menu } from 'semantic-ui-react';
+import Menu from 'semantic-ui-react/dist/commonjs/collections/Menu';
 import { size } from 'lodash';
 
 import { buildKeyFromStrings } from 'utils/build-key-from-strings';

--- a/src/components/collections/Header/utils/getLinkMarkup.js
+++ b/src/components/collections/Header/utils/getLinkMarkup.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Menu } from 'semantic-ui-react';
+import Menu from 'semantic-ui-react/dist/commonjs/collections/Menu';
 
 import { buildKeyFromStrings } from 'utils/build-key-from-strings';
 

--- a/src/components/collections/Header/utils/getLogoMarkup.js
+++ b/src/components/collections/Header/utils/getLogoMarkup.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Menu, Image } from 'semantic-ui-react';
+import Menu from 'semantic-ui-react/dist/commonjs/collections/Menu';
+import Image from 'semantic-ui-react/dist/commonjs/elements/Image';
 
 import { Heading } from 'typography/Heading';
 

--- a/src/components/collections/Header/utils/getLogoMarkup.spec.js
+++ b/src/components/collections/Header/utils/getLogoMarkup.spec.js
@@ -1,5 +1,5 @@
 import { shallow } from 'enzyme';
-import { Image } from 'semantic-ui-react';
+import Image from 'semantic-ui-react/dist/commonjs/elements/Image';
 import {
   expectComponentToBe,
   expectComponentToHaveChildren,

--- a/src/components/collections/Header/utils/getMobileMenuMarkup.js
+++ b/src/components/collections/Header/utils/getMobileMenuMarkup.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Menu, Accordion } from 'semantic-ui-react';
+import Menu from 'semantic-ui-react/dist/commonjs/collections/Menu';
+import Accordion from 'semantic-ui-react/dist/commonjs/modules/Accordion';
 import { size } from 'lodash';
 
 import { buildKeyFromStrings } from 'utils/build-key-from-strings';

--- a/src/components/collections/InputGroup/component.js
+++ b/src/components/collections/InputGroup/component.js
@@ -1,10 +1,10 @@
-import { Form } from 'semantic-ui-react';
+import FormGroup from 'semantic-ui-react/dist/commonjs/collections/Form/FormGroup';
 
 /**
  * InputGroup is the Lodgify UI interface for the
  * Semantic UI Form.Group.
  * @type {Object}
  */
-export const Component = Form.Group;
+export const Component = FormGroup;
 
 Component.displayName = 'InputGroup';

--- a/src/components/collections/Table/component.js
+++ b/src/components/collections/Table/component.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Table } from 'semantic-ui-react';
+import Table from 'semantic-ui-react/dist/commonjs/collections/Table';
 
 import { buildKeyFromStrings } from 'utils/build-key-from-strings';
 

--- a/src/components/collections/Table/component.spec.js
+++ b/src/components/collections/Table/component.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Table as SemanticUITable } from 'semantic-ui-react';
+import { default as SemanticUITable } from 'semantic-ui-react/dist/commonjs/collections/Table';
 import {
   expectComponentToBe,
   expectComponentToHaveProps,

--- a/src/components/elements/Button/component.js
+++ b/src/components/elements/Button/component.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import { Button } from 'semantic-ui-react';
+import Button from 'semantic-ui-react/dist/commonjs/elements/Button';
 
 import { Icon } from 'elements/Icon';
 

--- a/src/components/elements/Button/component.spec.js
+++ b/src/components/elements/Button/component.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Button as SemanticButton } from 'semantic-ui-react';
+import { default as SemanticButton } from 'semantic-ui-react/dist/commonjs/elements/Button';
 import {
   expectComponentToBe,
   expectComponentToHaveChildren,

--- a/src/components/elements/Divider/component.js
+++ b/src/components/elements/Divider/component.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Divider } from 'semantic-ui-react';
+import Divider from 'semantic-ui-react/dist/commonjs/elements/Divider';
 import getClassNames from 'classnames';
 
 import { getIsSizeLarge } from './utils/getIsSizeLarge';

--- a/src/components/elements/GoogleMap/component.js
+++ b/src/components/elements/GoogleMap/component.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Card } from 'semantic-ui-react';
+import Card from 'semantic-ui-react/dist/commonjs/views/Card';
 
 import { ReactGoogleMap } from 'utils/react-google-maps';
 

--- a/src/components/elements/GoogleMap/component.spec.js
+++ b/src/components/elements/GoogleMap/component.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Card } from 'semantic-ui-react';
+import Card from 'semantic-ui-react/dist/commonjs/views/Card';
 import {
   expectComponentToBe,
   expectComponentToHaveDisplayName,

--- a/src/components/elements/IconCard/component.js
+++ b/src/components/elements/IconCard/component.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Label } from 'semantic-ui-react';
+import Label from 'semantic-ui-react/dist/commonjs/elements/Label';
 import cx from 'classnames';
 
 import { getParagraphsFromStrings } from 'utils/get-paragraphs-from-strings';

--- a/src/components/elements/Link/component.js
+++ b/src/components/elements/Link/component.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button } from 'semantic-ui-react';
+import Button from 'semantic-ui-react/dist/commonjs/elements/Button';
 
 /**
  * A link indicates a referred resource.

--- a/src/components/elements/Link/component.spec.js
+++ b/src/components/elements/Link/component.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Button } from 'semantic-ui-react';
+import Button from 'semantic-ui-react/dist/commonjs/elements/Button';
 import {
   expectComponentToBe,
   expectComponentToHaveChildren,

--- a/src/components/elements/Modal/component.js
+++ b/src/components/elements/Modal/component.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Modal } from 'semantic-ui-react';
+import Modal from 'semantic-ui-react/dist/commonjs/modules/Modal';
 
 import { Icon, ICON_NAMES } from 'elements/Icon';
 

--- a/src/components/elements/Modal/component.spec.js
+++ b/src/components/elements/Modal/component.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Modal as SemanticModal } from 'semantic-ui-react';
+import { default as SemanticModal } from 'semantic-ui-react/dist/commonjs/modules/Modal';
 import {
   expectComponentToBe,
   expectComponentToHaveDisplayName,

--- a/src/components/elements/Pagination/component.js
+++ b/src/components/elements/Pagination/component.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Pagination } from 'semantic-ui-react';
+import Pagination from 'semantic-ui-react/dist/commonjs/addons/Pagination';
 
 import { nextItem, pageItem, prevItem } from './navigationMarkup';
 

--- a/src/components/elements/Pagination/component.spec.js
+++ b/src/components/elements/Pagination/component.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Pagination as SemanticPagination } from 'semantic-ui-react';
+import { default as SemanticPagination } from 'semantic-ui-react/dist/commonjs/addons/Pagination';
 import {
   expectComponentToBe,
   expectComponentToHaveDisplayName,

--- a/src/components/elements/Pagination/navigationMarkup.js
+++ b/src/components/elements/Pagination/navigationMarkup.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Label, Button } from 'semantic-ui-react';
+import Label from 'semantic-ui-react/dist/commonjs/elements/Label';
+import Button from 'semantic-ui-react/dist/commonjs/elements/Button';
 
 import { Icon, ICON_NAMES } from 'elements/Icon';
 

--- a/src/components/elements/Rating/component.js
+++ b/src/components/elements/Rating/component.js
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
-import { Rating } from 'semantic-ui-react';
+import Rating from 'semantic-ui-react/dist/commonjs/modules/Rating';
 
 /**
  * A rating displays star icons and an optional numeral.

--- a/src/components/elements/Rating/component.spec.js
+++ b/src/components/elements/Rating/component.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Rating as SemanticRating } from 'semantic-ui-react';
+import { default as SemanticRating } from 'semantic-ui-react/dist/commonjs/modules/Rating';
 import {
   expectComponentToHaveChildren,
   expectComponentToHaveDisplayName,

--- a/src/components/elements/Submenu/component.js
+++ b/src/components/elements/Submenu/component.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Dropdown } from 'semantic-ui-react';
+import Dropdown from 'semantic-ui-react/dist/commonjs/modules/Dropdown';
 
 import { Icon, ICON_NAMES } from 'elements/Icon';
 

--- a/src/components/elements/Submenu/component.spec.js
+++ b/src/components/elements/Submenu/component.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Dropdown } from 'semantic-ui-react';
+import Dropdown from 'semantic-ui-react/dist/commonjs/modules/Dropdown';
 import {
   expectComponentToBe,
   expectComponentToHaveDisplayName,

--- a/src/components/elements/Tooltip/component.js
+++ b/src/components/elements/Tooltip/component.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Popup } from 'semantic-ui-react';
+import Popup from 'semantic-ui-react/dist/commonjs/modules/Popup';
 
 import { getTriggerMarkup } from './getTriggerMarkup';
 

--- a/src/components/elements/Tooltip/component.spec.js
+++ b/src/components/elements/Tooltip/component.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Popup } from 'semantic-ui-react';
+import Popup from 'semantic-ui-react/dist/commonjs/modules/Popup';
 import {
   expectComponentToBe,
   expectComponentToHaveDisplayName,

--- a/src/components/general-widgets/FeaturedProperty/component.js
+++ b/src/components/general-widgets/FeaturedProperty/component.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Card, Image } from 'semantic-ui-react';
+import Card from 'semantic-ui-react/dist/commonjs/views/Card';
+import Image from 'semantic-ui-react/dist/commonjs/elements/Image';
 
 import { getNightPriceMarkup } from 'utils/get-night-price-markup';
 import { Subheading } from 'typography/Subheading';

--- a/src/components/general-widgets/FeaturedProperty/component.spec.js
+++ b/src/components/general-widgets/FeaturedProperty/component.spec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Card, Image } from 'semantic-ui-react';
+import Card from 'semantic-ui-react/dist/commonjs/views/Card';
+import Image from 'semantic-ui-react/dist/commonjs/elements/Image';
 import {
   expectComponentToBe,
   expectComponentToHaveChildren,

--- a/src/components/general-widgets/FeaturedRoomType/component.js
+++ b/src/components/general-widgets/FeaturedRoomType/component.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Card, Image } from 'semantic-ui-react';
+import Card from 'semantic-ui-react/dist/commonjs/views/Card';
+import Image from 'semantic-ui-react/dist/commonjs/elements/Image';
 
 import { getNightPriceMarkup } from 'utils/get-night-price-markup/';
 

--- a/src/components/general-widgets/FeaturedRoomType/component.spec.js
+++ b/src/components/general-widgets/FeaturedRoomType/component.spec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Card, Image } from 'semantic-ui-react';
+import Card from 'semantic-ui-react/dist/commonjs/views/Card';
+import Image from 'semantic-ui-react/dist/commonjs/elements/Image';
 import {
   expectComponentToBe,
   expectComponentToHaveChildren,

--- a/src/components/general-widgets/Promotion/component.js
+++ b/src/components/general-widgets/Promotion/component.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Statistic, Segment } from 'semantic-ui-react';
+import Statistic from 'semantic-ui-react/dist/commonjs/views/Statistic';
+import Segment from 'semantic-ui-react/dist/commonjs/elements/Segment';
 import getClassNames from 'classnames';
 
 import {

--- a/src/components/general-widgets/Promotion/component.spec.js
+++ b/src/components/general-widgets/Promotion/component.spec.js
@@ -5,7 +5,8 @@ import {
   expectComponentToHaveChildren,
   expectComponentToHaveProps,
 } from '@lodgify/enzyme-jest-expect-helpers';
-import { Statistic, Segment } from 'semantic-ui-react';
+import Statistic from 'semantic-ui-react/dist/commonjs/views/Statistic';
+import Segment from 'semantic-ui-react/dist/commonjs/elements/Segment';
 
 import { BOOK_NOW_DISCOUNT, USE_COUPON_CODE } from 'utils/default-strings';
 import { Button } from 'elements/Button';

--- a/src/components/general-widgets/Review/component.js
+++ b/src/components/general-widgets/Review/component.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Card } from 'semantic-ui-react';
+import Card from 'semantic-ui-react/dist/commonjs/views/Card';
 
 import { Divider } from 'elements/Divider';
 import { Grid } from 'layout/Grid';

--- a/src/components/general-widgets/Review/component.spec.js
+++ b/src/components/general-widgets/Review/component.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Card } from 'semantic-ui-react';
+import Card from 'semantic-ui-react/dist/commonjs/views/Card';
 import {
   expectComponentToBe,
   expectComponentToHaveChildren,

--- a/src/components/general-widgets/SearchBar/component.js
+++ b/src/components/general-widgets/SearchBar/component.js
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import { Form } from 'semantic-ui-react';
+import Form from 'semantic-ui-react/dist/commonjs/collections/Form';
 
 import { CHECK_OUR_AVAILABILITY, SEARCH } from 'utils/default-strings';
 import { HorizontalGutters } from 'layout/HorizontalGutters';

--- a/src/components/general-widgets/SearchBar/component.spec.js
+++ b/src/components/general-widgets/SearchBar/component.spec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Form, Modal as SemanticModal } from 'semantic-ui-react';
+import Form from 'semantic-ui-react/dist/commonjs/collections/Form';
+import { default as SemanticModal } from 'semantic-ui-react/dist/commonjs/modules/Modal';
 import {
   expectComponentToBe,
   expectComponentToHaveChildren,

--- a/src/components/general-widgets/SearchBar/utils/getFormFieldMarkup.js
+++ b/src/components/general-widgets/SearchBar/utils/getFormFieldMarkup.js
@@ -1,6 +1,6 @@
 /* eslint react/prop-types: 0 */
 import React, { Fragment } from 'react';
-import { Form } from 'semantic-ui-react';
+import Form from 'semantic-ui-react/dist/commonjs/collections/Form';
 import { size } from 'lodash';
 
 import { Icon, ICON_NAMES } from 'elements/Icon';

--- a/src/components/general-widgets/SearchBar/utils/getFormFieldMarkup.spec.js
+++ b/src/components/general-widgets/SearchBar/utils/getFormFieldMarkup.spec.js
@@ -4,7 +4,7 @@ import {
   expectComponentToHaveChildren,
   expectComponentToHaveProps,
 } from '@lodgify/enzyme-jest-expect-helpers';
-import { Form } from 'semantic-ui-react';
+import Form from 'semantic-ui-react/dist/commonjs/collections/Form';
 
 import { Icon } from 'elements/Icon';
 import { Dropdown } from 'inputs/Dropdown';

--- a/src/components/general-widgets/SearchBar/utils/getSearchBarModal.js
+++ b/src/components/general-widgets/SearchBar/utils/getSearchBarModal.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Modal as SemanticModal, Form } from 'semantic-ui-react';
+import Form from 'semantic-ui-react/dist/commonjs/collections/Form';
+import { default as SemanticModal } from 'semantic-ui-react/dist/commonjs/modules/Modal';
 
 import { Heading } from 'typography/Heading';
 import { Modal } from 'elements/Modal';

--- a/src/components/general-widgets/SearchBar/utils/getSearchBarModal.spec.js
+++ b/src/components/general-widgets/SearchBar/utils/getSearchBarModal.spec.js
@@ -4,7 +4,8 @@ import {
   expectComponentToHaveChildren,
   expectComponentToHaveProps,
 } from '@lodgify/enzyme-jest-expect-helpers';
-import { Modal as SemanticModal, Form } from 'semantic-ui-react';
+import Form from 'semantic-ui-react/dist/commonjs/collections/Form';
+import { default as SemanticModal } from 'semantic-ui-react/dist/commonjs/modules/Modal';
 import { expectComponentToBe } from '@lodgify/enzyme-jest-expect-helpers/lib/expectComponentToBe';
 
 import { Heading } from 'typography/Heading';

--- a/src/components/inputs/CaptchaInput/component.js
+++ b/src/components/inputs/CaptchaInput/component.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Form, Image } from 'semantic-ui-react';
+import Form from 'semantic-ui-react/dist/commonjs/collections/Form';
+import Image from 'semantic-ui-react/dist/commonjs/elements/Image';
 
 import { TextInput } from 'inputs/TextInput';
 

--- a/src/components/inputs/CaptchaInput/component.spec.js
+++ b/src/components/inputs/CaptchaInput/component.spec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Form, Image } from 'semantic-ui-react';
+import Form from 'semantic-ui-react/dist/commonjs/collections/Form';
+import Image from 'semantic-ui-react/dist/commonjs/elements/Image';
 import {
   expectComponentToBe,
   expectComponentToHaveChildren,

--- a/src/components/inputs/Checkbox/component.js
+++ b/src/components/inputs/Checkbox/component.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Checkbox } from 'semantic-ui-react';
+import Checkbox from 'semantic-ui-react/dist/commonjs/modules/Checkbox';
 
 /**
  * A checkbox allows a user to select a value from a small set of options, often binary.

--- a/src/components/inputs/Checkbox/component.spec.js
+++ b/src/components/inputs/Checkbox/component.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Checkbox as SemanticCheckbox } from 'semantic-ui-react';
+import { default as SemanticCheckbox } from 'semantic-ui-react/dist/commonjs/modules/Checkbox';
 import {
   expectComponentToBe,
   expectComponentToHaveDisplayName,

--- a/src/components/inputs/DateRangePicker/component.spec.js
+++ b/src/components/inputs/DateRangePicker/component.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { DateRangePicker as ReactDatesDateRangePicker } from 'react-dates';
-import { Responsive } from 'semantic-ui-react';
+import Responsive from 'semantic-ui-react/dist/commonjs/addons/Responsive';
 import moment from 'moment';
 import {
   expectComponentToBe,

--- a/src/components/inputs/Dropdown/component.js
+++ b/src/components/inputs/Dropdown/component.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { Dropdown } from 'semantic-ui-react';
+import Dropdown from 'semantic-ui-react/dist/commonjs/modules/Dropdown';
 import getClassNames from 'classnames';
 
 import { getHasErrorMessage } from 'utils/get-has-error-message';

--- a/src/components/inputs/Dropdown/component.spec.js
+++ b/src/components/inputs/Dropdown/component.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Dropdown as SemanticDropdown } from 'semantic-ui-react';
+import { default as SemanticDropdown } from 'semantic-ui-react/dist/commonjs/modules/Dropdown';
 import {
   expectComponentToBe,
   expectComponentToHaveChildren,

--- a/src/components/inputs/ErrorMessage/component.js
+++ b/src/components/inputs/ErrorMessage/component.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Label } from 'semantic-ui-react';
+import Label from 'semantic-ui-react/dist/commonjs/elements/Label';
 
 /**
  * Error message for use with input elements

--- a/src/components/inputs/ErrorMessage/component.spec.js
+++ b/src/components/inputs/ErrorMessage/component.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Label } from 'semantic-ui-react';
+import Label from 'semantic-ui-react/dist/commonjs/elements/Label';
 import {
   expectComponentToBe,
   expectComponentToHaveChildren,

--- a/src/components/inputs/InputController/component.js
+++ b/src/components/inputs/InputController/component.js
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { isEqual, some } from 'lodash';
-import { Input } from 'semantic-ui-react';
+import Input from 'semantic-ui-react/dist/commonjs/elements/Input';
 import getClassNames from 'classnames';
 
 import { getHasErrorMessage } from 'utils/get-has-error-message';

--- a/src/components/inputs/InputController/component.spec.js
+++ b/src/components/inputs/InputController/component.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow, mount } from 'enzyme';
-import { Input } from 'semantic-ui-react';
+import Input from 'semantic-ui-react/dist/commonjs/elements/Input';
 import {
   expectComponentToBe,
   expectComponentToHaveChildren,

--- a/src/components/inputs/PhoneInput/utils/getIconOrFlag.js
+++ b/src/components/inputs/PhoneInput/utils/getIconOrFlag.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { lowerCase } from 'lodash';
-import { Flag } from 'semantic-ui-react';
+import Flag from 'semantic-ui-react/dist/commonjs/elements/Flag';
 
 import { Icon, ICON_NAMES } from 'elements/Icon';
 

--- a/src/components/inputs/PhoneInput/utils/getIconOrFlag.spec.js
+++ b/src/components/inputs/PhoneInput/utils/getIconOrFlag.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Flag } from 'semantic-ui-react';
+import Flag from 'semantic-ui-react/dist/commonjs/elements/Flag';
 
 import { Icon, ICON_NAMES } from 'elements/Icon';
 

--- a/src/components/layout/Grid/component.js
+++ b/src/components/layout/Grid/component.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Grid } from 'semantic-ui-react';
+import Grid from 'semantic-ui-react/dist/commonjs/collections/Grid';
 
 /**
  * Grid is the Lodgify UI interface for the

--- a/src/components/layout/Grid/component.spec.js
+++ b/src/components/layout/Grid/component.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Grid } from 'semantic-ui-react';
+import Grid from 'semantic-ui-react/dist/commonjs/collections/Grid';
 import {
   expectComponentToHaveProps,
   expectComponentToHaveDisplayName,

--- a/src/components/layout/GridColumn/component.js
+++ b/src/components/layout/GridColumn/component.js
@@ -1,14 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Grid } from 'semantic-ui-react';
+import GridColumn from 'semantic-ui-react/dist/commonjs/collections/Grid/GridColumn';
 
 /**
  * GridColumn is the Lodgify UI interface for the
- * Semantic UI Grid.Column.
+ * Semantic UI GridColumn.
  */
 // eslint-disable-next-line jsdoc/require-jsdoc
 export const Component = ({ verticalAlignContent, ...props }) => (
-  <Grid.Column {...props} verticalAlign={verticalAlignContent} />
+  <GridColumn {...props} verticalAlign={verticalAlignContent} />
 );
 
 Component.displayName = 'GridColumn';

--- a/src/components/layout/GridColumn/component.spec.js
+++ b/src/components/layout/GridColumn/component.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Grid } from 'semantic-ui-react';
+import { default as SemanticGridColumn } from 'semantic-ui-react/dist/commonjs/collections/Grid/GridColumn';
 import {
   expectComponentToHaveProps,
   expectComponentToHaveDisplayName,
@@ -15,7 +15,7 @@ describe('<GridColumn />', () => {
   it('should render a single Semantic UI `Grid.Column` component', () => {
     const wrapper = getGridColumn();
 
-    expectComponentToBe(wrapper, Grid.Column);
+    expectComponentToBe(wrapper, SemanticGridColumn);
   });
 
   describe('the Semantic UI `Grid` component', () => {

--- a/src/components/layout/GridRow/component.js
+++ b/src/components/layout/GridRow/component.js
@@ -1,14 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Grid } from 'semantic-ui-react';
+import GridRow from 'semantic-ui-react/dist/commonjs/collections/Grid/GridRow';
 
 /**
  * GridRow is the Lodgify UI interface for the
- * Semantic UI Grid.Row.
+ * Semantic UI GridRow.
  */
 // eslint-disable-next-line jsdoc/require-jsdoc
 export const Component = ({ horizontalAlignContent, ...props }) => (
-  <Grid.Row {...props} textAlign={horizontalAlignContent} />
+  <GridRow {...props} textAlign={horizontalAlignContent} />
 );
 
 Component.displayName = 'GridRow';

--- a/src/components/layout/GridRow/component.spec.js
+++ b/src/components/layout/GridRow/component.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Grid } from 'semantic-ui-react';
+import { default as SemanticGridRow } from 'semantic-ui-react/dist/commonjs/collections/Grid/GridRow';
 import {
   expectComponentToHaveProps,
   expectComponentToHaveDisplayName,
@@ -12,10 +12,10 @@ import { Component as GridRow } from './component';
 const getGridRow = props => shallow(<GridRow {...props} />);
 
 describe('<GridRow />', () => {
-  it('should render a single Semantic UI `Grid.Column` component', () => {
+  it('should render a single Semantic UI `GridRow` component', () => {
     const wrapper = getGridRow();
 
-    expectComponentToBe(wrapper, Grid.Row);
+    expectComponentToBe(wrapper, SemanticGridRow);
   });
 
   describe('the Semantic UI `Grid` component', () => {

--- a/src/components/layout/HorizontalGutters/component.js
+++ b/src/components/layout/HorizontalGutters/component.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Container } from 'semantic-ui-react';
+import Container from 'semantic-ui-react/dist/commonjs/elements/Container';
 
 /**
  * HorizontalGutters wraps child components with responsive

--- a/src/components/layout/HorizontalGutters/component.spec.js
+++ b/src/components/layout/HorizontalGutters/component.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Container } from 'semantic-ui-react';
+import Container from 'semantic-ui-react/dist/commonjs/elements/Container';
 import {
   expectComponentToHaveDisplayName,
   expectComponentToBe,

--- a/src/components/media/FullBleed/component.js
+++ b/src/components/media/FullBleed/component.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import getClassNames from 'classnames';
-import { Segment } from 'semantic-ui-react';
+import Segment from 'semantic-ui-react/dist/commonjs/elements/Segment';
 import { size } from 'lodash';
 
 import { getBackgroundImageUrl } from 'utils/get-background-image-url';

--- a/src/components/media/ResponsiveImage/component.js
+++ b/src/components/media/ResponsiveImage/component.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Image, Label } from 'semantic-ui-react';
+import Image from 'semantic-ui-react/dist/commonjs/elements/Image';
+import Label from 'semantic-ui-react/dist/commonjs/elements/Label';
 
 import {
   IMAGE_NOT_FOUND,

--- a/src/components/media/Slideshow/utils/renderNavButton.js
+++ b/src/components/media/Slideshow/utils/renderNavButton.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button } from 'semantic-ui-react';
+import Button from 'semantic-ui-react/dist/commonjs/elements/Button';
 
 import { Icon } from 'elements/Icon';
 

--- a/src/components/media/Slideshow/utils/renderNavButton.spec.js
+++ b/src/components/media/Slideshow/utils/renderNavButton.spec.js
@@ -1,4 +1,4 @@
-import { Button } from 'semantic-ui-react';
+import Button from 'semantic-ui-react/dist/commonjs/elements/Button';
 
 import { ICON_NAMES } from 'elements/Icon';
 

--- a/src/components/property-page-widgets/Amenities/component.spec.js
+++ b/src/components/property-page-widgets/Amenities/component.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Modal as SemanticModal } from 'semantic-ui-react';
+import { default as SemanticModal } from 'semantic-ui-react/dist/commonjs/modules/Modal';
 import {
   expectComponentToBe,
   expectComponentToHaveChildren,

--- a/src/components/property-page-widgets/Amenities/utils/getAmenityMarkup.spec.js
+++ b/src/components/property-page-widgets/Amenities/utils/getAmenityMarkup.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Modal as SemanticModal } from 'semantic-ui-react';
+import { default as SemanticModal } from 'semantic-ui-react/dist/commonjs/modules/Modal';
 import {
   expectComponentToHaveChildren,
   expectComponentToHaveProps,

--- a/src/components/property-page-widgets/Amenities/utils/getExtraItemsMarkup.js
+++ b/src/components/property-page-widgets/Amenities/utils/getExtraItemsMarkup.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Modal as SemanticModal } from 'semantic-ui-react';
+import { default as SemanticModal } from 'semantic-ui-react/dist/commonjs/modules/Modal';
 
 import { GridColumn } from 'layout/GridColumn';
 import { GridRow } from 'layout/GridRow';

--- a/src/components/property-page-widgets/Availability/component.js
+++ b/src/components/property-page-widgets/Availability/component.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { CalendarMonth, CalendarDay } from 'react-dates';
 import { BLOCKED_MODIFIER } from 'react-dates/constants';
 import moment from 'moment';
-import { Card } from 'semantic-ui-react';
+import Card from 'semantic-ui-react/dist/commonjs/views/Card';
 
 import { buildKeyFromStrings } from 'utils/build-key-from-strings';
 import { Paragraph } from 'typography/Paragraph';

--- a/src/components/property-page-widgets/Availability/component.spec.js
+++ b/src/components/property-page-widgets/Availability/component.spec.js
@@ -2,7 +2,8 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import moment from 'moment';
 import { CalendarMonth } from 'react-dates';
-import { Card, Responsive } from 'semantic-ui-react';
+import Card from 'semantic-ui-react/dist/commonjs/views/Card';
+import Responsive from 'semantic-ui-react/dist/commonjs/addons/Responsive';
 import {
   expectComponentToBe,
   expectComponentToHaveChildren,

--- a/src/components/property-page-widgets/Description/component.js
+++ b/src/components/property-page-widgets/Description/component.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { List } from 'semantic-ui-react';
+import List from 'semantic-ui-react/dist/commonjs/elements/List';
 
 import { HOME_HIGHLIGHTS } from 'utils/default-strings';
 import { buildKeyFromStrings } from 'utils/build-key-from-strings';

--- a/src/components/property-page-widgets/Description/component.spec.js
+++ b/src/components/property-page-widgets/Description/component.spec.js
@@ -6,8 +6,8 @@ import {
   expectComponentToHaveDisplayName,
   expectComponentToHaveProps,
 } from '@lodgify/enzyme-jest-expect-helpers';
-import { List } from 'semantic-ui-react';
-import { ListItem } from 'semantic-ui-react';
+import List from 'semantic-ui-react/dist/commonjs/elements/List';
+import ListItem from 'semantic-ui-react/dist/commonjs/elements/List/ListItem';
 
 import { getArrayOfLengthOfItem } from 'utils/get-array-of-length-of-item';
 import { getParagraphsFromStrings } from 'utils/get-paragraphs-from-strings';

--- a/src/components/property-page-widgets/Description/utils/formatParagraphWithModal.js
+++ b/src/components/property-page-widgets/Description/utils/formatParagraphWithModal.js
@@ -1,5 +1,5 @@
 import React, { Fragment } from 'react';
-import { Button } from 'semantic-ui-react';
+import Button from 'semantic-ui-react/dist/commonjs/elements/Button';
 
 import { Modal } from 'elements/Modal';
 import { getParagraphsFromStrings } from 'utils/get-paragraphs-from-strings';

--- a/src/components/property-page-widgets/Description/utils/formatParagraphWithModal.spec.js
+++ b/src/components/property-page-widgets/Description/utils/formatParagraphWithModal.spec.js
@@ -4,7 +4,7 @@ import {
   expectComponentToHaveChildren,
   expectComponentToHaveProps,
 } from '@lodgify/enzyme-jest-expect-helpers';
-import { Button } from 'semantic-ui-react';
+import Button from 'semantic-ui-react/dist/commonjs/elements/Button';
 
 import { getArrayOfLengthOfItem } from 'utils/get-array-of-length-of-item';
 import { getParagraphsFromStrings } from 'utils/get-paragraphs-from-strings';

--- a/src/components/property-page-widgets/HostProfile/component.js
+++ b/src/components/property-page-widgets/HostProfile/component.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { List, Item } from 'semantic-ui-react';
+import List from 'semantic-ui-react/dist/commonjs/elements/List';
+import Item from 'semantic-ui-react/dist/commonjs/views/Item';
 
 import {
   CONTACT_INFORMATION,

--- a/src/components/property-page-widgets/HostProfile/component.spec.js
+++ b/src/components/property-page-widgets/HostProfile/component.spec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { List, Item } from 'semantic-ui-react';
+import List from 'semantic-ui-react/dist/commonjs/elements/List';
+import Item from 'semantic-ui-react/dist/commonjs/views/Item';
 import {
   expectComponentToHaveChildren,
   expectComponentToHaveProps,

--- a/src/components/property-page-widgets/KeyFacts/component.js
+++ b/src/components/property-page-widgets/KeyFacts/component.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Label } from 'semantic-ui-react';
+import Label from 'semantic-ui-react/dist/commonjs/elements/Label';
 
 import { KEY_FACTS } from 'utils/default-strings';
 import { buildKeyFromStrings } from 'utils/build-key-from-strings';

--- a/src/components/property-page-widgets/KeyFacts/component.spec.js
+++ b/src/components/property-page-widgets/KeyFacts/component.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Label } from 'semantic-ui-react';
+import Label from 'semantic-ui-react/dist/commonjs/elements/Label';
 import {
   expectComponentToHaveChildren,
   expectComponentToHaveProps,

--- a/src/components/property-page-widgets/Location/component.spec.js
+++ b/src/components/property-page-widgets/Location/component.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { mount, shallow } from 'enzyme';
-import { Responsive } from 'semantic-ui-react';
+import Responsive from 'semantic-ui-react/dist/commonjs/addons/Responsive';
 import {
   expectComponentToBe,
   expectComponentToHaveDisplayName,

--- a/src/components/property-page-widgets/Location/utils/getTransportOptionsMarkup.js
+++ b/src/components/property-page-widgets/Location/utils/getTransportOptionsMarkup.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Label } from 'semantic-ui-react';
+import Label from 'semantic-ui-react/dist/commonjs/elements/Label';
 
 import { buildKeyFromStrings } from 'utils/build-key-from-strings';
 import { getFirstFourItems } from 'utils/get-first-four-items';

--- a/src/components/property-page-widgets/PaymentInformation/component.js
+++ b/src/components/property-page-widgets/PaymentInformation/component.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Statistic } from 'semantic-ui-react';
+import Statistic from 'semantic-ui-react/dist/commonjs/views/Statistic';
 
 import { getParagraphsFromStrings } from 'utils/get-paragraphs-from-strings';
 import { buildKeyFromStrings } from 'utils/build-key-from-strings';

--- a/src/components/property-page-widgets/PaymentInformation/component.spec.js
+++ b/src/components/property-page-widgets/PaymentInformation/component.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Statistic } from 'semantic-ui-react';
+import Statistic from 'semantic-ui-react/dist/commonjs/views/Statistic';
 import {
   expectComponentToBe,
   expectComponentToHaveChildren,

--- a/src/components/property-page-widgets/Rates/component.js
+++ b/src/components/property-page-widgets/Rates/component.js
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
-import { Card } from 'semantic-ui-react';
+import Card from 'semantic-ui-react/dist/commonjs/views/Card';
 
 import {
   VIEW_RATE_INFORMATION_FOR,

--- a/src/components/property-page-widgets/RoomType/component.js
+++ b/src/components/property-page-widgets/RoomType/component.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Card } from 'semantic-ui-react';
+import Card from 'semantic-ui-react/dist/commonjs/views/Card';
 
 import { Divider } from 'elements/Divider';
 import { Grid } from 'layout/Grid';

--- a/src/components/property-page-widgets/RoomType/utils/getModalContentMarkup.js
+++ b/src/components/property-page-widgets/RoomType/utils/getModalContentMarkup.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Modal, List } from 'semantic-ui-react';
+import Modal from 'semantic-ui-react/dist/commonjs/modules/Modal';
+import List from 'semantic-ui-react/dist/commonjs/elements/List';
 
 import { buildKeyFromStrings } from 'utils/build-key-from-strings';
 import { Amenities } from 'property-page-widgets/Amenities';

--- a/src/components/property-page-widgets/RoomType/utils/getModalContentMarkup.spec.js
+++ b/src/components/property-page-widgets/RoomType/utils/getModalContentMarkup.spec.js
@@ -4,7 +4,8 @@ import {
   expectComponentToHaveChildren,
   expectComponentToHaveProps,
 } from '@lodgify/enzyme-jest-expect-helpers';
-import { List, ListItem } from 'semantic-ui-react';
+import List from 'semantic-ui-react/dist/commonjs/elements/List';
+import ListItem from 'semantic-ui-react/dist/commonjs/elements/List/ListItem';
 
 import { getArrayOfLengthOfItem } from 'utils/get-array-of-length-of-item';
 import { Amenities } from 'property-page-widgets/Amenities';

--- a/src/components/property-page-widgets/RoomType/utils/getRoomFeaturesMarkup.js
+++ b/src/components/property-page-widgets/RoomType/utils/getRoomFeaturesMarkup.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { List } from 'semantic-ui-react';
+import List from 'semantic-ui-react/dist/commonjs/elements/List';
 
 import { GridColumn } from 'layout/GridColumn';
 import { Icon } from 'elements/Icon';

--- a/src/components/property-page-widgets/RoomType/utils/getRoomFeaturesMarkup.spec.js
+++ b/src/components/property-page-widgets/RoomType/utils/getRoomFeaturesMarkup.spec.js
@@ -5,7 +5,7 @@ import {
   expectComponentToHaveChildren,
   expectComponentToHaveProps,
 } from '@lodgify/enzyme-jest-expect-helpers';
-import { List } from 'semantic-ui-react';
+import List from 'semantic-ui-react/dist/commonjs/elements/List';
 
 import { GridColumn } from 'layout/GridColumn';
 import { getArrayOfLengthOfItem } from 'utils/get-array-of-length-of-item';

--- a/src/components/property-page-widgets/Rules/component.js
+++ b/src/components/property-page-widgets/Rules/component.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { List } from 'semantic-ui-react';
+import List from 'semantic-ui-react/dist/commonjs/elements/List';
 import { size } from 'lodash';
 
 import { buildKeyFromStrings } from 'utils/build-key-from-strings';

--- a/src/components/property-page-widgets/Summary/component.js
+++ b/src/components/property-page-widgets/Summary/component.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Segment } from 'semantic-ui-react';
+import Segment from 'semantic-ui-react/dist/commonjs/elements/Segment';
 
 import { ShowOnDesktop } from 'layout/ShowOnDesktop';
 import { ShowOnMobile } from 'layout/ShowOnMobile';

--- a/src/components/property-page-widgets/Summary/utils/getLocationNameMarkup.js
+++ b/src/components/property-page-widgets/Summary/utils/getLocationNameMarkup.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Segment } from 'semantic-ui-react';
+import Segment from 'semantic-ui-react/dist/commonjs/elements/Segment';
 
 import { Icon, ICON_NAMES } from 'elements/Icon';
 

--- a/src/components/property-page-widgets/Summary/utils/getLocationNameMarkup.spec.js
+++ b/src/components/property-page-widgets/Summary/utils/getLocationNameMarkup.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Segment } from 'semantic-ui-react';
+import Segment from 'semantic-ui-react/dist/commonjs/elements/Segment';
 import {
   expectComponentToBe,
   expectComponentToHaveChildren,

--- a/src/components/property-page-widgets/Summary/utils/getNightPriceAndRatingMarkup.js
+++ b/src/components/property-page-widgets/Summary/utils/getNightPriceAndRatingMarkup.js
@@ -1,5 +1,5 @@
 import React, { Fragment } from 'react';
-import { Segment } from 'semantic-ui-react';
+import Segment from 'semantic-ui-react/dist/commonjs/elements/Segment';
 
 import { getNightPriceMarkup } from 'utils/get-night-price-markup';
 import { Rating } from 'elements/Rating';

--- a/src/components/property-page-widgets/Summary/utils/getNightPriceAndRatingMarkup.spec.js
+++ b/src/components/property-page-widgets/Summary/utils/getNightPriceAndRatingMarkup.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Segment } from 'semantic-ui-react';
+import Segment from 'semantic-ui-react/dist/commonjs/elements/Segment';
 import {
   expectComponentToHaveChildren,
   expectComponentToHaveProps,

--- a/src/components/property-page-widgets/Summary/utils/getNightPriceRatingAndLocationMarkup.js
+++ b/src/components/property-page-widgets/Summary/utils/getNightPriceRatingAndLocationMarkup.js
@@ -1,5 +1,5 @@
 import React, { Fragment } from 'react';
-import { Segment } from 'semantic-ui-react';
+import Segment from 'semantic-ui-react/dist/commonjs/elements/Segment';
 
 import { getNightPriceMarkup } from 'utils/get-night-price-markup';
 import { Rating } from 'elements/Rating';

--- a/src/components/property-page-widgets/Summary/utils/getNightPriceRatingAndLocationMarkup.spec.js
+++ b/src/components/property-page-widgets/Summary/utils/getNightPriceRatingAndLocationMarkup.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Segment } from 'semantic-ui-react';
+import Segment from 'semantic-ui-react/dist/commonjs/elements/Segment';
 import {
   expectComponentToHaveChildren,
   expectComponentToHaveProps,

--- a/src/components/typography/Heading/component.js
+++ b/src/components/typography/Heading/component.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Header } from 'semantic-ui-react';
+import Header from 'semantic-ui-react/dist/commonjs/elements/Header';
 
 import { getHeadingNumber } from './getHeadingNumber';
 

--- a/src/components/typography/Heading/component.spec.js
+++ b/src/components/typography/Heading/component.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Header } from 'semantic-ui-react';
+import Header from 'semantic-ui-react/dist/commonjs/elements/Header';
 import {
   expectComponentToBe,
   expectComponentToHaveProps,

--- a/src/utils/with-responsive/withResponsive.js
+++ b/src/utils/with-responsive/withResponsive.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Responsive } from 'semantic-ui-react';
+import Responsive from 'semantic-ui-react/dist/commonjs/addons/Responsive';
 
 import { TABLET_BREAKPOINT } from './constants';
 

--- a/src/utils/with-responsive/withResponsive.spec.js
+++ b/src/utils/with-responsive/withResponsive.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow, mount } from 'enzyme';
-import { Responsive } from 'semantic-ui-react';
+import Responsive from 'semantic-ui-react/dist/commonjs/addons/Responsive';
 import {
   expectComponentToBe,
   expectComponentToHaveProps,


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1276)

### What **one** thing does this PR do?
Import each Semantic UI react components by path. 

### other notes
The Semantic components are imported from the `/commonjs` folder because Jest does not yet have support for ES modules.
- The support for this is being discussed here `https://github.com/facebook/jest/issues/4842`
- The component is visually and functionally the same no matter if imported with ES modules or CommonJS
