### PR TITLE
TE-1406: Just load the image if it exists in the cache

### DIFF
--- a/src/components/media/ResponsiveImage/__snapshots__/component.spec.js.snap
+++ b/src/components/media/ResponsiveImage/__snapshots__/component.spec.js.snap
@@ -134,7 +134,7 @@ exports[`<ResponsiveImage /> if \`props.placeholderImageUrl\` and \`props.imageU
     role="figure"
   >
     <div
-      className="image-with-placeholder-container has-blurred-children"
+      className="image-with-placeholder-container has-blurred-children is-visible"
     >
       <Image
         alt="Alternative Text 😝"

--- a/src/components/media/ResponsiveImage/component.js
+++ b/src/components/media/ResponsiveImage/component.js
@@ -19,11 +19,27 @@ import { getPlaceholderImageMarkup } from './utils/getPlaceholderImageMarkup';
 // eslint-disable-next-line jsdoc/require-jsdoc
 export class Component extends PureComponent {
   state = {
-    shouldImageLoad: false,
     isImageLoaded: false,
+    isImageLoadedFromCache: false,
+    shouldImageLoad: false,
   };
 
-  componentDidMount = () => this.setState({ shouldImageLoad: true });
+  componentDidMount = () => {
+    const { imageUrl, placeholderImageUrl } = this.props;
+
+    if (!!placeholderImageUrl && !!imageUrl) {
+      const fullsizeImage = new Image();
+
+      fullsizeImage.src = imageUrl;
+
+      this.setState({
+        shouldImageLoad: true,
+        isImageLoadedFromCache: fullsizeImage.complete,
+      });
+    } else {
+      this.setState({ shouldImageLoad: true });
+    }
+  };
 
   handleImageLoad = () => this.setState({ isImageLoaded: true });
 
@@ -40,8 +56,9 @@ export class Component extends PureComponent {
 
     const imageProps = {
       ...this.props,
-      isImageLoaded: this.state.isImageLoaded,
       handleImageLoad: this.handleImageLoad,
+      isImageLoaded: this.state.isImageLoaded,
+      isImageLoadedFromCache: this.state.isImageLoadedFromCache,
       shouldImageLoad: this.state.shouldImageLoad,
     };
 

--- a/src/components/media/ResponsiveImage/component.spec.js
+++ b/src/components/media/ResponsiveImage/component.spec.js
@@ -81,6 +81,7 @@ describe('<ResponsiveImage />', () => {
 
       expect(actual).toEqual({
         isImageLoaded: false,
+        isImageLoadedFromCache: false,
         shouldImageLoad: true,
       });
     });
@@ -94,8 +95,9 @@ describe('<ResponsiveImage />', () => {
       const actual = wrapper.state();
 
       expect(actual).toEqual({
-        shouldImageLoad: true,
         isImageLoaded: true,
+        isImageLoadedFromCache: false,
+        shouldImageLoad: true,
       });
     });
   });

--- a/src/components/media/ResponsiveImage/utils/__snapshots__/getPlaceHolderImageMarkup.spec.js.snap
+++ b/src/components/media/ResponsiveImage/utils/__snapshots__/getPlaceHolderImageMarkup.spec.js.snap
@@ -50,6 +50,92 @@ exports[`\`getPlaceholderImageMarkup\` if \`isImageLoaded === false\` should ren
 </div>
 `;
 
+exports[`\`getPlaceholderImageMarkup\` if \`isImageLoadedFromCache === false\` should render the right structure 1`] = `
+<div
+  className="image-with-placeholder-container is-visible"
+>
+  <Image
+    alt="someAltText"
+    as="img"
+    avatar={false}
+    fluid={true}
+    onLoad={[Function]}
+    title="someTitle"
+    ui={true}
+  >
+    <div
+      alt="someAltText"
+      className="ui fluid image"
+      onLoad={[Function]}
+      title="someTitle"
+    >
+      <Label
+        content="someLabel"
+      >
+        <div
+          className="ui label"
+          onClick={[Function]}
+        >
+          someLabel
+        </div>
+      </Label>
+    </div>
+  </Image>
+  <div
+    className="placeholder-image-container"
+  >
+    <img
+      className="placeholder-image ui image fluid"
+      src="anotherUrl"
+    />
+    <Label
+      content="someLabel"
+    >
+      <div
+        className="ui label"
+        onClick={[Function]}
+      >
+        someLabel
+      </div>
+    </Label>
+  </div>
+</div>
+`;
+
+exports[`\`getPlaceholderImageMarkup\` if \`isImageLoadedFromCache === true\` should render the right structure 1`] = `
+<div
+  className="image-with-placeholder-container is-visible"
+>
+  <Image
+    alt="someAltText"
+    as="img"
+    avatar={false}
+    fluid={true}
+    onLoad={[Function]}
+    title="someTitle"
+    ui={true}
+  >
+    <div
+      alt="someAltText"
+      className="ui fluid image"
+      onLoad={[Function]}
+      title="someTitle"
+    >
+      <Label
+        content="someLabel"
+      >
+        <div
+          className="ui label"
+          onClick={[Function]}
+        >
+          someLabel
+        </div>
+      </Label>
+    </div>
+  </Image>
+</div>
+`;
+
 exports[`\`getPlaceholderImageMarkup\` if \`shouldImageLoad === false\` should render the right structure 1`] = `
 <div
   className="image-with-placeholder-container"
@@ -77,7 +163,7 @@ exports[`\`getPlaceholderImageMarkup\` if \`shouldImageLoad === false\` should r
 
 exports[`\`getPlaceholderImageMarkup\` if \`shouldImageLoad === true\` if \`imageUrl\` is passed should render the right structure 1`] = `
 <div
-  className="image-with-placeholder-container"
+  className="image-with-placeholder-container is-visible"
 >
   <Image
     alt="someAltText"
@@ -110,7 +196,7 @@ exports[`\`getPlaceholderImageMarkup\` if \`shouldImageLoad === true\` if \`imag
 
 exports[`\`getPlaceholderImageMarkup\` if \`shouldImageLoad === true\` should render the right structure 1`] = `
 <div
-  className="image-with-placeholder-container"
+  className="image-with-placeholder-container is-visible"
 >
   <Image
     alt="someAltText"

--- a/src/components/media/ResponsiveImage/utils/getImageMarkup.js
+++ b/src/components/media/ResponsiveImage/utils/getImageMarkup.js
@@ -12,7 +12,6 @@ import { getIsFluid } from './getIsFluid';
  * @param  {string}        imageProps.imageUrl
  * @param  {number|string} imageProps.imageWidth
  * @param  {boolean}       imageProps.isAvatar
- * @param  {boolean}       imageProps.isFluid
  * @return {Function}
  */
 export const getImageMarkup = ({

--- a/src/components/media/ResponsiveImage/utils/getPlaceHolderImageMarkup.spec.js
+++ b/src/components/media/ResponsiveImage/utils/getPlaceHolderImageMarkup.spec.js
@@ -60,4 +60,26 @@ describe('`getPlaceholderImageMarkup`', () => {
       expect(actual).toMatchSnapshot();
     });
   });
+
+  describe('if `isImageLoadedFromCache === true`', () => {
+    it('should render the right structure', () => {
+      const actual = getPlaceholderImage({
+        isImageLoadedFromCache: true,
+        shouldImageLoad: true,
+      });
+
+      expect(actual).toMatchSnapshot();
+    });
+  });
+
+  describe('if `isImageLoadedFromCache === false`', () => {
+    it('should render the right structure', () => {
+      const actual = getPlaceholderImage({
+        isImageLoadedFromCache: false,
+        shouldImageLoad: true,
+      });
+
+      expect(actual).toMatchSnapshot();
+    });
+  });
 });

--- a/src/components/media/ResponsiveImage/utils/getPlaceholderImageMarkup.js
+++ b/src/components/media/ResponsiveImage/utils/getPlaceholderImageMarkup.js
@@ -17,7 +17,9 @@ import { getAspectRatioPlaceholderMarkup } from './getAspectRatioPlaceholderMark
  * @param  {boolean}       imageProps.isAvatar
  * @param  {boolean}       imageProps.isFluid
  * @param  {boolean}       imageProps.isImageLoaded
+ * @param  {boolean}       imageProps.isImageLoadedFromCache
  * @param  {string}        imageProps.placeholderImageUrl
+ * @param  {boolean}       imageProps.shouldImageLoad
  * @return {Function}
  */
 export const getPlaceholderImageMarkup = ({
@@ -31,13 +33,15 @@ export const getPlaceholderImageMarkup = ({
   imageWidth,
   isAvatar,
   isImageLoaded,
+  isImageLoadedFromCache,
   placeholderImageUrl,
   shouldImageLoad,
   /* eslint-enable react/prop-types */
 }) => (
   <div
     className={getClassNames('image-with-placeholder-container', {
-      'has-blurred-children': !isImageLoaded,
+      'has-blurred-children': !isImageLoaded && !isImageLoadedFromCache,
+      'is-visible': shouldImageLoad,
     })}
   >
     {getAspectRatioPlaceholderMarkup(imageWidth, imageHeight)}
@@ -53,14 +57,16 @@ export const getPlaceholderImageMarkup = ({
         {!imageUrl ? <Label content={imageNotFoundLabelText} /> : null}
       </Image>
     )}
-    <div className="placeholder-image-container">
-      <img
-        className={getClassNames('placeholder-image', {
-          'ui image fluid': getIsFluid(imageWidth, imageHeight),
-        })}
-        src={placeholderImageUrl}
-      />
-      {!imageUrl && <Label content={imageNotFoundLabelText} />}
-    </div>
+    {!isImageLoadedFromCache && (
+      <div className="placeholder-image-container">
+        <img
+          className={getClassNames('placeholder-image', {
+            'ui image fluid': getIsFluid(imageWidth, imageHeight),
+          })}
+          src={placeholderImageUrl}
+        />
+        {!imageUrl && <Label content={imageNotFoundLabelText} />}
+      </div>
+    )}
   </div>
 );

--- a/src/components/media/ResponsiveImage/utils/getPlaceholderImageMarkup.js
+++ b/src/components/media/ResponsiveImage/utils/getPlaceholderImageMarkup.js
@@ -15,7 +15,6 @@ import { getAspectRatioPlaceholderMarkup } from './getAspectRatioPlaceholderMark
  * @param  {string}        imageProps.imageUrl
  * @param  {string|number} imageProps.imageWidth
  * @param  {boolean}       imageProps.isAvatar
- * @param  {boolean}       imageProps.isFluid
  * @param  {boolean}       imageProps.isImageLoaded
  * @param  {boolean}       imageProps.isImageLoadedFromCache
  * @param  {string}        imageProps.placeholderImageUrl

--- a/src/styles/semantic/themes/livingstone/elements/image.overrides
+++ b/src/styles/semantic/themes/livingstone/elements/image.overrides
@@ -22,6 +22,12 @@
   overflow: hidden;
   width: 100%;
   height: 100%;
+  opacity: 0;
+  transition: @imageWithPlaceholderContainerTransition;
+
+  &.is-visible {
+    opacity: 1;
+  }
 
   &.has-blurred-children {
 

--- a/src/styles/semantic/themes/livingstone/elements/image.variables
+++ b/src/styles/semantic/themes/livingstone/elements/image.variables
@@ -21,3 +21,4 @@
 @imageWithPlaceholderBlur: blur(20px);
 @imageWithPlaceholderTransformScale: scale(1.15);
 @imageWithPlaceholderTransition: 0.5s filter ease-out, 0.5s transform ease-out, 0.5s opacity ease-out;
+@imageWithPlaceholderContainerTransition: opacity 0.3s;


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1406)

### What **one** thing does this PR do?
If the image is in the cache, then just show it and do not show the blurred image. 

### Any other notes
- Also removed the `isFluid` JsDoc param from the image markup utilities

### Preview of Gallery
![kapture 2018-11-13 at 15 37 12](https://user-images.githubusercontent.com/25742275/48420150-07478280-e75a-11e8-843f-c02bfb313d0d.gif)

### Preview of the Homepage Hero
![kapture 2018-11-13 at 15 35 00](https://user-images.githubusercontent.com/25742275/48420228-3e1d9880-e75a-11e8-896d-d5efddd7362d.gif)

