### PR TITLE
TE-1389: The Promotion appears as expected if nested under Grid

### DIFF
--- a/src/styles/semantic/themes/livingstone/elements/segment.overrides
+++ b/src/styles/semantic/themes/livingstone/elements/segment.overrides
@@ -131,6 +131,11 @@
   @media @tabletScreen {
     padding: 0;
 
+    .ui.stackable.grid {
+      margin-left: 0 !important;
+      margin-right: 0 !important;
+    }
+
     p + .button {
       float: none;
       margin-left: auto;
@@ -146,8 +151,11 @@
     }
 
     .discount-section {
-      padding: @promotionStackedDiscountPadding;
       height: auto;
+
+      .ui.statistic {
+        padding: @promotionStackedDiscountPadding;
+      }
     }
   }
 


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1389)

### What **one** thing does this PR do?
Fixes the rendering of the Promotion component for the mobile viewport when the component is nested in a `Grid`

### Any other notes
- Also, when the Promotion is shown on mobile, the discount section will now have the padding correctly applied

### Why this was occurring
- Conflicting CSS rules were being applied to a nested Grid in the Promotion component when the component was being rendered in TemplatesSSR, this update will override these conflicting CSS rules.

In the following previews, the promotion component is nested in a `Grid`

### Before
<img width="548" alt="screen shot 2018-11-12 at 17 32 09" src="https://user-images.githubusercontent.com/25742275/48361453-d441b800-e6a1-11e8-82d3-cda88f6553c4.png">

### After
<img width="613" alt="screen shot 2018-11-12 at 17 34 21" src="https://user-images.githubusercontent.com/25742275/48361465-da379900-e6a1-11e8-8ec7-b9ca83974365.png">
