### PR TITLE
TE-1276: Add babel import plugin for Semantic Ui React components

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,7 +2,10 @@
   "env": {
     "production": {
       "comments": false,
-      "ignore": ["**/*.spec.js"]
+      "ignore": ["**/*.spec.js"],
+      "plugins": [
+        "semantic-ui-react-transform-imports"
+      ]
     }
   },
   "presets": [ "@babel/react", "@babel/env" ],

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "size-limit": [
     {
-      "limit": "256 KB",
+      "limit": "247 KB",
       "path": "lib/index.js"
     }
   ],

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "babel-loader": "^8.0.2",
     "babel-plugin-lodash": "^3.3.4",
     "babel-plugin-module-resolver": "^3.1.1",
+    "babel-plugin-semantic-ui-react-transform-imports": "^1.3.2",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.19",
     "commitizen": "^2.9.6",
     "css-loader": "^0.28.10",


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1276)

### What **one** thing does this PR do?
Reduces the overall build size by converting our Semantic UI React imports into path imports when babel transforms our code.

### On the babel plugin
- This plugin for Babel was implemented since the official plugin does not yet support Babel 7 https://www.npmjs.com/package/babel-plugin-semantic-ui-react-transform-imports
- Discussed here `https://github.com/skleeschulte/babel-plugin-transform-semantic-ui-react-imports/pull/2`

### Before - Current build size in production
```
Package size: 251.82 KB
Size limit:   256 KB
```

### After - The build size after this change

```
Package size: 246.4 KB
Size limit:   247 KB
```
