### PR TITLE
TE-1422: Use default required message if the passed prop is an empty string

### DIFF
--- a/src/components/collections/Form/utils/getValidationWithDefaults.js
+++ b/src/components/collections/Form/utils/getValidationWithDefaults.js
@@ -11,11 +11,11 @@ import { DEFAULT_IS_REQUIRED_MESSAGE } from '../constants';
 export const getValidationWithDefaults = ({
   getIsEmpty = value => !value && value !== 0,
   getIsValid = Function.prototype,
-  isRequiredMessage = DEFAULT_IS_REQUIRED_MESSAGE,
+  isRequiredMessage,
   ...rest
 } = {}) => ({
   getIsEmpty,
   getIsValid,
-  isRequiredMessage,
+  isRequiredMessage: isRequiredMessage || DEFAULT_IS_REQUIRED_MESSAGE,
   ...rest,
 });

--- a/src/components/collections/Form/utils/getValidationWithDefaults.spec.js
+++ b/src/components/collections/Form/utils/getValidationWithDefaults.spec.js
@@ -21,6 +21,18 @@ describe('getValidationWithDefaults', () => {
     );
   });
 
+  it('should set defaults for `isRequiredMessage` if an empty string is passed', () => {
+    const actual = getValidationWithDefaults({
+      isRequiredMessage: '',
+    });
+
+    expect(actual).toEqual(
+      expect.objectContaining({
+        isRequiredMessage: DEFAULT_IS_REQUIRED_MESSAGE,
+      })
+    );
+  });
+
   it('should pass through other properties', () => {
     const getIsEmpty = 'some function';
     const isRequiredMessage = '💁';


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1422)

### What **one** thing does this PR do?
Ensures the default required message string is used if the passed `isRequiredMessage` contains an empty string

### Any other notes
- This is causing the Forms to appear without field validation
- This is currently an issue since the translated messages are returning empty strings

### Before
![kapture 2018-11-14 at 11 07 10](https://user-images.githubusercontent.com/25742275/48476186-ac1b9b80-e7fe-11e8-82dd-559976d4369a.gif)

### After
![kapture 2018-11-14 at 11 08 03](https://user-images.githubusercontent.com/25742275/48476201-b5a50380-e7fe-11e8-9332-a083fb570f76.gif)
