### PR TITLE
TE-1389: Make the Promotion component responsive

### DIFF
--- a/src/components/collections/Header/utils/getDesktopMenuMarkup.js
+++ b/src/components/collections/Header/utils/getDesktopMenuMarkup.js
@@ -25,28 +25,27 @@ export const getDesktopMenuMarkup = ({
   /* eslint-enable react/prop-types */
 }) => (
   <ShowOnDesktop parent={Menu.Menu} parentProps={{ position: 'right' }}>
-    {navigationItems.map(
-      ({ subItems, text, href }, index) =>
-        size(subItems) > 0 ? (
-          <Submenu
-            isMenuItem
-            isSelectedDisabled
-            isSimple
-            isTriggerUnderlined={index === activeNavigationItemIndex}
-            isTriggeredOnHover
-            items={subItems}
-            key={buildKeyFromStrings(text, index)}
-            pointing={getSubmenuPointing(
-              index,
-              size(navigationItems),
-              !!primaryCTA
-            )}
-          >
-            {text}
-          </Submenu>
-        ) : (
-          getLinkMarkup(text, href, index, activeNavigationItemIndex)
-        )
+    {navigationItems.map(({ subItems, text, href }, index) =>
+      size(subItems) > 0 ? (
+        <Submenu
+          isMenuItem
+          isSelectedDisabled
+          isSimple
+          isTriggerUnderlined={index === activeNavigationItemIndex}
+          isTriggeredOnHover
+          items={subItems}
+          key={buildKeyFromStrings(text, index)}
+          pointing={getSubmenuPointing(
+            index,
+            size(navigationItems),
+            !!primaryCTA
+          )}
+        >
+          {text}
+        </Submenu>
+      ) : (
+        getLinkMarkup(text, href, index, activeNavigationItemIndex)
+      )
     )}
     {primaryCTA && (
       <Menu.Item className="no-underline" link>

--- a/src/components/collections/Header/utils/getMobileMenuMarkup.js
+++ b/src/components/collections/Header/utils/getMobileMenuMarkup.js
@@ -54,35 +54,34 @@ export const getMobileMenuMarkup = ({
       <Modal isFullscreen trigger={<Icon name={ICON_NAMES.BARS} />}>
         <Menu text vertical>
           {getLogoMarkup(logoSrc, logoText)}
-          {navigationItems.map(
-            ({ subItems, text, href }, index) =>
-              size(subItems) ? (
-                <Accordion
-                  as={Menu.Item}
-                  key={buildKeyFromStrings(text, index)}
-                  panels={[
-                    {
-                      title: {
-                        content: text,
-                        key: buildKeyFromStrings(text, index),
-                      },
-                      content: {
-                        content: subItems.map(({ text, href }, index) =>
-                          getLinkMarkup(
-                            text,
-                            href,
-                            index,
-                            activeNavigationItemIndex
-                          )
-                        ),
-                        key: buildKeyFromStrings(index, text),
-                      },
+          {navigationItems.map(({ subItems, text, href }, index) =>
+            size(subItems) ? (
+              <Accordion
+                as={Menu.Item}
+                key={buildKeyFromStrings(text, index)}
+                panels={[
+                  {
+                    title: {
+                      content: text,
+                      key: buildKeyFromStrings(text, index),
                     },
-                  ]}
-                />
-              ) : (
-                getLinkMarkup(text, href, index, activeNavigationItemIndex)
-              )
+                    content: {
+                      content: subItems.map(({ text, href }, index) =>
+                        getLinkMarkup(
+                          text,
+                          href,
+                          index,
+                          activeNavigationItemIndex
+                        )
+                      ),
+                      key: buildKeyFromStrings(index, text),
+                    },
+                  },
+                ]}
+              />
+            ) : (
+              getLinkMarkup(text, href, index, activeNavigationItemIndex)
+            )
           )}
         </Menu>
       </Modal>

--- a/src/components/elements/Icon/component.js
+++ b/src/components/elements/Icon/component.js
@@ -37,13 +37,15 @@ export const Component = ({
     // compatibility with dynamic components e.g. `ToolTip`
     {...otherProps}
   >
-    {!!labelText &&
-      isLabelLeft && <Paragraph weight={labelWeight}>{labelText}</Paragraph>}
+    {!!labelText && isLabelLeft && (
+      <Paragraph weight={labelWeight}>{labelText}</Paragraph>
+    )}
     <svg viewBox="0 0 24 24">
       <path d={getPath(name, path)} fill="currentColor" />
     </svg>
-    {!!labelText &&
-      !isLabelLeft && <Paragraph weight={labelWeight}>{labelText}</Paragraph>}
+    {!!labelText && !isLabelLeft && (
+      <Paragraph weight={labelWeight}>{labelText}</Paragraph>
+    )}
   </i>
 );
 

--- a/src/components/general-widgets/Promotion/Readme.md
+++ b/src/components/general-widgets/Promotion/Readme.md
@@ -23,17 +23,3 @@
   headingText="Summertime Festival"
   onClick={console.log} />
 ```
-
-### Variations
-
-#### Display Stacked
-
-```jsx
-<Promotion
-  backgroundImage="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
-  discountCode="F1KDH193S"
-  discountAmount="200€"
-  headingText="Summertime Festival"
-  isDisplayedStacked
-  onClick={console.log} />
-```

--- a/src/components/general-widgets/Promotion/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/Promotion/__snapshots__/component.spec.js.snap
@@ -1,321 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`The \`Promotion\` component \`Promotion\` as stacked \`Segment\` should have the right structure 1`] = `
-<Promotion
-  backgroundImage="testimage"
-  discountAmount="100%"
-  discountAmountParagraphText="Save up to"
-  discountCode="123"
-  discountCodeParagraphText="Use the coupon code"
-  discountHoverButtonText="Book Now with Discount"
-  headingText="Hello World!"
-  isDisplayedStacked={true}
-  onClick={[Function]}
-  placeholderBackgroundImage={null}
->
-  <Segment
-    basic={true}
-    className="is-promotion display-stacked"
-    onClick={[Function]}
-  >
-    <div
-      className="ui basic segment is-promotion display-stacked"
-      onClick={[Function]}
-    >
-      <Grid
-        areColumnsCentered={false}
-        className="first-grid"
-        stackable={true}
-        stretched={true}
-      >
-        <Grid
-          centered={false}
-          className="first-grid"
-          stackable={true}
-          stretched={true}
-        >
-          <div
-            className="ui stackable stretched grid first-grid"
-          >
-            <GridRow
-              horizontalAlignContent="left"
-              verticalAlign="middle"
-            >
-              <GridRow
-                textAlign="left"
-                verticalAlign="middle"
-              >
-                <div
-                  className="left aligned middle aligned row"
-                >
-                  <GridColumn
-                    className="content-section"
-                    verticalAlignContent="top"
-                    width={12}
-                  >
-                    <GridColumn
-                      className="content-section"
-                      verticalAlign="top"
-                      width={12}
-                    >
-                      <div
-                        className="top aligned twelve wide column content-section"
-                      >
-                        <ResponsiveImage
-                          alternativeText="Image Widget"
-                          hasRoundedCorners={false}
-                          imageHeight={null}
-                          imageNotFoundLabelText="Image not found!"
-                          imageTitle="Image Title"
-                          imageUrl="testimage"
-                          imageWidth={null}
-                          isAvatar={false}
-                          isCircular={false}
-                          isFluid={false}
-                          label={null}
-                          placeholderImageUrl={null}
-                          sources={Array []}
-                        >
-                          <picture
-                            className="responsive-image"
-                            role="figure"
-                          >
-                            <Image
-                              alt="Image Widget"
-                              as="img"
-                              avatar={false}
-                              fluid={true}
-                              src="testimage"
-                              title="Image Title"
-                              ui={true}
-                            >
-                              <img
-                                alt="Image Widget"
-                                className="ui fluid image"
-                                src="testimage"
-                                title="Image Title"
-                              />
-                            </Image>
-                          </picture>
-                        </ResponsiveImage>
-                        <Grid
-                          areColumnsCentered={false}
-                          padded={true}
-                        >
-                          <Grid
-                            centered={false}
-                            padded={true}
-                          >
-                            <div
-                              className="ui padded grid"
-                            >
-                              <GridRow
-                                horizontalAlignContent="left"
-                                verticalAlign="top"
-                              >
-                                <GridRow
-                                  textAlign="left"
-                                  verticalAlign="top"
-                                >
-                                  <div
-                                    className="left aligned top aligned row"
-                                  >
-                                    <GridColumn
-                                      textAlign="center"
-                                      verticalAlignContent="top"
-                                      width={12}
-                                    >
-                                      <GridColumn
-                                        textAlign="center"
-                                        verticalAlign="top"
-                                        width={12}
-                                      >
-                                        <div
-                                          className="center aligned top aligned twelve wide column"
-                                        >
-                                          <Heading
-                                            isColorInverted={false}
-                                            size="medium"
-                                            textAlign={null}
-                                          >
-                                            <Header
-                                              as="h3"
-                                              inverted={false}
-                                              textAlign={null}
-                                            >
-                                              <h3
-                                                className="ui header"
-                                              >
-                                                Hello World!
-                                              </h3>
-                                            </Header>
-                                          </Heading>
-                                        </div>
-                                      </GridColumn>
-                                    </GridColumn>
-                                  </div>
-                                </GridRow>
-                              </GridRow>
-                              <GridRow
-                                horizontalAlignContent="left"
-                                verticalAlign="top"
-                              >
-                                <GridRow
-                                  textAlign="left"
-                                  verticalAlign="top"
-                                >
-                                  <div
-                                    className="left aligned top aligned row"
-                                  >
-                                    <GridColumn
-                                      floated="right"
-                                      textAlign="center"
-                                      verticalAlignContent="top"
-                                      width={12}
-                                    >
-                                      <GridColumn
-                                        floated="right"
-                                        textAlign="center"
-                                        verticalAlign="top"
-                                        width={12}
-                                      >
-                                        <div
-                                          className="center aligned right floated top aligned twelve wide column"
-                                        >
-                                          <div>
-                                            <Paragraph
-                                              size="tiny"
-                                              weight={null}
-                                            >
-                                              <p
-                                                className="tiny"
-                                              >
-                                                Use the coupon code
-                                              </p>
-                                            </Paragraph>
-                                            <Button
-                                              hasShadow={true}
-                                              icon={null}
-                                              isCompact={false}
-                                              isDisabled={false}
-                                              isLoading={false}
-                                              isPositionedRight={true}
-                                              isRounded={false}
-                                              isSecondary={false}
-                                              onClick={[Function]}
-                                              size={null}
-                                            >
-                                              <Button
-                                                as="button"
-                                                circular={false}
-                                                className="has-shadow"
-                                                compact={false}
-                                                disabled={false}
-                                                floated="right"
-                                                loading={false}
-                                                onClick={[Function]}
-                                                secondary={false}
-                                                size={null}
-                                              >
-                                                <button
-                                                  className="ui right floated button has-shadow"
-                                                  onClick={[Function]}
-                                                  role="button"
-                                                >
-                                                  123
-                                                </button>
-                                              </Button>
-                                            </Button>
-                                          </div>
-                                        </div>
-                                      </GridColumn>
-                                    </GridColumn>
-                                  </div>
-                                </GridRow>
-                              </GridRow>
-                            </div>
-                          </Grid>
-                        </Grid>
-                      </div>
-                    </GridColumn>
-                  </GridColumn>
-                  <GridColumn
-                    className="discount-section"
-                    textAlign="center"
-                    verticalAlign="middle"
-                    verticalAlignContent="top"
-                    width={12}
-                  >
-                    <GridColumn
-                      className="discount-section"
-                      textAlign="center"
-                      verticalAlign="top"
-                      width={12}
-                    >
-                      <div
-                        className="center aligned top aligned twelve wide column discount-section"
-                      >
-                        <Statistic
-                          size="small"
-                        >
-                          <div
-                            className="ui small statistic"
-                          >
-                            <StatisticLabel>
-                              <div
-                                className="label"
-                              >
-                                <Paragraph
-                                  size="medium"
-                                  weight="heavy"
-                                >
-                                  <p
-                                    className="heavy"
-                                  >
-                                    Save up to
-                                  </p>
-                                </Paragraph>
-                              </div>
-                            </StatisticLabel>
-                            <StatisticValue>
-                              <div
-                                className="value"
-                              >
-                                <Heading
-                                  isColorInverted={false}
-                                  size="large"
-                                  textAlign={null}
-                                >
-                                  <Header
-                                    as="h2"
-                                    inverted={false}
-                                    textAlign={null}
-                                  >
-                                    <h2
-                                      className="ui header"
-                                    >
-                                      100%
-                                    </h2>
-                                  </Header>
-                                </Heading>
-                              </div>
-                            </StatisticValue>
-                          </div>
-                        </Statistic>
-                      </div>
-                    </GridColumn>
-                  </GridColumn>
-                </div>
-              </GridRow>
-            </GridRow>
-          </div>
-        </Grid>
-      </Grid>
-    </div>
-  </Segment>
-</Promotion>
-`;
-
 exports[`The \`Promotion\` component should have the right structure 1`] = `
 <Promotion
   backgroundImage="testimage"
@@ -325,7 +9,6 @@ exports[`The \`Promotion\` component should have the right structure 1`] = `
   discountCodeParagraphText="Use the coupon code"
   discountHoverButtonText="Book Now with Discount"
   headingText="Hello World!"
-  isDisplayedStacked={false}
   onClick={[Function]}
   placeholderBackgroundImage={null}
 >
@@ -366,16 +49,22 @@ exports[`The \`Promotion\` component should have the right structure 1`] = `
                 >
                   <GridColumn
                     className="content-section"
+                    computer={9}
+                    mobile={12}
+                    tablet={9}
                     verticalAlignContent="top"
-                    width={9}
+                    width={null}
                   >
                     <GridColumn
                       className="content-section"
+                      computer={9}
+                      mobile={12}
+                      tablet={9}
                       verticalAlign="top"
-                      width={9}
+                      width={null}
                     >
                       <div
-                        className="top aligned nine wide column content-section"
+                        className="top aligned nine wide computer twelve wide mobile nine wide tablet column content-section"
                       >
                         <ResponsiveImage
                           alternativeText="Image Widget"
@@ -436,182 +125,347 @@ exports[`The \`Promotion\` component should have the right structure 1`] = `
                                   <div
                                     className="left aligned top aligned row"
                                   >
-                                    <GridColumn
-                                      textAlign="left"
-                                      verticalAlignContent="top"
-                                      width={12}
+                                    <ShowOnDesktop
+                                      parent={[Function]}
+                                      parentProps={
+                                        Object {
+                                          "textAlign": "left",
+                                          "width": 12,
+                                        }
+                                      }
                                     >
                                       <GridColumn
+                                        className="show-on-desktop"
                                         textAlign="left"
-                                        verticalAlign="top"
+                                        verticalAlignContent="top"
                                         width={12}
                                       >
-                                        <div
-                                          className="left aligned top aligned twelve wide column"
+                                        <GridColumn
+                                          className="show-on-desktop"
+                                          textAlign="left"
+                                          verticalAlign="top"
+                                          width={12}
                                         >
-                                          <Heading
-                                            isColorInverted={false}
-                                            size="medium"
-                                            textAlign={null}
+                                          <div
+                                            className="left aligned top aligned twelve wide column show-on-desktop"
                                           >
-                                            <Header
-                                              as="h3"
-                                              inverted={false}
+                                            <Heading
+                                              isColorInverted={false}
+                                              size="medium"
                                               textAlign={null}
                                             >
-                                              <h3
-                                                className="ui header"
+                                              <Header
+                                                as="h3"
+                                                inverted={false}
+                                                textAlign={null}
                                               >
-                                                Hello World!
-                                              </h3>
-                                            </Header>
-                                          </Heading>
-                                        </div>
+                                                <h3
+                                                  className="ui header"
+                                                >
+                                                  Hello World!
+                                                </h3>
+                                              </Header>
+                                            </Heading>
+                                          </div>
+                                        </GridColumn>
                                       </GridColumn>
-                                    </GridColumn>
+                                    </ShowOnDesktop>
+                                    <ShowOnMobile
+                                      parent={[Function]}
+                                      parentProps={
+                                        Object {
+                                          "textAlign": "center",
+                                          "width": 12,
+                                        }
+                                      }
+                                    >
+                                      <GridColumn
+                                        className="show-on-mobile"
+                                        textAlign="center"
+                                        verticalAlignContent="top"
+                                        width={12}
+                                      >
+                                        <GridColumn
+                                          className="show-on-mobile"
+                                          textAlign="center"
+                                          verticalAlign="top"
+                                          width={12}
+                                        >
+                                          <div
+                                            className="center aligned top aligned twelve wide column show-on-mobile"
+                                          >
+                                            <Heading
+                                              isColorInverted={false}
+                                              size="medium"
+                                              textAlign={null}
+                                            >
+                                              <Header
+                                                as="h3"
+                                                inverted={false}
+                                                textAlign={null}
+                                              >
+                                                <h3
+                                                  className="ui header"
+                                                >
+                                                  Hello World!
+                                                </h3>
+                                              </Header>
+                                            </Heading>
+                                          </div>
+                                        </GridColumn>
+                                      </GridColumn>
+                                    </ShowOnMobile>
                                   </div>
                                 </GridRow>
                               </GridRow>
-                              <GridRow
-                                className="book-now-button-container"
-                                horizontalAlignContent="left"
+                              <ShowOnDesktop
+                                parent={[Function]}
+                                parentProps={
+                                  Object {
+                                    "className": "book-now-button-container",
+                                  }
+                                }
                               >
                                 <GridRow
-                                  className="book-now-button-container"
-                                  textAlign="left"
+                                  className="book-now-button-container show-on-desktop"
+                                  horizontalAlignContent="left"
                                 >
-                                  <div
-                                    className="left aligned row book-now-button-container"
+                                  <GridRow
+                                    className="book-now-button-container show-on-desktop"
+                                    textAlign="left"
                                   >
-                                    <GridColumn
-                                      textAlign="center"
-                                      verticalAlignContent="top"
-                                      width={12}
+                                    <div
+                                      className="left aligned row book-now-button-container show-on-desktop"
                                     >
                                       <GridColumn
                                         textAlign="center"
-                                        verticalAlign="top"
+                                        verticalAlignContent="top"
                                         width={12}
                                       >
-                                        <div
-                                          className="center aligned top aligned twelve wide column"
+                                        <GridColumn
+                                          textAlign="center"
+                                          verticalAlign="top"
+                                          width={12}
                                         >
-                                          <Button
-                                            hasShadow={false}
-                                            icon={null}
-                                            isCompact={false}
-                                            isDisabled={false}
-                                            isLoading={false}
-                                            isPositionedRight={false}
-                                            isRounded={true}
-                                            isSecondary={false}
-                                            onClick={[Function]}
-                                            size={null}
+                                          <div
+                                            className="center aligned top aligned twelve wide column"
                                           >
                                             <Button
-                                              as="button"
-                                              circular={true}
-                                              className=""
-                                              compact={false}
-                                              disabled={false}
-                                              floated="left"
-                                              loading={false}
-                                              onClick={[Function]}
-                                              secondary={false}
-                                              size={null}
-                                            >
-                                              <button
-                                                className="ui circular left floated button"
-                                                onClick={[Function]}
-                                                role="button"
-                                              >
-                                                Book Now with Discount
-                                              </button>
-                                            </Button>
-                                          </Button>
-                                        </div>
-                                      </GridColumn>
-                                    </GridColumn>
-                                  </div>
-                                </GridRow>
-                              </GridRow>
-                              <GridRow
-                                horizontalAlignContent="left"
-                                verticalAlign="bottom"
-                              >
-                                <GridRow
-                                  textAlign="left"
-                                  verticalAlign="bottom"
-                                >
-                                  <div
-                                    className="left aligned bottom aligned row"
-                                  >
-                                    <GridColumn
-                                      floated="right"
-                                      textAlign="right"
-                                      verticalAlignContent="top"
-                                      width={6}
-                                    >
-                                      <GridColumn
-                                        floated="right"
-                                        textAlign="right"
-                                        verticalAlign="top"
-                                        width={6}
-                                      >
-                                        <div
-                                          className="right aligned right floated top aligned six wide column"
-                                        >
-                                          <div>
-                                            <Paragraph
-                                              size="tiny"
-                                              weight={null}
-                                            >
-                                              <p
-                                                className="tiny"
-                                              >
-                                                Use the coupon code
-                                              </p>
-                                            </Paragraph>
-                                            <Button
-                                              hasShadow={true}
+                                              hasShadow={false}
                                               icon={null}
                                               isCompact={false}
                                               isDisabled={false}
                                               isLoading={false}
-                                              isPositionedRight={true}
-                                              isRounded={false}
+                                              isPositionedRight={false}
+                                              isRounded={true}
                                               isSecondary={false}
                                               onClick={[Function]}
                                               size={null}
                                             >
                                               <Button
                                                 as="button"
-                                                circular={false}
-                                                className="has-shadow"
+                                                circular={true}
+                                                className=""
                                                 compact={false}
                                                 disabled={false}
-                                                floated="right"
+                                                floated="left"
                                                 loading={false}
                                                 onClick={[Function]}
                                                 secondary={false}
                                                 size={null}
                                               >
                                                 <button
-                                                  className="ui right floated button has-shadow"
+                                                  className="ui circular left floated button"
                                                   onClick={[Function]}
                                                   role="button"
                                                 >
-                                                  123
+                                                  Book Now with Discount
                                                 </button>
                                               </Button>
                                             </Button>
                                           </div>
-                                        </div>
+                                        </GridColumn>
                                       </GridColumn>
-                                    </GridColumn>
-                                  </div>
+                                    </div>
+                                  </GridRow>
                                 </GridRow>
-                              </GridRow>
+                              </ShowOnDesktop>
+                              <ShowOnMobile
+                                parent={[Function]}
+                                parentProps={
+                                  Object {
+                                    "verticalAlign": "top",
+                                  }
+                                }
+                              >
+                                <GridRow
+                                  className="show-on-mobile"
+                                  horizontalAlignContent="left"
+                                  verticalAlign="top"
+                                >
+                                  <GridRow
+                                    className="show-on-mobile"
+                                    textAlign="left"
+                                    verticalAlign="top"
+                                  >
+                                    <div
+                                      className="left aligned top aligned row show-on-mobile"
+                                    >
+                                      <GridColumn
+                                        floated="right"
+                                        textAlign="center"
+                                        verticalAlignContent="top"
+                                        width={12}
+                                      >
+                                        <GridColumn
+                                          floated="right"
+                                          textAlign="center"
+                                          verticalAlign="top"
+                                          width={12}
+                                        >
+                                          <div
+                                            className="center aligned right floated top aligned twelve wide column"
+                                          >
+                                            <div>
+                                              <Paragraph
+                                                size="tiny"
+                                                weight={null}
+                                              >
+                                                <p
+                                                  className="tiny"
+                                                >
+                                                  Use the coupon code
+                                                </p>
+                                              </Paragraph>
+                                              <Button
+                                                hasShadow={true}
+                                                icon={null}
+                                                isCompact={false}
+                                                isDisabled={false}
+                                                isLoading={false}
+                                                isPositionedRight={true}
+                                                isRounded={false}
+                                                isSecondary={false}
+                                                onClick={[Function]}
+                                                size={null}
+                                              >
+                                                <Button
+                                                  as="button"
+                                                  circular={false}
+                                                  className="has-shadow"
+                                                  compact={false}
+                                                  disabled={false}
+                                                  floated="right"
+                                                  loading={false}
+                                                  onClick={[Function]}
+                                                  secondary={false}
+                                                  size={null}
+                                                >
+                                                  <button
+                                                    className="ui right floated button has-shadow"
+                                                    onClick={[Function]}
+                                                    role="button"
+                                                  >
+                                                    123
+                                                  </button>
+                                                </Button>
+                                              </Button>
+                                            </div>
+                                          </div>
+                                        </GridColumn>
+                                      </GridColumn>
+                                    </div>
+                                  </GridRow>
+                                </GridRow>
+                              </ShowOnMobile>
+                              <ShowOnDesktop
+                                parent={[Function]}
+                                parentProps={
+                                  Object {
+                                    "verticalAlign": "bottom",
+                                  }
+                                }
+                              >
+                                <GridRow
+                                  className="show-on-desktop"
+                                  horizontalAlignContent="left"
+                                  verticalAlign="bottom"
+                                >
+                                  <GridRow
+                                    className="show-on-desktop"
+                                    textAlign="left"
+                                    verticalAlign="bottom"
+                                  >
+                                    <div
+                                      className="left aligned bottom aligned row show-on-desktop"
+                                    >
+                                      <GridColumn
+                                        floated="right"
+                                        textAlign="right"
+                                        verticalAlignContent="top"
+                                        width={6}
+                                      >
+                                        <GridColumn
+                                          floated="right"
+                                          textAlign="right"
+                                          verticalAlign="top"
+                                          width={6}
+                                        >
+                                          <div
+                                            className="right aligned right floated top aligned six wide column"
+                                          >
+                                            <div>
+                                              <Paragraph
+                                                size="tiny"
+                                                weight={null}
+                                              >
+                                                <p
+                                                  className="tiny"
+                                                >
+                                                  Use the coupon code
+                                                </p>
+                                              </Paragraph>
+                                              <Button
+                                                hasShadow={true}
+                                                icon={null}
+                                                isCompact={false}
+                                                isDisabled={false}
+                                                isLoading={false}
+                                                isPositionedRight={true}
+                                                isRounded={false}
+                                                isSecondary={false}
+                                                onClick={[Function]}
+                                                size={null}
+                                              >
+                                                <Button
+                                                  as="button"
+                                                  circular={false}
+                                                  className="has-shadow"
+                                                  compact={false}
+                                                  disabled={false}
+                                                  floated="right"
+                                                  loading={false}
+                                                  onClick={[Function]}
+                                                  secondary={false}
+                                                  size={null}
+                                                >
+                                                  <button
+                                                    className="ui right floated button has-shadow"
+                                                    onClick={[Function]}
+                                                    role="button"
+                                                  >
+                                                    123
+                                                  </button>
+                                                </Button>
+                                              </Button>
+                                            </div>
+                                          </div>
+                                        </GridColumn>
+                                      </GridColumn>
+                                    </div>
+                                  </GridRow>
+                                </GridRow>
+                              </ShowOnDesktop>
                             </div>
                           </Grid>
                         </Grid>
@@ -620,19 +474,25 @@ exports[`The \`Promotion\` component should have the right structure 1`] = `
                   </GridColumn>
                   <GridColumn
                     className="discount-section"
+                    computer={3}
+                    mobile={12}
+                    tablet={3}
                     textAlign="center"
                     verticalAlign="middle"
                     verticalAlignContent="top"
-                    width={3}
+                    width={null}
                   >
                     <GridColumn
                       className="discount-section"
+                      computer={3}
+                      mobile={12}
+                      tablet={3}
                       textAlign="center"
                       verticalAlign="top"
-                      width={3}
+                      width={null}
                     >
                       <div
-                        className="center aligned top aligned three wide column discount-section"
+                        className="center aligned top aligned three wide computer twelve wide mobile three wide tablet column discount-section"
                       >
                         <Statistic
                           size="small"

--- a/src/components/general-widgets/Promotion/component.js
+++ b/src/components/general-widgets/Promotion/component.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Statistic, Segment } from 'semantic-ui-react';
-import getClassNames from 'classnames';
 
+import { ShowOnDesktop } from 'layout/ShowOnDesktop';
+import { ShowOnMobile } from 'layout/ShowOnMobile';
 import { ResponsiveImage } from 'media/ResponsiveImage';
 import {
   BOOK_NOW_DISCOUNT,
@@ -30,22 +31,17 @@ export const Component = ({
   discountCodeParagraphText,
   discountHoverButtonText,
   headingText,
-  isDisplayedStacked,
   onClick,
   placeholderBackgroundImage,
 }) => (
-  <Segment
-    basic
-    className={getClassNames('is-promotion', {
-      'display-stacked': isDisplayedStacked,
-    })}
-    onClick={onClick}
-  >
+  <Segment basic className="is-promotion" onClick={onClick}>
     <Grid className="first-grid" stackable stretched>
       <GridRow verticalAlign="middle">
         <GridColumn
           className="content-section"
-          width={isDisplayedStacked ? 12 : 9}
+          computer={9}
+          mobile={12}
+          tablet={9}
         >
           <ResponsiveImage
             imageHeight={backgroundImageHeight}
@@ -55,26 +51,32 @@ export const Component = ({
           />
           <Grid padded>
             <GridRow verticalAlign="top">
-              <GridColumn
-                textAlign={isDisplayedStacked ? 'center' : 'left'}
-                width={12}
+              <ShowOnDesktop
+                parent={GridColumn}
+                parentProps={{ textAlign: 'left', width: 12 }}
               >
                 <Heading>{headingText}</Heading>
-              </GridColumn>
-            </GridRow>
-            {!isDisplayedStacked && (
-              <GridRow className="book-now-button-container">
-                <GridColumn textAlign="center" width={12}>
-                  <Button isRounded>{discountHoverButtonText}</Button>
-                </GridColumn>
-              </GridRow>
-            )}
-            <GridRow verticalAlign={isDisplayedStacked ? 'top' : 'bottom'}>
-              <GridColumn
-                floated="right"
-                textAlign={isDisplayedStacked ? 'center' : 'right'}
-                width={isDisplayedStacked ? 12 : 6}
+              </ShowOnDesktop>
+              <ShowOnMobile
+                parent={GridColumn}
+                parentProps={{ textAlign: 'center', width: 12 }}
               >
+                <Heading>{headingText}</Heading>
+              </ShowOnMobile>
+            </GridRow>
+            <ShowOnDesktop
+              parent={GridRow}
+              parentProps={{ className: 'book-now-button-container' }}
+            >
+              <GridColumn textAlign="center" width={12}>
+                <Button isRounded>{discountHoverButtonText}</Button>
+              </GridColumn>
+            </ShowOnDesktop>
+            <ShowOnMobile
+              parent={GridRow}
+              parentProps={{ verticalAlign: 'top' }}
+            >
+              <GridColumn floated="right" textAlign="center" width={12}>
                 <div>
                   <Paragraph size="tiny">{discountCodeParagraphText}</Paragraph>
                   <Button hasShadow isPositionedRight>
@@ -82,14 +84,29 @@ export const Component = ({
                   </Button>
                 </div>
               </GridColumn>
-            </GridRow>
+            </ShowOnMobile>
+            <ShowOnDesktop
+              parent={GridRow}
+              parentProps={{ verticalAlign: 'bottom' }}
+            >
+              <GridColumn floated="right" textAlign="right" width={6}>
+                <div>
+                  <Paragraph size="tiny">{discountCodeParagraphText}</Paragraph>
+                  <Button hasShadow isPositionedRight>
+                    {discountCode}
+                  </Button>
+                </div>
+              </GridColumn>
+            </ShowOnDesktop>
           </Grid>
         </GridColumn>
         <GridColumn
           className="discount-section"
+          computer={3}
+          mobile={12}
+          tablet={3}
           textAlign="center"
           verticalAlign="middle"
-          width={isDisplayedStacked ? 12 : 3}
         >
           <Statistic size="small">
             <Statistic.Label>
@@ -115,7 +132,6 @@ Component.defaultProps = {
   discountAmountParagraphText: SAVE_UP_TO,
   discountCodeParagraphText: USE_COUPON_CODE,
   discountHoverButtonText: BOOK_NOW_DISCOUNT,
-  isDisplayedStacked: false,
   placeholderBackgroundImage: null,
 };
 
@@ -138,8 +154,6 @@ Component.propTypes = {
   discountHoverButtonText: PropTypes.string,
   /** The text to display as a heading at the top of the widget. */
   headingText: PropTypes.string.isRequired,
-  /** Is the component displayed with each item above one another. */
-  isDisplayedStacked: PropTypes.bool,
   /** The function to call when the component is clicked. */
   onClick: PropTypes.func.isRequired,
   /** The background placeholder image. */

--- a/src/components/general-widgets/Promotion/component.spec.js
+++ b/src/components/general-widgets/Promotion/component.spec.js
@@ -13,23 +13,10 @@ const componentProps = {
 
 const getPromotion = () => mount(<Promotion {...componentProps} />);
 
-const getPromotionAsStacked = () =>
-  mount(<Promotion {...componentProps} isDisplayedStacked />);
-
 describe('The `Promotion` component', () => {
   it('should have the right structure', () => {
     const wrapper = getPromotion();
 
     expect(wrapper).toMatchSnapshot();
-  });
-
-  describe('`Promotion` as stacked', () => {
-    describe('`Segment`', () => {
-      it('should have the right structure', () => {
-        const wrapper = getPromotionAsStacked();
-
-        expect(wrapper).toMatchSnapshot();
-      });
-    });
   });
 });

--- a/src/components/inputs/Dropdown/component.js
+++ b/src/components/inputs/Dropdown/component.js
@@ -81,8 +81,9 @@ export class Component extends PureComponent {
           selection
           upward={willOpenAbove}
         />
-        {!hasImages &&
-          label && <label onClick={() => this.handleOpen(true)}>{label}</label>}
+        {!hasImages && label && (
+          <label onClick={() => this.handleOpen(true)}>{label}</label>
+        )}
       </div>
     );
   }

--- a/src/styles/semantic/themes/livingstone/elements/segment.overrides
+++ b/src/styles/semantic/themes/livingstone/elements/segment.overrides
@@ -124,11 +124,12 @@
     padding: 0;
   }
 
-  @media @mobileScreen {
-    padding: 0;
+  .responsive-image img {
+    min-height: 100%;
   }
 
-  &.display-stacked {
+  @media @tabletScreen {
+    padding: 0;
 
     p + .button {
       float: none;
@@ -150,19 +151,22 @@
     }
   }
 
-  &:not(.display-stacked):hover .content-section {
+  @media @computerScreen {
 
-    p,
-    p + .button,
-    .header,
-    > picture.responsive-image .ui.image {
-      filter: @promotionHoverBlur;
-      -ms-filter: @promotionHoverBlur;
-      pointer-events: none;
-    }
+    &:hover .content-section {
 
-    .book-now-button-container .button {
-      opacity: 1;
+      p,
+      p + .button,
+      .header,
+      > picture.responsive-image .ui.image {
+        filter: @promotionHoverBlur;
+        -ms-filter: @promotionHoverBlur;
+        pointer-events: none;
+      }
+
+      .book-now-button-container .button {
+        opacity: 1;
+      }
     }
   }
 


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1389)

### What **one** thing does this PR do?
Makes the Promotion component responsive and removes the `isDisplayedStacked` prop

### Other notes
- Fixes any lint issues that have been introduced from a recent update to `prettier`

### Before
<img width="710" alt="screen shot 2018-11-07 at 12 04 02" src="https://user-images.githubusercontent.com/25742275/48127944-4cb10f00-e285-11e8-99bf-52bb0d9f3c9f.png">

### After
![kapture 2018-11-07 at 11 57 19](https://user-images.githubusercontent.com/25742275/48127564-538b5200-e284-11e8-884a-ccc01367875c.gif)

