### PR TITLE
TE-1393 Remove blur from graceful images

### DIFF
--- a/src/components/media/ResponsiveImage/component.js
+++ b/src/components/media/ResponsiveImage/component.js
@@ -19,8 +19,11 @@ import { getPlaceholderImageMarkup } from './utils/getPlaceholderImageMarkup';
 // eslint-disable-next-line jsdoc/require-jsdoc
 export class Component extends PureComponent {
   state = {
+    shouldImageLoad: false,
     isImageLoaded: false,
   };
+
+  componentDidMount = () => this.setState({ shouldImageLoad: true });
 
   handleImageLoad = () => this.setState({ isImageLoaded: true });
 
@@ -39,6 +42,7 @@ export class Component extends PureComponent {
       ...this.props,
       isImageLoaded: this.state.isImageLoaded,
       handleImageLoad: this.handleImageLoad,
+      shouldImageLoad: this.state.shouldImageLoad,
     };
 
     return (

--- a/src/components/media/ResponsiveImage/component.spec.js
+++ b/src/components/media/ResponsiveImage/component.spec.js
@@ -72,15 +72,29 @@ describe('<ResponsiveImage />', () => {
     });
   });
 
+  describe('on mount', () => {
+    it('should set `shouldImageLoad` to `true` in the components state', () => {
+      const wrapper = getResponsiveImage();
+
+      wrapper.instance().componentDidMount();
+      const actual = wrapper.state();
+
+      expect(actual).toEqual({
+        isImageLoaded: false,
+        shouldImageLoad: true,
+      });
+    });
+  });
+
   describe('`handleImageLoad`', () => {
     it('should set `isImageLoaded` to `true` in the components state', () => {
       const wrapper = getResponsiveImage();
 
       wrapper.instance().handleImageLoad();
-
       const actual = wrapper.state();
 
       expect(actual).toEqual({
+        shouldImageLoad: true,
         isImageLoaded: true,
       });
     });

--- a/src/components/media/ResponsiveImage/utils/__snapshots__/getPlaceHolderImageMarkup.spec.js.snap
+++ b/src/components/media/ResponsiveImage/utils/__snapshots__/getPlaceHolderImageMarkup.spec.js.snap
@@ -4,33 +4,6 @@ exports[`\`getPlaceholderImageMarkup\` by default should render the right struct
 <div
   className="image-with-placeholder-container"
 >
-  <Image
-    alt="someAltText"
-    as="img"
-    avatar={false}
-    fluid={true}
-    onLoad={[Function]}
-    title="someTitle"
-    ui={true}
-  >
-    <div
-      alt="someAltText"
-      className="ui fluid image"
-      onLoad={[Function]}
-      title="someTitle"
-    >
-      <Label
-        content="someLabel"
-      >
-        <div
-          className="ui label"
-          onClick={[Function]}
-        >
-          someLabel
-        </div>
-      </Label>
-    </div>
-  </Image>
   <div
     className="placeholder-image-container"
   >
@@ -52,7 +25,57 @@ exports[`\`getPlaceholderImageMarkup\` by default should render the right struct
 </div>
 `;
 
-exports[`\`getPlaceholderImageMarkup\` if \`imageUrl\` is passed should render the right structure 1`] = `
+exports[`\`getPlaceholderImageMarkup\` if \`isImageLoaded === false\` should render the right structure 1`] = `
+<div
+  className="image-with-placeholder-container has-blurred-children"
+>
+  <div
+    className="placeholder-image-container"
+  >
+    <img
+      className="placeholder-image ui image fluid"
+      src="anotherUrl"
+    />
+    <Label
+      content="someLabel"
+    >
+      <div
+        className="ui label"
+        onClick={[Function]}
+      >
+        someLabel
+      </div>
+    </Label>
+  </div>
+</div>
+`;
+
+exports[`\`getPlaceholderImageMarkup\` if \`shouldImageLoad === false\` should render the right structure 1`] = `
+<div
+  className="image-with-placeholder-container"
+>
+  <div
+    className="placeholder-image-container"
+  >
+    <img
+      className="placeholder-image ui image fluid"
+      src="anotherUrl"
+    />
+    <Label
+      content="someLabel"
+    >
+      <div
+        className="ui label"
+        onClick={[Function]}
+      >
+        someLabel
+      </div>
+    </Label>
+  </div>
+</div>
+`;
+
+exports[`\`getPlaceholderImageMarkup\` if \`shouldImageLoad === true\` if \`imageUrl\` is passed should render the right structure 1`] = `
 <div
   className="image-with-placeholder-container"
 >
@@ -85,9 +108,9 @@ exports[`\`getPlaceholderImageMarkup\` if \`imageUrl\` is passed should render t
 </div>
 `;
 
-exports[`\`getPlaceholderImageMarkup\` if \`isImageLoaded === false\` should render the right structure 1`] = `
+exports[`\`getPlaceholderImageMarkup\` if \`shouldImageLoad === true\` should render the right structure 1`] = `
 <div
-  className="image-with-placeholder-container has-blurred-children"
+  className="image-with-placeholder-container"
 >
   <Image
     alt="someAltText"

--- a/src/components/media/ResponsiveImage/utils/getPlaceHolderImageMarkup.spec.js
+++ b/src/components/media/ResponsiveImage/utils/getPlaceHolderImageMarkup.spec.js
@@ -24,9 +24,30 @@ describe('`getPlaceholderImageMarkup`', () => {
     });
   });
 
-  describe('if `imageUrl` is passed', () => {
+  describe('if `shouldImageLoad === true`', () => {
+    const getPlaceholderWithImageLoad = extraProps =>
+      getPlaceholderImage({ shouldImageLoad: true, ...extraProps });
+
     it('should render the right structure', () => {
-      const actual = getPlaceholderImage({ imageUrl: 'yoyoUrl' });
+      const actual = getPlaceholderWithImageLoad();
+
+      expect(actual).toMatchSnapshot();
+    });
+
+    describe('if `imageUrl` is passed', () => {
+      it('should render the right structure', () => {
+        const actual = getPlaceholderWithImageLoad({
+          imageUrl: 'yoyoUrl',
+        });
+
+        expect(actual).toMatchSnapshot();
+      });
+    });
+  });
+
+  describe('if `shouldImageLoad === false`', () => {
+    it('should render the right structure', () => {
+      const actual = getPlaceholderImage({ shouldImageLoad: false });
 
       expect(actual).toMatchSnapshot();
     });

--- a/src/components/media/ResponsiveImage/utils/getPlaceholderImageMarkup.js
+++ b/src/components/media/ResponsiveImage/utils/getPlaceholderImageMarkup.js
@@ -32,6 +32,7 @@ export const getPlaceholderImageMarkup = ({
   isAvatar,
   isImageLoaded,
   placeholderImageUrl,
+  shouldImageLoad,
   /* eslint-enable react/prop-types */
 }) => (
   <div
@@ -40,16 +41,18 @@ export const getPlaceholderImageMarkup = ({
     })}
   >
     {getAspectRatioPlaceholderMarkup(imageWidth, imageHeight)}
-    <Image
-      alt={alternativeText}
-      avatar={isAvatar}
-      fluid={getIsFluid(imageWidth, imageHeight)}
-      onLoad={handleImageLoad}
-      src={imageUrl}
-      title={imageTitle}
-    >
-      {!imageUrl ? <Label content={imageNotFoundLabelText} /> : null}
-    </Image>
+    {shouldImageLoad && (
+      <Image
+        alt={alternativeText}
+        avatar={isAvatar}
+        fluid={getIsFluid(imageWidth, imageHeight)}
+        onLoad={handleImageLoad}
+        src={imageUrl}
+        title={imageTitle}
+      >
+        {!imageUrl ? <Label content={imageNotFoundLabelText} /> : null}
+      </Image>
+    )}
     <div className="placeholder-image-container">
       <img
         className={getClassNames('placeholder-image', {


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1393)

### What **one** thing does this PR do?
Removes the blur from components, that didn't have a component lifecycle method, when the image has loaded.

### Any other notes
These screenshots are taken from running the node server locally. Which is the closest I could get to staging.

![kapture 2018-11-08 at 12 45 14](https://user-images.githubusercontent.com/10498995/48196886-30c86e80-e354-11e8-85a0-78142d2ce49a.gif)

![kapture 2018-11-08 at 12 45 59](https://user-images.githubusercontent.com/10498995/48196938-5190c400-e354-11e8-9085-7aac8aec4031.gif)
