### PR TITLE
TE-1375: Correct the props in features and extraFeatures in RoomType

### DIFF
--- a/src/components/property-page-widgets/RoomType/component.js
+++ b/src/components/property-page-widgets/RoomType/component.js
@@ -146,24 +146,20 @@ Component.propTypes = {
   /** The room features to display in the modal */
   extraFeatures: PropTypes.arrayOf(
     PropTypes.shape({
-      /** The feature count to display. */
-      count: PropTypes.number,
-      /** The feature name to display. */
-      name: PropTypes.string,
+      /** The feature label to display. */
+      labelText: PropTypes.string,
     })
   ),
   /** The room features to display in the card and modal */
   features: PropTypes.arrayOf(
     PropTypes.shape({
-      /** The feature count to display. */
-      count: PropTypes.number,
       /**
        * The name of the icon to display.
        * [See here for the full list of valid icon names](https://github.com/lodgify/lodgify-ui/blob/production/src/components/elements/Icon/constants.js)
        */
       iconName: PropTypes.string,
       /** The feature label to display. */
-      label: PropTypes.string,
+      labelText: PropTypes.string,
     })
   ).isRequired,
   /**

--- a/src/components/property-page-widgets/RoomType/utils/getRoomFeaturesMarkup.js
+++ b/src/components/property-page-widgets/RoomType/utils/getRoomFeaturesMarkup.js
@@ -17,16 +17,12 @@ export const getRoomFeaturesMarkup = (showIcons, features) => (
     floated="left"
     horizontal
   >
-    {features.map((infoItem, index) => (
+    {features.map(({ labelText, iconName }, index) => (
       <List.Item key={index}>
         {showIcons ? (
-          <Paragraph>{infoItem.labelText}</Paragraph>
+          <Paragraph>{labelText}</Paragraph>
         ) : (
-          <Icon
-            labelText={infoItem.labelText}
-            name={infoItem.iconName}
-            size="small"
-          />
+          <Icon labelText={labelText} name={iconName} size="small" />
         )}
       </List.Item>
     ))}


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1375)

### What **one** thing does this PR do?
Corrects the prop structure of the `features` and `extraFeatures` in `RoomType`

### Before
<img width="698" alt="screen shot 2018-11-02 at 09 54 36" src="https://user-images.githubusercontent.com/25742275/47904783-daf05400-de85-11e8-9a42-52972cf9b53c.png">

### After
<img width="702" alt="screen shot 2018-11-02 at 09 54 45" src="https://user-images.githubusercontent.com/25742275/47904794-dfb50800-de85-11e8-82d4-c3945413eae6.png">
