### PR TITLE
TE-1291 Move `moment` from dependencies to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "size-limit": [
     {
-      "limit": "321 KB",
+      "limit": "256 KB",
       "path": "lib/index.js"
     }
   ],

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "build:less": "webpack --config $npm_package_config_less_build_config",
     "build:js": "BABEL_ENV=production babel src/ -d lib/",
     "commit": "git-cz",
-    "install:peers": "npm install react@^16.3.2 react-dom@^16.3.2 --no-save",
+    "install:peers": "npm install react@^16.3.2 react-dom@^16.3.2 moment@^2.18.1 --no-save",
     "lint": "run-p lint:js lint:less",
     "lint:js": "eslint . --ext .js,.jsx",
     "lint:js:debug": "npm run lint:js -- --debug",
@@ -113,7 +113,6 @@
     "is-url": "^1.2.4",
     "libphonenumber-js": "^1.1.9",
     "lodash": "^4.17.5",
-    "moment": "^2.22.1",
     "react-dates": "^17.0.0",
     "react-google-maps": "^9.4.5",
     "react-image-gallery": "^0.8.7",
@@ -123,6 +122,7 @@
     "semantic-ui-react": "^0.79.1"
   },
   "peerDependencies": {
+    "moment": "^2.18.1",
     "react": ">=0.14.0 <= 16",
     "react-dom": ">=0.14.0 <= 16"
   }


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1291)

### What **one** thing does this PR do?
Move `moment` from dependencies to peerDependencies

### Any other notes
Since `moment` objects are exposed at the `@lodgify/ui` interface, the library ought to be a peer dependency.

This also reduce the 'library' size significantly. It is up to the consumer of the library how the choose to optimise `moment`. There are a bunch of optimisations which can be made.

### Before
```sh
  Package size: 320.06 KB
  Size limit:   350 KB
```
### After
```sh
  Package size: 251.59 KB
  Size limit:   321 KB
```