### PR TITLE
TE-1303 Thumbnail to use ResponsiveImage

### DIFF
--- a/src/components/collections/Hero/__snapshots__/component.spec.js.snap
+++ b/src/components/collections/Hero/__snapshots__/component.spec.js.snap
@@ -54,12 +54,14 @@ exports[`<Hero /> by default should render the right structure 1`] = `
       >
         <ResponsiveImage
           alternativeText="Image Widget"
+          hasRoundedCorners={false}
           imageHeight={null}
           imageNotFoundLabelText="Image not found!"
           imageTitle="Image Title"
           imageUrl="https://darkpurple.com"
           imageWidth={null}
           isAvatar={false}
+          isCircular={false}
           isFluid={true}
           label={null}
           placeholderImageUrl={null}

--- a/src/components/general-widgets/HomepageHero/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/HomepageHero/__snapshots__/component.spec.js.snap
@@ -106,12 +106,14 @@ exports[`HomepageHero by default should render the right structure 1`] = `
         >
           <ResponsiveImage
             alternativeText="Image Widget"
+            hasRoundedCorners={false}
             imageHeight={null}
             imageNotFoundLabelText="Image not found!"
             imageTitle="Image Title"
             imageUrl="url"
             imageWidth={null}
             isAvatar={false}
+            isCircular={false}
             isFluid={true}
             label={null}
             placeholderImageUrl={null}

--- a/src/components/general-widgets/Promotion/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/Promotion/__snapshots__/component.spec.js.snap
@@ -63,12 +63,14 @@ exports[`The \`Promotion\` component \`Promotion\` as stacked \`Segment\` should
                       >
                         <ResponsiveImage
                           alternativeText="Image Widget"
+                          hasRoundedCorners={false}
                           imageHeight={null}
                           imageNotFoundLabelText="Image not found!"
                           imageTitle="Image Title"
                           imageUrl="testimage"
                           imageWidth={null}
                           isAvatar={false}
+                          isCircular={false}
                           isFluid={true}
                           label={null}
                           placeholderImageUrl={null}
@@ -381,12 +383,14 @@ exports[`The \`Promotion\` component should have the right structure 1`] = `
                       >
                         <ResponsiveImage
                           alternativeText="Image Widget"
+                          hasRoundedCorners={false}
                           imageHeight={null}
                           imageNotFoundLabelText="Image not found!"
                           imageTitle="Image Title"
                           imageUrl="testimage"
                           imageWidth={null}
                           isAvatar={false}
+                          isCircular={false}
                           isFluid={true}
                           label={null}
                           placeholderImageUrl={null}

--- a/src/components/media/FullBleed/__snapshots__/component.spec.js.snap
+++ b/src/components/media/FullBleed/__snapshots__/component.spec.js.snap
@@ -15,12 +15,14 @@ exports[`<FullBleed /> by default should have the right structure 1`] = `
     >
       <ResponsiveImage
         alternativeText="Image Widget"
+        hasRoundedCorners={false}
         imageHeight={null}
         imageNotFoundLabelText="Image not found!"
         imageTitle="Image Title"
         imageUrl="🐱🐱"
         imageWidth={null}
         isAvatar={false}
+        isCircular={false}
         isFluid={true}
         label={null}
         placeholderImageUrl={null}
@@ -72,12 +74,14 @@ exports[`<FullBleed /> if \`hasGradient\` is passed should have the right struct
     >
       <ResponsiveImage
         alternativeText="Image Widget"
+        hasRoundedCorners={false}
         imageHeight={null}
         imageNotFoundLabelText="Image not found!"
         imageTitle="Image Title"
         imageUrl="🐱🐱"
         imageWidth={null}
         isAvatar={false}
+        isCircular={false}
         isFluid={true}
         label={null}
         placeholderImageUrl={null}
@@ -129,12 +133,14 @@ exports[`<FullBleed /> if \`props.children > 0\` should have the right structure
     >
       <ResponsiveImage
         alternativeText="Image Widget"
+        hasRoundedCorners={false}
         imageHeight={null}
         imageNotFoundLabelText="Image not found!"
         imageTitle="Image Title"
         imageUrl="🐱🐱"
         imageWidth={null}
         isAvatar={false}
+        isCircular={false}
         isFluid={true}
         label={null}
         placeholderImageUrl={null}

--- a/src/components/media/ResponsiveImage/Readme.md
+++ b/src/components/media/ResponsiveImage/Readme.md
@@ -69,6 +69,24 @@
 </div>
 ```
 
+#### Rounded corners
+
+```jsx
+<ResponsiveImage
+  imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=600&mode=max"
+  hasRoundedCorners
+/>
+```
+
+#### Circular
+
+```jsx
+<ResponsiveImage
+  imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=600&mode=max"
+  isCircular
+/>
+```
+
 #### No url
 
 ```jsx

--- a/src/components/media/ResponsiveImage/__snapshots__/component.spec.js.snap
+++ b/src/components/media/ResponsiveImage/__snapshots__/component.spec.js.snap
@@ -3,12 +3,14 @@
 exports[`<ResponsiveImage /> by default should have the right structure 1`] = `
 <ResponsiveImage
   alternativeText="Alternative Text 😝"
+  hasRoundedCorners={false}
   imageHeight={null}
   imageNotFoundLabelText="Image not found!"
   imageTitle="ResponsiveImage title"
   imageUrl=""
   imageWidth={null}
   isAvatar={false}
+  isCircular={false}
   isFluid={true}
   label={null}
   onLoad={[Function]}
@@ -56,12 +58,14 @@ exports[`<ResponsiveImage /> by default should have the right structure 1`] = `
 exports[`<ResponsiveImage /> if \`props.label\` is passed should have the right structure 1`] = `
 <ResponsiveImage
   alternativeText="Alternative Text 😝"
+  hasRoundedCorners={false}
   imageHeight={null}
   imageNotFoundLabelText="Image not found!"
   imageTitle="ResponsiveImage title"
   imageUrl=""
   imageWidth={null}
   isAvatar={false}
+  isCircular={false}
   isFluid={true}
   label="🔷"
   onLoad={[Function]}
@@ -119,12 +123,14 @@ exports[`<ResponsiveImage /> if \`props.label\` is passed should have the right 
 exports[`<ResponsiveImage /> if \`props.placeholderImageUrl\` and \`props.imageUrl\` are passed should have the right structure 1`] = `
 <ResponsiveImage
   alternativeText="Alternative Text 😝"
+  hasRoundedCorners={false}
   imageHeight={null}
   imageNotFoundLabelText="Image not found!"
   imageTitle="ResponsiveImage title"
   imageUrl="yooo"
   imageWidth={null}
   isAvatar={false}
+  isCircular={false}
   isFluid={true}
   label={null}
   onLoad={[Function]}
@@ -178,12 +184,14 @@ exports[`<ResponsiveImage /> if \`props.placeholderImageUrl\` and \`props.imageU
 exports[`<ResponsiveImage /> if \`props.placeholderImageUrl\` is passed should have the right structure 1`] = `
 <ResponsiveImage
   alternativeText="Alternative Text 😝"
+  hasRoundedCorners={false}
   imageHeight={null}
   imageNotFoundLabelText="Image not found!"
   imageTitle="ResponsiveImage title"
   imageUrl=""
   imageWidth={null}
   isAvatar={false}
+  isCircular={false}
   isFluid={true}
   label={null}
   onLoad={[Function]}
@@ -232,12 +240,14 @@ exports[`<ResponsiveImage /> if \`props.placeholderImageUrl\` is passed should h
 exports[`<ResponsiveImage /> if \`props.sources\` is passed should have the right structure 1`] = `
 <ResponsiveImage
   alternativeText="Alternative Text 😝"
+  hasRoundedCorners={false}
   imageHeight={null}
   imageNotFoundLabelText="Image not found!"
   imageTitle="ResponsiveImage title"
   imageUrl=""
   imageWidth={null}
   isAvatar={false}
+  isCircular={false}
   isFluid={true}
   label={null}
   onLoad={[Function]}

--- a/src/components/media/ResponsiveImage/component.js
+++ b/src/components/media/ResponsiveImage/component.js
@@ -31,6 +31,8 @@ export class Component extends PureComponent {
       placeholderImageUrl,
       imageUrl,
       isFluid,
+      hasRoundedCorners,
+      isCircular,
     } = this.props;
 
     const imageProps = {
@@ -43,6 +45,8 @@ export class Component extends PureComponent {
       <picture
         className={getClassNames('responsive-image', {
           'is-fluid': isFluid,
+          'is-rounded': hasRoundedCorners,
+          'is-circular': isCircular,
         })}
         role="figure"
       >
@@ -66,48 +70,54 @@ Component.displayName = 'ResponsiveImage';
 
 Component.defaultProps = {
   alternativeText: IMAGE_WIDGET,
+  hasRoundedCorners: false,
   imageHeight: null,
   imageNotFoundLabelText: IMAGE_NOT_FOUND,
   imageTitle: IMAGE_TITLE,
   imageUrl: '',
+  imageWidth: null,
   isAvatar: false,
+  isCircular: false,
   isFluid: true,
   label: null,
   placeholderImageUrl: undefined,
   sources: [],
-  imageWidth: null,
 };
 
 Component.propTypes = {
-  /** Alternative text to show if the image can't be loaded by the browser */
+  /** Alternative text to show if the image can't be loaded by the browser. */
   // eslint-disable-next-line react/no-unused-prop-types
   alternativeText: PropTypes.string,
-  /** The height of the image */
+  /** Is the image rounded on the corners. */
+  hasRoundedCorners: PropTypes.bool,
+  /** The height of the image. */
   // eslint-disable-next-line react/no-unused-prop-types
   imageHeight: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   /** The label text for the when the image is not found. */
   // eslint-disable-next-line react/no-unused-prop-types
   imageNotFoundLabelText: PropTypes.string,
-  /** Title of the image to show when hovering it on desktop browsers */
+  /** Title of the image to show when hovering it on desktop browsers. */
   // eslint-disable-next-line react/no-unused-prop-types
   imageTitle: PropTypes.string,
-  /** URL pointing to the image to render */
+  /** URL pointing to the image to render. */
   // eslint-disable-next-line react/no-unused-prop-types
   imageUrl: PropTypes.string,
-  /** The width of the image */
+  /** The width of the image. */
   // eslint-disable-next-line react/no-unused-prop-types
   imageWidth: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  /** Whether to render the image as an avatar */
+  /** Whether to render the image as an avatar. */
   // eslint-disable-next-line react/no-unused-prop-types
   isAvatar: PropTypes.bool,
-  /** Whether to render fluidly the image or not */
+  /** Is the image circular. */
+  isCircular: PropTypes.bool,
+  /** Whether to render fluidly the image or not. */
   // eslint-disable-next-line react/no-unused-prop-types
   isFluid: PropTypes.bool,
-  /** A visible label for the image */
+  /** A visible label for the image. */
   label: PropTypes.string,
-  /** URL pointing to the placeholder image to render */
+  /** URL pointing to the placeholder image to render. */
   placeholderImageUrl: PropTypes.string,
-  /** Collection of objects to specify different image sources
+  /** Collection of objects to specify different image sources.
    *  [See this for more info](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images)
    */
   sources: PropTypes.arrayOf(

--- a/src/components/media/Thumbnail/__snapshots__/component.spec.js.snap
+++ b/src/components/media/Thumbnail/__snapshots__/component.spec.js.snap
@@ -1,0 +1,293 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Thumbnail /> by default should render the right structure 1`] = `
+<Thumbnail
+  alternativeText="Thumbnail element"
+  className="🚥"
+  imageUrl="www.⚡️.net"
+  isSquare={false}
+  label={null}
+  placeholderImageUrl={null}
+  size={null}
+>
+  <div
+    className="ui thumbnail 🚥"
+  >
+    <ResponsiveImage
+      alternativeText="Thumbnail element"
+      hasRoundedCorners={false}
+      imageHeight={null}
+      imageNotFoundLabelText="Image not found!"
+      imageTitle="Image Title"
+      imageUrl="www.⚡️.net"
+      imageWidth={null}
+      isAvatar={false}
+      isCircular={false}
+      isFluid={true}
+      label={null}
+      placeholderImageUrl={null}
+      sources={Array []}
+    >
+      <picture
+        className="responsive-image is-fluid"
+        role="figure"
+      >
+        <Image
+          alt="Thumbnail element"
+          as="img"
+          avatar={false}
+          fluid={true}
+          height={null}
+          src="www.⚡️.net"
+          title="Image Title"
+          ui={true}
+          width={null}
+        >
+          <img
+            alt="Thumbnail element"
+            className="ui fluid image"
+            height={null}
+            src="www.⚡️.net"
+            title="Image Title"
+            width={null}
+          />
+        </Image>
+      </picture>
+    </ResponsiveImage>
+  </div>
+</Thumbnail>
+`;
+
+exports[`<Thumbnail /> if \`props.isCircular\` is true should render the right structure 1`] = `
+<Thumbnail
+  alternativeText="Thumbnail element"
+  className="🚥"
+  imageUrl="www.⚡️.net"
+  isCircular={true}
+  isSquare={false}
+  label={null}
+  placeholderImageUrl={null}
+  size={null}
+>
+  <div
+    className="ui thumbnail 🚥 proportional-width-and-height"
+  >
+    <ResponsiveImage
+      alternativeText="Thumbnail element"
+      hasRoundedCorners={false}
+      imageHeight={null}
+      imageNotFoundLabelText="Image not found!"
+      imageTitle="Image Title"
+      imageUrl="www.⚡️.net"
+      imageWidth={null}
+      isAvatar={false}
+      isCircular={true}
+      isFluid={true}
+      label={null}
+      placeholderImageUrl={null}
+      sources={Array []}
+    >
+      <picture
+        className="responsive-image is-fluid circular"
+        role="figure"
+      >
+        <Image
+          alt="Thumbnail element"
+          as="img"
+          avatar={false}
+          fluid={true}
+          height={null}
+          src="www.⚡️.net"
+          title="Image Title"
+          ui={true}
+          width={null}
+        >
+          <img
+            alt="Thumbnail element"
+            className="ui fluid image"
+            height={null}
+            src="www.⚡️.net"
+            title="Image Title"
+            width={null}
+          />
+        </Image>
+      </picture>
+    </ResponsiveImage>
+  </div>
+</Thumbnail>
+`;
+
+exports[`<Thumbnail /> if \`props.isSquare\` is true should render the right structure 1`] = `
+<Thumbnail
+  alternativeText="Thumbnail element"
+  className="🚥"
+  imageUrl="www.⚡️.net"
+  isCircular={true}
+  isSquare={false}
+  label={null}
+  placeholderImageUrl={null}
+  size={null}
+>
+  <div
+    className="ui thumbnail 🚥 proportional-width-and-height"
+  >
+    <ResponsiveImage
+      alternativeText="Thumbnail element"
+      hasRoundedCorners={false}
+      imageHeight={null}
+      imageNotFoundLabelText="Image not found!"
+      imageTitle="Image Title"
+      imageUrl="www.⚡️.net"
+      imageWidth={null}
+      isAvatar={false}
+      isCircular={true}
+      isFluid={true}
+      label={null}
+      placeholderImageUrl={null}
+      sources={Array []}
+    >
+      <picture
+        className="responsive-image is-fluid circular"
+        role="figure"
+      >
+        <Image
+          alt="Thumbnail element"
+          as="img"
+          avatar={false}
+          fluid={true}
+          height={null}
+          src="www.⚡️.net"
+          title="Image Title"
+          ui={true}
+          width={null}
+        >
+          <img
+            alt="Thumbnail element"
+            className="ui fluid image"
+            height={null}
+            src="www.⚡️.net"
+            title="Image Title"
+            width={null}
+          />
+        </Image>
+      </picture>
+    </ResponsiveImage>
+  </div>
+</Thumbnail>
+`;
+
+exports[`<Thumbnail /> if \`props.size\` is supplied should render the right structure 1`] = `
+<Thumbnail
+  alternativeText="Thumbnail element"
+  className="🚥"
+  imageUrl="www.⚡️.net"
+  isSquare={false}
+  label={null}
+  placeholderImageUrl={null}
+  size="small"
+>
+  <div
+    className="ui thumbnail 🚥 small"
+  >
+    <ResponsiveImage
+      alternativeText="Thumbnail element"
+      hasRoundedCorners={false}
+      imageHeight={null}
+      imageNotFoundLabelText="Image not found!"
+      imageTitle="Image Title"
+      imageUrl="www.⚡️.net"
+      imageWidth={null}
+      isAvatar={false}
+      isCircular={false}
+      isFluid={true}
+      label={null}
+      placeholderImageUrl={null}
+      sources={Array []}
+    >
+      <picture
+        className="responsive-image is-fluid"
+        role="figure"
+      >
+        <Image
+          alt="Thumbnail element"
+          as="img"
+          avatar={false}
+          fluid={true}
+          height={null}
+          src="www.⚡️.net"
+          title="Image Title"
+          ui={true}
+          width={null}
+        >
+          <img
+            alt="Thumbnail element"
+            className="ui fluid image"
+            height={null}
+            src="www.⚡️.net"
+            title="Image Title"
+            width={null}
+          />
+        </Image>
+      </picture>
+    </ResponsiveImage>
+  </div>
+</Thumbnail>
+`;
+
+exports[`<Thumbnail /> should render the right structure 1`] = `
+<Thumbnail
+  alternativeText="Thumbnail element"
+  className="🚥"
+  imageUrl="www.⚡️.net"
+  isSquare={false}
+  label={null}
+  placeholderImageUrl={null}
+  size={null}
+>
+  <div
+    className="ui thumbnail 🚥"
+  >
+    <ResponsiveImage
+      alternativeText="Thumbnail element"
+      hasRoundedCorners={false}
+      imageHeight={null}
+      imageNotFoundLabelText="Image not found!"
+      imageTitle="Image Title"
+      imageUrl="www.⚡️.net"
+      imageWidth={null}
+      isAvatar={false}
+      isCircular={false}
+      isFluid={true}
+      label={null}
+      placeholderImageUrl={null}
+      sources={Array []}
+    >
+      <picture
+        className="responsive-image is-fluid"
+        role="figure"
+      >
+        <Image
+          alt="Thumbnail element"
+          as="img"
+          avatar={false}
+          fluid={true}
+          height={null}
+          src="www.⚡️.net"
+          title="Image Title"
+          ui={true}
+          width={null}
+        >
+          <img
+            alt="Thumbnail element"
+            className="ui fluid image"
+            height={null}
+            src="www.⚡️.net"
+            title="Image Title"
+            width={null}
+          />
+        </Image>
+      </picture>
+    </ResponsiveImage>
+  </div>
+</Thumbnail>
+`;

--- a/src/components/media/Thumbnail/__snapshots__/component.spec.js.snap
+++ b/src/components/media/Thumbnail/__snapshots__/component.spec.js.snap
@@ -88,7 +88,7 @@ exports[`<Thumbnail /> if \`props.isCircular\` is true should render the right s
       sources={Array []}
     >
       <picture
-        className="responsive-image is-fluid circular"
+        className="responsive-image is-fluid is-circular"
         role="figure"
       >
         <Image
@@ -147,7 +147,7 @@ exports[`<Thumbnail /> if \`props.isSquare\` is true should render the right str
       sources={Array []}
     >
       <picture
-        className="responsive-image is-fluid circular"
+        className="responsive-image is-fluid is-circular"
         role="figure"
       >
         <Image
@@ -188,64 +188,6 @@ exports[`<Thumbnail /> if \`props.size\` is supplied should render the right str
 >
   <div
     className="ui thumbnail 🚥 small"
-  >
-    <ResponsiveImage
-      alternativeText="Thumbnail element"
-      hasRoundedCorners={false}
-      imageHeight={null}
-      imageNotFoundLabelText="Image not found!"
-      imageTitle="Image Title"
-      imageUrl="www.⚡️.net"
-      imageWidth={null}
-      isAvatar={false}
-      isCircular={false}
-      isFluid={true}
-      label={null}
-      placeholderImageUrl={null}
-      sources={Array []}
-    >
-      <picture
-        className="responsive-image is-fluid"
-        role="figure"
-      >
-        <Image
-          alt="Thumbnail element"
-          as="img"
-          avatar={false}
-          fluid={true}
-          height={null}
-          src="www.⚡️.net"
-          title="Image Title"
-          ui={true}
-          width={null}
-        >
-          <img
-            alt="Thumbnail element"
-            className="ui fluid image"
-            height={null}
-            src="www.⚡️.net"
-            title="Image Title"
-            width={null}
-          />
-        </Image>
-      </picture>
-    </ResponsiveImage>
-  </div>
-</Thumbnail>
-`;
-
-exports[`<Thumbnail /> should render the right structure 1`] = `
-<Thumbnail
-  alternativeText="Thumbnail element"
-  className="🚥"
-  imageUrl="www.⚡️.net"
-  isSquare={false}
-  label={null}
-  placeholderImageUrl={null}
-  size={null}
->
-  <div
-    className="ui thumbnail 🚥"
   >
     <ResponsiveImage
       alternativeText="Thumbnail element"

--- a/src/components/media/Thumbnail/component.js
+++ b/src/components/media/Thumbnail/component.js
@@ -2,8 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import getClassNames from 'classnames';
 
-import { Paragraph } from 'typography/Paragraph';
-import { getBackgroundImageUrl } from 'utils/get-background-image-url';
+import { ResponsiveImage } from 'media/ResponsiveImage';
 
 /**
  * A thumbnail displays a small image.
@@ -11,26 +10,28 @@ import { getBackgroundImageUrl } from 'utils/get-background-image-url';
 // eslint-disable-next-line jsdoc/require-jsdoc
 export const Component = ({
   alternativeText,
+  className,
+  hasRoundedCorners,
   imageUrl,
   isCircular,
-  hasRoundedCorners,
   isSquare,
   label,
+  placeholderImageUrl,
   size,
-  className,
 }) => (
-  <div className={getClassNames('ui', 'thumbnail', className)}>
-    <div
-      className={getClassNames('ui', 'image', size, {
-        circular: isCircular,
-        square: isSquare,
-        rounded: hasRoundedCorners,
-      })}
-      style={{ backgroundImage: getBackgroundImageUrl(imageUrl) }}
-    >
-      <span aria-label={alternativeText} role="img" />
-    </div>
-    {!!label ? <Paragraph>{label}</Paragraph> : null}
+  <div
+    className={getClassNames('ui', 'thumbnail', className, size, {
+      'proportional-width-and-height': isSquare || isCircular,
+    })}
+  >
+    <ResponsiveImage
+      alternativeText={alternativeText}
+      hasRoundedCorners={hasRoundedCorners}
+      imageUrl={imageUrl}
+      isCircular={isCircular}
+      label={label}
+      placeholderImageUrl={placeholderImageUrl}
+    />
   </div>
 );
 
@@ -39,10 +40,11 @@ Component.displayName = 'Thumbnail';
 Component.defaultProps = {
   alternativeText: 'Thumbnail element',
   className: '',
-  isCircular: false,
-  hasRoundedCorners: false,
+  isCircular: undefined,
+  hasRoundedCorners: undefined,
   isSquare: false,
   label: null,
+  placeholderImageUrl: null,
   size: null,
 };
 
@@ -65,6 +67,8 @@ Component.propTypes = {
   isSquare: PropTypes.bool,
   /** A visible label for the thumbnail */
   label: PropTypes.string,
+  /** URL pointing to the placeholder image to render. */
+  placeholderImageUrl: PropTypes.string,
   /** The size of the thumbnail */
   size: PropTypes.oneOf(['small', 'large', 'huge']),
 };

--- a/src/components/media/Thumbnail/component.spec.js
+++ b/src/components/media/Thumbnail/component.spec.js
@@ -1,14 +1,6 @@
 import React from 'react';
-import { shallow } from 'enzyme';
-import {
-  expectComponentToBe,
-  expectComponentToHaveChildren,
-  expectComponentToHaveDisplayName,
-  expectComponentToHaveProps,
-} from '@lodgify/enzyme-jest-expect-helpers';
-
-import { getBackgroundImageUrl } from 'utils/get-background-image-url';
-import { Paragraph } from 'typography/Paragraph';
+import { mount } from 'enzyme';
+import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
 
 import { Component as Thumbnail } from './component';
 
@@ -18,143 +10,38 @@ const props = {
 };
 
 const getThumbnail = extraProps =>
-  shallow(<Thumbnail {...props} {...extraProps} />);
+  mount(<Thumbnail {...props} {...extraProps} />);
 
 describe('<Thumbnail />', () => {
-  it('should render a single Lodgify UI `div` element', () => {
-    const wrapper = getThumbnail();
+  describe('by default', () => {
+    it('should render the right structure', () => {
+      const actual = getThumbnail();
 
-    expectComponentToBe(wrapper, 'div');
-  });
-
-  it('should have the right `ui thumbnail` classNames', () => {
-    const wrapper = getThumbnail();
-
-    expectComponentToHaveProps(wrapper, {
-      className: 'ui thumbnail 🚥',
+      expect(actual).toMatchSnapshot();
     });
   });
 
-  it('should render a single `div`', () => {
-    const wrapper = getThumbnail();
+  describe('if `props.isCircular` is true', () => {
+    it('should render the right structure', () => {
+      const actual = getThumbnail({ isCircular: true });
 
-    expectComponentToHaveChildren(wrapper, 'div');
-  });
-
-  describe('the second `div` element', () => {
-    const getSecondDiv = () =>
-      getThumbnail()
-        .find('div')
-        .at(1);
-
-    it('should have the right props', () => {
-      const wrapper = getSecondDiv();
-
-      expectComponentToHaveProps(wrapper, {
-        className: 'ui image',
-        style: {
-          backgroundImage: getBackgroundImageUrl(props.imageUrl),
-        },
-      });
-    });
-
-    describe('if `props.isCircular` is true', () => {
-      const getSecondDivWithIsCircularProp = () =>
-        getThumbnail({ isCircular: true })
-          .find('div')
-          .at(1);
-
-      it('should have the right classNames', () => {
-        const wrapper = getSecondDivWithIsCircularProp();
-
-        expectComponentToHaveProps(wrapper, {
-          className: 'ui image circular',
-        });
-      });
-    });
-
-    describe('if `props.isSquare` is true', () => {
-      const getSecondDivWithIsSquareProp = () =>
-        getThumbnail({ isSquare: true })
-          .find('div')
-          .at(1);
-
-      it('should have the right classNames', () => {
-        const wrapper = getSecondDivWithIsSquareProp();
-
-        expectComponentToHaveProps(wrapper, {
-          className: 'ui image square',
-        });
-      });
-    });
-
-    describe('if `props.hasRoundedCorners` is true', () => {
-      const getSecondDivWithIsSquareProp = () =>
-        getThumbnail({ hasRoundedCorners: true })
-          .find('div')
-          .at(1);
-
-      it('should have the right classNames', () => {
-        const wrapper = getSecondDivWithIsSquareProp();
-
-        expectComponentToHaveProps(wrapper, {
-          className: 'ui image rounded',
-        });
-      });
-    });
-
-    describe('if `props.size` is supplied', () => {
-      const getSecondDivWithSizeProp = () =>
-        getThumbnail({ size: 'small' })
-          .find('div')
-          .at(1);
-
-      it('should have the right classNames', () => {
-        const wrapper = getSecondDivWithSizeProp();
-
-        expectComponentToHaveProps(wrapper, {
-          className: 'ui image small',
-        });
-      });
-    });
-
-    it('should have the right children', () => {
-      const wrapper = getSecondDiv();
-
-      expectComponentToHaveChildren(wrapper, 'span');
+      expect(actual).toMatchSnapshot();
     });
   });
 
-  describe('the only `span`', () => {
-    const getFirstSpan = () => getThumbnail().find('span');
+  describe('if `props.isSquare` is true', () => {
+    it('should render the right structure', () => {
+      const actual = getThumbnail({ isCircular: true });
 
-    it('should have the right props', () => {
-      const wrapper = getFirstSpan();
-
-      expectComponentToHaveProps(wrapper, {
-        role: 'img',
-      });
-    });
-
-    describe('if `props.alternativeText` is informed', () => {
-      const getFirstSpanWithPropAlternativeText = () =>
-        getThumbnail({ alternativeText: 'lightning' }).find('span');
-
-      it('should have the right `props`', () => {
-        const wrapper = getFirstSpanWithPropAlternativeText();
-
-        expectComponentToHaveProps(wrapper, {
-          'aria-label': 'lightning',
-        });
-      });
+      expect(actual).toMatchSnapshot();
     });
   });
 
-  describe('if `props.Label` is informed', () => {
-    it('should render the right children', () => {
-      const wrapper = getThumbnail({ label: 'Hello' });
+  describe('if `props.size` is supplied', () => {
+    it('should render the right structure', () => {
+      const actual = getThumbnail({ size: 'small' });
 
-      expectComponentToHaveChildren(wrapper, 'div', Paragraph);
+      expect(actual).toMatchSnapshot();
     });
   });
 

--- a/src/components/property-page-widgets/Pictures/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Pictures/__snapshots__/component.spec.js.snap
@@ -107,39 +107,66 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                       <Thumbnail
                         alternativeText="Thumbnail element"
                         className="show-on-desktop"
-                        hasRoundedCorners={false}
                         imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
-                        isCircular={false}
                         isSquare={false}
                         label="Entrance"
+                        placeholderImageUrl={null}
                         size="huge"
                       >
                         <div
-                          className="ui thumbnail show-on-desktop"
+                          className="ui thumbnail show-on-desktop huge"
                         >
-                          <div
-                            className="ui image huge"
-                            style={
-                              Object {
-                                "backgroundImage": "url(https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max)",
-                              }
-                            }
+                          <ResponsiveImage
+                            alternativeText="Thumbnail element"
+                            hasRoundedCorners={false}
+                            imageHeight={null}
+                            imageNotFoundLabelText="Image not found!"
+                            imageTitle="Image Title"
+                            imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                            imageWidth={null}
+                            isAvatar={false}
+                            isCircular={false}
+                            isFluid={true}
+                            label="Entrance"
+                            placeholderImageUrl={null}
+                            sources={Array []}
                           >
-                            <span
-                              aria-label="Thumbnail element"
-                              role="img"
-                            />
-                          </div>
-                          <Paragraph
-                            size="medium"
-                            weight={null}
-                          >
-                            <p
-                              className=""
+                            <picture
+                              className="responsive-image is-fluid"
+                              role="figure"
                             >
-                              Entrance
-                            </p>
-                          </Paragraph>
+                              <Image
+                                alt="Thumbnail element"
+                                as="img"
+                                avatar={false}
+                                fluid={true}
+                                height={null}
+                                src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                title="Image Title"
+                                ui={true}
+                                width={null}
+                              >
+                                <img
+                                  alt="Thumbnail element"
+                                  className="ui fluid image"
+                                  height={null}
+                                  src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                  title="Image Title"
+                                  width={null}
+                                />
+                              </Image>
+                              <Paragraph
+                                size="medium"
+                                weight={null}
+                              >
+                                <p
+                                  className=""
+                                >
+                                  Entrance
+                                </p>
+                              </Paragraph>
+                            </picture>
+                          </ResponsiveImage>
                         </div>
                       </Thumbnail>
                     </ShowOnDesktop>
@@ -160,37 +187,65 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                         className="show-on-mobile"
                         hasRoundedCorners={true}
                         imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
-                        isCircular={false}
                         isSquare={true}
                         label="Entrance"
+                        placeholderImageUrl={null}
                         size="large"
                       >
                         <div
-                          className="ui thumbnail show-on-mobile"
+                          className="ui thumbnail show-on-mobile large proportional-width-and-height"
                         >
-                          <div
-                            className="ui image large square rounded"
-                            style={
-                              Object {
-                                "backgroundImage": "url(https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max)",
-                              }
-                            }
+                          <ResponsiveImage
+                            alternativeText="Thumbnail element"
+                            hasRoundedCorners={true}
+                            imageHeight={null}
+                            imageNotFoundLabelText="Image not found!"
+                            imageTitle="Image Title"
+                            imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                            imageWidth={null}
+                            isAvatar={false}
+                            isCircular={false}
+                            isFluid={true}
+                            label="Entrance"
+                            placeholderImageUrl={null}
+                            sources={Array []}
                           >
-                            <span
-                              aria-label="Thumbnail element"
-                              role="img"
-                            />
-                          </div>
-                          <Paragraph
-                            size="medium"
-                            weight={null}
-                          >
-                            <p
-                              className=""
+                            <picture
+                              className="responsive-image is-fluid is-rounded"
+                              role="figure"
                             >
-                              Entrance
-                            </p>
-                          </Paragraph>
+                              <Image
+                                alt="Thumbnail element"
+                                as="img"
+                                avatar={false}
+                                fluid={true}
+                                height={null}
+                                src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                title="Image Title"
+                                ui={true}
+                                width={null}
+                              >
+                                <img
+                                  alt="Thumbnail element"
+                                  className="ui fluid image"
+                                  height={null}
+                                  src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                  title="Image Title"
+                                  width={null}
+                                />
+                              </Image>
+                              <Paragraph
+                                size="medium"
+                                weight={null}
+                              >
+                                <p
+                                  className=""
+                                >
+                                  Entrance
+                                </p>
+                              </Paragraph>
+                            </picture>
+                          </ResponsiveImage>
                         </div>
                       </Thumbnail>
                     </ShowOnMobile>
@@ -237,39 +292,66 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                       <Thumbnail
                         alternativeText="Thumbnail element"
                         className="show-on-desktop"
-                        hasRoundedCorners={false}
                         imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
-                        isCircular={false}
                         isSquare={false}
                         label="Kitchen"
+                        placeholderImageUrl={null}
                         size="huge"
                       >
                         <div
-                          className="ui thumbnail show-on-desktop"
+                          className="ui thumbnail show-on-desktop huge"
                         >
-                          <div
-                            className="ui image huge"
-                            style={
-                              Object {
-                                "backgroundImage": "url(https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max)",
-                              }
-                            }
+                          <ResponsiveImage
+                            alternativeText="Thumbnail element"
+                            hasRoundedCorners={false}
+                            imageHeight={null}
+                            imageNotFoundLabelText="Image not found!"
+                            imageTitle="Image Title"
+                            imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                            imageWidth={null}
+                            isAvatar={false}
+                            isCircular={false}
+                            isFluid={true}
+                            label="Kitchen"
+                            placeholderImageUrl={null}
+                            sources={Array []}
                           >
-                            <span
-                              aria-label="Thumbnail element"
-                              role="img"
-                            />
-                          </div>
-                          <Paragraph
-                            size="medium"
-                            weight={null}
-                          >
-                            <p
-                              className=""
+                            <picture
+                              className="responsive-image is-fluid"
+                              role="figure"
                             >
-                              Kitchen
-                            </p>
-                          </Paragraph>
+                              <Image
+                                alt="Thumbnail element"
+                                as="img"
+                                avatar={false}
+                                fluid={true}
+                                height={null}
+                                src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                title="Image Title"
+                                ui={true}
+                                width={null}
+                              >
+                                <img
+                                  alt="Thumbnail element"
+                                  className="ui fluid image"
+                                  height={null}
+                                  src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                  title="Image Title"
+                                  width={null}
+                                />
+                              </Image>
+                              <Paragraph
+                                size="medium"
+                                weight={null}
+                              >
+                                <p
+                                  className=""
+                                >
+                                  Kitchen
+                                </p>
+                              </Paragraph>
+                            </picture>
+                          </ResponsiveImage>
                         </div>
                       </Thumbnail>
                     </ShowOnDesktop>
@@ -290,37 +372,65 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                         className="show-on-mobile"
                         hasRoundedCorners={true}
                         imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
-                        isCircular={false}
                         isSquare={true}
                         label="Kitchen"
+                        placeholderImageUrl={null}
                         size="large"
                       >
                         <div
-                          className="ui thumbnail show-on-mobile"
+                          className="ui thumbnail show-on-mobile large proportional-width-and-height"
                         >
-                          <div
-                            className="ui image large square rounded"
-                            style={
-                              Object {
-                                "backgroundImage": "url(https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max)",
-                              }
-                            }
+                          <ResponsiveImage
+                            alternativeText="Thumbnail element"
+                            hasRoundedCorners={true}
+                            imageHeight={null}
+                            imageNotFoundLabelText="Image not found!"
+                            imageTitle="Image Title"
+                            imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                            imageWidth={null}
+                            isAvatar={false}
+                            isCircular={false}
+                            isFluid={true}
+                            label="Kitchen"
+                            placeholderImageUrl={null}
+                            sources={Array []}
                           >
-                            <span
-                              aria-label="Thumbnail element"
-                              role="img"
-                            />
-                          </div>
-                          <Paragraph
-                            size="medium"
-                            weight={null}
-                          >
-                            <p
-                              className=""
+                            <picture
+                              className="responsive-image is-fluid is-rounded"
+                              role="figure"
                             >
-                              Kitchen
-                            </p>
-                          </Paragraph>
+                              <Image
+                                alt="Thumbnail element"
+                                as="img"
+                                avatar={false}
+                                fluid={true}
+                                height={null}
+                                src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                title="Image Title"
+                                ui={true}
+                                width={null}
+                              >
+                                <img
+                                  alt="Thumbnail element"
+                                  className="ui fluid image"
+                                  height={null}
+                                  src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                  title="Image Title"
+                                  width={null}
+                                />
+                              </Image>
+                              <Paragraph
+                                size="medium"
+                                weight={null}
+                              >
+                                <p
+                                  className=""
+                                >
+                                  Kitchen
+                                </p>
+                              </Paragraph>
+                            </picture>
+                          </ResponsiveImage>
                         </div>
                       </Thumbnail>
                     </ShowOnMobile>
@@ -367,39 +477,66 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                       <Thumbnail
                         alternativeText="Thumbnail element"
                         className="show-on-desktop"
-                        hasRoundedCorners={false}
                         imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
-                        isCircular={false}
                         isSquare={false}
                         label="Living room"
+                        placeholderImageUrl={null}
                         size="huge"
                       >
                         <div
-                          className="ui thumbnail show-on-desktop"
+                          className="ui thumbnail show-on-desktop huge"
                         >
-                          <div
-                            className="ui image huge"
-                            style={
-                              Object {
-                                "backgroundImage": "url(https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max)",
-                              }
-                            }
+                          <ResponsiveImage
+                            alternativeText="Thumbnail element"
+                            hasRoundedCorners={false}
+                            imageHeight={null}
+                            imageNotFoundLabelText="Image not found!"
+                            imageTitle="Image Title"
+                            imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                            imageWidth={null}
+                            isAvatar={false}
+                            isCircular={false}
+                            isFluid={true}
+                            label="Living room"
+                            placeholderImageUrl={null}
+                            sources={Array []}
                           >
-                            <span
-                              aria-label="Thumbnail element"
-                              role="img"
-                            />
-                          </div>
-                          <Paragraph
-                            size="medium"
-                            weight={null}
-                          >
-                            <p
-                              className=""
+                            <picture
+                              className="responsive-image is-fluid"
+                              role="figure"
                             >
-                              Living room
-                            </p>
-                          </Paragraph>
+                              <Image
+                                alt="Thumbnail element"
+                                as="img"
+                                avatar={false}
+                                fluid={true}
+                                height={null}
+                                src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                title="Image Title"
+                                ui={true}
+                                width={null}
+                              >
+                                <img
+                                  alt="Thumbnail element"
+                                  className="ui fluid image"
+                                  height={null}
+                                  src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                  title="Image Title"
+                                  width={null}
+                                />
+                              </Image>
+                              <Paragraph
+                                size="medium"
+                                weight={null}
+                              >
+                                <p
+                                  className=""
+                                >
+                                  Living room
+                                </p>
+                              </Paragraph>
+                            </picture>
+                          </ResponsiveImage>
                         </div>
                       </Thumbnail>
                     </ShowOnDesktop>
@@ -420,37 +557,65 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                         className="show-on-mobile"
                         hasRoundedCorners={true}
                         imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
-                        isCircular={false}
                         isSquare={true}
                         label="Living room"
+                        placeholderImageUrl={null}
                         size="large"
                       >
                         <div
-                          className="ui thumbnail show-on-mobile"
+                          className="ui thumbnail show-on-mobile large proportional-width-and-height"
                         >
-                          <div
-                            className="ui image large square rounded"
-                            style={
-                              Object {
-                                "backgroundImage": "url(https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max)",
-                              }
-                            }
+                          <ResponsiveImage
+                            alternativeText="Thumbnail element"
+                            hasRoundedCorners={true}
+                            imageHeight={null}
+                            imageNotFoundLabelText="Image not found!"
+                            imageTitle="Image Title"
+                            imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                            imageWidth={null}
+                            isAvatar={false}
+                            isCircular={false}
+                            isFluid={true}
+                            label="Living room"
+                            placeholderImageUrl={null}
+                            sources={Array []}
                           >
-                            <span
-                              aria-label="Thumbnail element"
-                              role="img"
-                            />
-                          </div>
-                          <Paragraph
-                            size="medium"
-                            weight={null}
-                          >
-                            <p
-                              className=""
+                            <picture
+                              className="responsive-image is-fluid is-rounded"
+                              role="figure"
                             >
-                              Living room
-                            </p>
-                          </Paragraph>
+                              <Image
+                                alt="Thumbnail element"
+                                as="img"
+                                avatar={false}
+                                fluid={true}
+                                height={null}
+                                src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                title="Image Title"
+                                ui={true}
+                                width={null}
+                              >
+                                <img
+                                  alt="Thumbnail element"
+                                  className="ui fluid image"
+                                  height={null}
+                                  src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                  title="Image Title"
+                                  width={null}
+                                />
+                              </Image>
+                              <Paragraph
+                                size="medium"
+                                weight={null}
+                              >
+                                <p
+                                  className=""
+                                >
+                                  Living room
+                                </p>
+                              </Paragraph>
+                            </picture>
+                          </ResponsiveImage>
                         </div>
                       </Thumbnail>
                     </ShowOnMobile>
@@ -497,39 +662,66 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                       <Thumbnail
                         alternativeText="Thumbnail element"
                         className="show-on-desktop"
-                        hasRoundedCorners={false}
                         imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
-                        isCircular={false}
                         isSquare={false}
                         label="Studio"
+                        placeholderImageUrl={null}
                         size="huge"
                       >
                         <div
-                          className="ui thumbnail show-on-desktop"
+                          className="ui thumbnail show-on-desktop huge"
                         >
-                          <div
-                            className="ui image huge"
-                            style={
-                              Object {
-                                "backgroundImage": "url(https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max)",
-                              }
-                            }
+                          <ResponsiveImage
+                            alternativeText="Thumbnail element"
+                            hasRoundedCorners={false}
+                            imageHeight={null}
+                            imageNotFoundLabelText="Image not found!"
+                            imageTitle="Image Title"
+                            imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                            imageWidth={null}
+                            isAvatar={false}
+                            isCircular={false}
+                            isFluid={true}
+                            label="Studio"
+                            placeholderImageUrl={null}
+                            sources={Array []}
                           >
-                            <span
-                              aria-label="Thumbnail element"
-                              role="img"
-                            />
-                          </div>
-                          <Paragraph
-                            size="medium"
-                            weight={null}
-                          >
-                            <p
-                              className=""
+                            <picture
+                              className="responsive-image is-fluid"
+                              role="figure"
                             >
-                              Studio
-                            </p>
-                          </Paragraph>
+                              <Image
+                                alt="Thumbnail element"
+                                as="img"
+                                avatar={false}
+                                fluid={true}
+                                height={null}
+                                src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                title="Image Title"
+                                ui={true}
+                                width={null}
+                              >
+                                <img
+                                  alt="Thumbnail element"
+                                  className="ui fluid image"
+                                  height={null}
+                                  src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                  title="Image Title"
+                                  width={null}
+                                />
+                              </Image>
+                              <Paragraph
+                                size="medium"
+                                weight={null}
+                              >
+                                <p
+                                  className=""
+                                >
+                                  Studio
+                                </p>
+                              </Paragraph>
+                            </picture>
+                          </ResponsiveImage>
                         </div>
                       </Thumbnail>
                     </ShowOnDesktop>
@@ -550,37 +742,65 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                         className="show-on-mobile"
                         hasRoundedCorners={true}
                         imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
-                        isCircular={false}
                         isSquare={true}
                         label="Studio"
+                        placeholderImageUrl={null}
                         size="large"
                       >
                         <div
-                          className="ui thumbnail show-on-mobile"
+                          className="ui thumbnail show-on-mobile large proportional-width-and-height"
                         >
-                          <div
-                            className="ui image large square rounded"
-                            style={
-                              Object {
-                                "backgroundImage": "url(https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max)",
-                              }
-                            }
+                          <ResponsiveImage
+                            alternativeText="Thumbnail element"
+                            hasRoundedCorners={true}
+                            imageHeight={null}
+                            imageNotFoundLabelText="Image not found!"
+                            imageTitle="Image Title"
+                            imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                            imageWidth={null}
+                            isAvatar={false}
+                            isCircular={false}
+                            isFluid={true}
+                            label="Studio"
+                            placeholderImageUrl={null}
+                            sources={Array []}
                           >
-                            <span
-                              aria-label="Thumbnail element"
-                              role="img"
-                            />
-                          </div>
-                          <Paragraph
-                            size="medium"
-                            weight={null}
-                          >
-                            <p
-                              className=""
+                            <picture
+                              className="responsive-image is-fluid is-rounded"
+                              role="figure"
                             >
-                              Studio
-                            </p>
-                          </Paragraph>
+                              <Image
+                                alt="Thumbnail element"
+                                as="img"
+                                avatar={false}
+                                fluid={true}
+                                height={null}
+                                src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                title="Image Title"
+                                ui={true}
+                                width={null}
+                              >
+                                <img
+                                  alt="Thumbnail element"
+                                  className="ui fluid image"
+                                  height={null}
+                                  src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                  title="Image Title"
+                                  width={null}
+                                />
+                              </Image>
+                              <Paragraph
+                                size="medium"
+                                weight={null}
+                              >
+                                <p
+                                  className=""
+                                >
+                                  Studio
+                                </p>
+                              </Paragraph>
+                            </picture>
+                          </ResponsiveImage>
                         </div>
                       </Thumbnail>
                     </ShowOnMobile>
@@ -627,39 +847,66 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                       <Thumbnail
                         alternativeText="Thumbnail element"
                         className="show-on-desktop"
-                        hasRoundedCorners={false}
                         imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
-                        isCircular={false}
                         isSquare={false}
                         label="Garden room"
+                        placeholderImageUrl={null}
                         size="huge"
                       >
                         <div
-                          className="ui thumbnail show-on-desktop"
+                          className="ui thumbnail show-on-desktop huge"
                         >
-                          <div
-                            className="ui image huge"
-                            style={
-                              Object {
-                                "backgroundImage": "url(https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max)",
-                              }
-                            }
+                          <ResponsiveImage
+                            alternativeText="Thumbnail element"
+                            hasRoundedCorners={false}
+                            imageHeight={null}
+                            imageNotFoundLabelText="Image not found!"
+                            imageTitle="Image Title"
+                            imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                            imageWidth={null}
+                            isAvatar={false}
+                            isCircular={false}
+                            isFluid={true}
+                            label="Garden room"
+                            placeholderImageUrl={null}
+                            sources={Array []}
                           >
-                            <span
-                              aria-label="Thumbnail element"
-                              role="img"
-                            />
-                          </div>
-                          <Paragraph
-                            size="medium"
-                            weight={null}
-                          >
-                            <p
-                              className=""
+                            <picture
+                              className="responsive-image is-fluid"
+                              role="figure"
                             >
-                              Garden room
-                            </p>
-                          </Paragraph>
+                              <Image
+                                alt="Thumbnail element"
+                                as="img"
+                                avatar={false}
+                                fluid={true}
+                                height={null}
+                                src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                title="Image Title"
+                                ui={true}
+                                width={null}
+                              >
+                                <img
+                                  alt="Thumbnail element"
+                                  className="ui fluid image"
+                                  height={null}
+                                  src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                  title="Image Title"
+                                  width={null}
+                                />
+                              </Image>
+                              <Paragraph
+                                size="medium"
+                                weight={null}
+                              >
+                                <p
+                                  className=""
+                                >
+                                  Garden room
+                                </p>
+                              </Paragraph>
+                            </picture>
+                          </ResponsiveImage>
                         </div>
                       </Thumbnail>
                     </ShowOnDesktop>
@@ -680,37 +927,65 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                         className="show-on-mobile"
                         hasRoundedCorners={true}
                         imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
-                        isCircular={false}
                         isSquare={true}
                         label="Garden room"
+                        placeholderImageUrl={null}
                         size="large"
                       >
                         <div
-                          className="ui thumbnail show-on-mobile"
+                          className="ui thumbnail show-on-mobile large proportional-width-and-height"
                         >
-                          <div
-                            className="ui image large square rounded"
-                            style={
-                              Object {
-                                "backgroundImage": "url(https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max)",
-                              }
-                            }
+                          <ResponsiveImage
+                            alternativeText="Thumbnail element"
+                            hasRoundedCorners={true}
+                            imageHeight={null}
+                            imageNotFoundLabelText="Image not found!"
+                            imageTitle="Image Title"
+                            imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                            imageWidth={null}
+                            isAvatar={false}
+                            isCircular={false}
+                            isFluid={true}
+                            label="Garden room"
+                            placeholderImageUrl={null}
+                            sources={Array []}
                           >
-                            <span
-                              aria-label="Thumbnail element"
-                              role="img"
-                            />
-                          </div>
-                          <Paragraph
-                            size="medium"
-                            weight={null}
-                          >
-                            <p
-                              className=""
+                            <picture
+                              className="responsive-image is-fluid is-rounded"
+                              role="figure"
                             >
-                              Garden room
-                            </p>
-                          </Paragraph>
+                              <Image
+                                alt="Thumbnail element"
+                                as="img"
+                                avatar={false}
+                                fluid={true}
+                                height={null}
+                                src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                title="Image Title"
+                                ui={true}
+                                width={null}
+                              >
+                                <img
+                                  alt="Thumbnail element"
+                                  className="ui fluid image"
+                                  height={null}
+                                  src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                  title="Image Title"
+                                  width={null}
+                                />
+                              </Image>
+                              <Paragraph
+                                size="medium"
+                                weight={null}
+                              >
+                                <p
+                                  className=""
+                                >
+                                  Garden room
+                                </p>
+                              </Paragraph>
+                            </picture>
+                          </ResponsiveImage>
                         </div>
                       </Thumbnail>
                     </ShowOnMobile>
@@ -843,12 +1118,14 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                               </Heading>
                               <ResponsiveImage
                                 alternativeText="Image Widget"
+                                hasRoundedCorners={false}
                                 imageHeight={null}
                                 imageNotFoundLabelText="Image not found!"
                                 imageTitle="Image Title"
                                 imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
                                 imageWidth={null}
                                 isAvatar={false}
+                                isCircular={false}
                                 isFluid={true}
                                 label={null}
                                 sources={Array []}
@@ -872,12 +1149,14 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                               </Heading>
                               <ResponsiveImage
                                 alternativeText="Image Widget"
+                                hasRoundedCorners={false}
                                 imageHeight={null}
                                 imageNotFoundLabelText="Image not found!"
                                 imageTitle="Image Title"
                                 imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
                                 imageWidth={null}
                                 isAvatar={false}
+                                isCircular={false}
                                 isFluid={true}
                                 label={null}
                                 sources={Array []}
@@ -901,12 +1180,14 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                               </Heading>
                               <ResponsiveImage
                                 alternativeText="Image Widget"
+                                hasRoundedCorners={false}
                                 imageHeight={null}
                                 imageNotFoundLabelText="Image not found!"
                                 imageTitle="Image Title"
                                 imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
                                 imageWidth={null}
                                 isAvatar={false}
+                                isCircular={false}
                                 isFluid={true}
                                 label={null}
                                 sources={Array []}
@@ -930,12 +1211,14 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                               </Heading>
                               <ResponsiveImage
                                 alternativeText="Image Widget"
+                                hasRoundedCorners={false}
                                 imageHeight={null}
                                 imageNotFoundLabelText="Image not found!"
                                 imageTitle="Image Title"
                                 imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
                                 imageWidth={null}
                                 isAvatar={false}
+                                isCircular={false}
                                 isFluid={true}
                                 label={null}
                                 sources={Array []}
@@ -959,12 +1242,14 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                               </Heading>
                               <ResponsiveImage
                                 alternativeText="Image Widget"
+                                hasRoundedCorners={false}
                                 imageHeight={null}
                                 imageNotFoundLabelText="Image not found!"
                                 imageTitle="Image Title"
                                 imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
                                 imageWidth={null}
                                 isAvatar={false}
+                                isCircular={false}
                                 isFluid={true}
                                 label={null}
                                 sources={Array []}

--- a/src/styles/semantic/themes/livingstone/elements/image.overrides
+++ b/src/styles/semantic/themes/livingstone/elements/image.overrides
@@ -77,4 +77,18 @@ picture.responsive-image {
       }
     }
   }
+
+  &.is-circular {
+
+    .ui.image {
+      border-radius: @circularBorderRadius;
+    }
+  }
+
+  &.is-rounded {
+
+    .ui.image {
+      border-radius: @thumbnailBorderRadius;
+    }
+  }
 }

--- a/src/styles/semantic/themes/livingstone/globals/site.overrides
+++ b/src/styles/semantic/themes/livingstone/globals/site.overrides
@@ -345,47 +345,34 @@ blockquote.ui.quote .row {
 --------------------*/
 
 .ui.thumbnail {
+  width: 100%;
+  height: @thumbnailHeight;
 
-  .image {
-    background: @thumbnailBackground;
-    width: 100%;
-    height: @thumbnailHeight;
+  &.small {
+    height: @smallThumbnailHeight;
+  }
+
+  &.large {
+    height: @largeThumbnailHeight;
+  }
+
+  &.huge {
+    height: @hugeThumbnailHeight;
+  }
+
+  &.proportional-width-and-height {
+    width: @thumbnailWidth;
 
     &.small {
-      height: @smallThumbnailHeight;
+      width: @smallThumbnailWidth;
     }
 
     &.large {
-      height: @largeThumbnailHeight;
+      width: @largeThumbnailWidth;
     }
 
     &.huge {
-      height: @hugeThumbnailHeight;
-    }
-
-    &.circular {
-      border-radius: @circularBorderRadius;
-    }
-
-    &.rounded {
-      border-radius: @thumbnailBorderRadius;
-    }
-
-    &.circular,
-    &.square {
-      width: @thumbnailWidth;
-
-      &.small {
-        width: @smallThumbnailWidth;
-      }
-
-      &.large {
-        width: @largeThumbnailWidth;
-      }
-
-      &.huge {
-        width: @hugeThumbnailWidth;
-      }
+      width: @hugeThumbnailWidth;
     }
   }
 }


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1303)

### What **one** thing does this PR do?
Gives the Thumbnail the capability to gracefully load

### Any other notes
#### Thumbnail
**Before**
![kapture 2018-10-29 at 12 55 45](https://user-images.githubusercontent.com/10498995/47648323-00c1e400-db7a-11e8-95b5-02ead4e5c654.gif)
**After**
![kapture 2018-10-29 at 12 54 54](https://user-images.githubusercontent.com/10498995/47648291-e38d1580-db79-11e8-8a44-a93883b33c88.gif)

#### Pictures
![image](https://user-images.githubusercontent.com/10498995/47648488-7af26880-db7a-11e8-962b-fc9ea2940716.png)


#### ResponsiveImage
![image](https://user-images.githubusercontent.com/10498995/47648471-6c0bb600-db7a-11e8-80a2-dc3a4bed1e49.png)

![image](https://user-images.githubusercontent.com/10498995/47648457-5d250380-db7a-11e8-8dd1-482515845971.png)


