### PR TITLE
TE-1385: ensure getIsEmpty returns false if value is 0

### DIFF
--- a/src/components/collections/Form/utils/getValidationWithDefaults.js
+++ b/src/components/collections/Form/utils/getValidationWithDefaults.js
@@ -9,7 +9,7 @@ import { DEFAULT_IS_REQUIRED_MESSAGE } from '../constants';
  * @return {Object}
  */
 export const getValidationWithDefaults = ({
-  getIsEmpty = value => !value,
+  getIsEmpty = value => !value && value !== 0,
   getIsValid = Function.prototype,
   isRequiredMessage = DEFAULT_IS_REQUIRED_MESSAGE,
   ...rest

--- a/src/components/collections/Form/utils/getValidationWithDefaults.spec.js
+++ b/src/components/collections/Form/utils/getValidationWithDefaults.spec.js
@@ -38,4 +38,26 @@ describe('getValidationWithDefaults', () => {
       another,
     });
   });
+
+  describe('getIsEmpty', () => {
+    const validationDefaults = getValidationWithDefaults();
+
+    it('should return true if is empty', () => {
+      const actual = validationDefaults.getIsEmpty('');
+
+      expect(actual).toBe(true);
+    });
+
+    it('should return false if the value is not empty', () => {
+      const actual = validationDefaults.getIsEmpty('🏝');
+
+      expect(actual).toBe(false);
+    });
+
+    it('should return false if the value is `0`', () => {
+      const actual = validationDefaults.getIsEmpty('0');
+
+      expect(actual).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1385)

### What **one** thing does this PR do?
This will ensure if a field contains the value `0`, the field will not be seen to have an empty value in the form

### Any other notes
- Some spec coverage has also been added for `getIsEmpty`.
