### PR TITLE
TE-1296 Pin stylelint to v9.6.0 while bug is patched

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "semantic-release": "^15.4.0",
     "size-limit": "^0.20.1",
     "style-loader": "^0.20.2",
-    "stylelint": "^9.2.0",
+    "stylelint": "9.6.0",
     "stylelint-config-standard": "^18.2.0",
     "webpack": "^4.19.0",
     "webpack-cli": "^3.0.0"


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1296)

### What **one** thing does this PR do?
Pins `stylelint` to version 9.6.0 while the bug reported at https://github.com/stylelint/stylelint/issues/3749 is patched

