### PR TITLE
TE-1311: Use commonjs when getting Semantic UI react components

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,7 +4,9 @@
       "comments": false,
       "ignore": ["**/*.spec.js"],
       "plugins": [
-        "semantic-ui-react-transform-imports"
+        ["semantic-ui-react-transform-imports", {
+          "importType": "commonjs"
+        }]
       ]
     }
   },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "size-limit": [
     {
-      "limit": "247 KB",
+      "limit": "256 KB",
       "path": "lib/index.js"
     }
   ],


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1311)

### What **one** thing does this PR do?
This will import the Semantic Ui React components with commonjs instead of Es modules

### Any other notes
- This is a requirement since TemplatesSSR will render the components on the server where Es modules are not yet supported.
