### PR TITLE
TE-1447: Hide rows if relevant props are undefined in PaymentInformation

### DIFF
--- a/src/components/property-page-widgets/PaymentInformation/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/PaymentInformation/__snapshots__/component.spec.js.snap
@@ -1,0 +1,1161 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<PaymentInformation /> if \`props.cancellationPolicyText\` is passed should have the right structure 1`] = `
+<PaymentInformation
+  cancellationPolicyHeadingText="Cancellation Policy"
+  cancellationPolicyText="All paid prepayments are non-refundable."
+  cleaningCharge={null}
+  cleaningChargeHeadingText="Cleaning Charge"
+  damageDepositHeadingText="Damage Deposit"
+  damageDepositText={null}
+  extraNotesText={null}
+  headingText="Payment Information"
+  modalTriggerText="View more"
+  notesHeadingText="Notes"
+  notesText={null}
+  paymentScheduleHeadingText="Payment Schedule"
+  paymentScheduleText={null}
+  taxesDescriptionText={null}
+  taxesHeadingText="Taxes"
+  taxesText={null}
+>
+  <Grid
+    areColumnsCentered={false}
+    stackable={true}
+  >
+    <Grid
+      centered={false}
+      stackable={true}
+    >
+      <div
+        className="ui stackable grid"
+      >
+        <GridRow
+          horizontalAlignContent="left"
+        >
+          <GridRow
+            textAlign="left"
+          >
+            <div
+              className="left aligned row"
+            >
+              <GridColumn
+                verticalAlignContent="top"
+                width={12}
+              >
+                <GridColumn
+                  verticalAlign="top"
+                  width={12}
+                >
+                  <div
+                    className="top aligned twelve wide column"
+                  >
+                    <Heading
+                      isColorInverted={false}
+                      size="medium"
+                      textAlign={null}
+                    >
+                      <Header
+                        as="h3"
+                        inverted={false}
+                        textAlign={null}
+                      >
+                        <h3
+                          className="ui header"
+                        >
+                          Payment Information
+                        </h3>
+                      </Header>
+                    </Heading>
+                  </div>
+                </GridColumn>
+              </GridColumn>
+            </div>
+          </GridRow>
+        </GridRow>
+        <GridRow
+          horizontalAlignContent="left"
+        >
+          <GridRow
+            textAlign="left"
+          >
+            <div
+              className="left aligned row"
+            >
+              <GridColumn
+                verticalAlignContent="top"
+                width={6}
+              >
+                <GridColumn
+                  verticalAlign="top"
+                  width={6}
+                >
+                  <div
+                    className="top aligned six wide column"
+                  >
+                    <Heading
+                      isColorInverted={false}
+                      size="small"
+                      textAlign={null}
+                    >
+                      <Header
+                        as="h4"
+                        inverted={false}
+                        textAlign={null}
+                      >
+                        <h4
+                          className="ui header"
+                        >
+                          Cancellation Policy
+                        </h4>
+                      </Header>
+                    </Heading>
+                    <Paragraph
+                      size="medium"
+                      weight={null}
+                    >
+                      <p
+                        className=""
+                      >
+                        All paid prepayments are non-refundable.
+                      </p>
+                    </Paragraph>
+                  </div>
+                </GridColumn>
+              </GridColumn>
+            </div>
+          </GridRow>
+        </GridRow>
+      </div>
+    </Grid>
+  </Grid>
+</PaymentInformation>
+`;
+
+exports[`<PaymentInformation /> if \`props.cleaningCharge\` is passed should have the right structure 1`] = `
+<PaymentInformation
+  cancellationPolicyHeadingText="Cancellation Policy"
+  cancellationPolicyText={null}
+  cleaningCharge="25$ (USD)"
+  cleaningChargeHeadingText="Cleaning Charge"
+  damageDepositHeadingText="Damage Deposit"
+  damageDepositText={null}
+  extraNotesText={null}
+  headingText="Payment Information"
+  modalTriggerText="View more"
+  notesHeadingText="Notes"
+  notesText={null}
+  paymentScheduleHeadingText="Payment Schedule"
+  paymentScheduleText={null}
+  taxesDescriptionText={null}
+  taxesHeadingText="Taxes"
+  taxesText={null}
+>
+  <Grid
+    areColumnsCentered={false}
+    stackable={true}
+  >
+    <Grid
+      centered={false}
+      stackable={true}
+    >
+      <div
+        className="ui stackable grid"
+      >
+        <GridRow
+          horizontalAlignContent="left"
+        >
+          <GridRow
+            textAlign="left"
+          >
+            <div
+              className="left aligned row"
+            >
+              <GridColumn
+                verticalAlignContent="top"
+                width={12}
+              >
+                <GridColumn
+                  verticalAlign="top"
+                  width={12}
+                >
+                  <div
+                    className="top aligned twelve wide column"
+                  >
+                    <Heading
+                      isColorInverted={false}
+                      size="medium"
+                      textAlign={null}
+                    >
+                      <Header
+                        as="h3"
+                        inverted={false}
+                        textAlign={null}
+                      >
+                        <h3
+                          className="ui header"
+                        >
+                          Payment Information
+                        </h3>
+                      </Header>
+                    </Heading>
+                  </div>
+                </GridColumn>
+              </GridColumn>
+            </div>
+          </GridRow>
+        </GridRow>
+        <GridRow
+          horizontalAlignContent="left"
+        >
+          <GridRow
+            textAlign="left"
+          >
+            <div
+              className="left aligned row"
+            >
+              <GridColumn
+                verticalAlignContent="top"
+                width={6}
+              >
+                <GridColumn
+                  verticalAlign="top"
+                  width={6}
+                >
+                  <div
+                    className="top aligned six wide column"
+                  >
+                    <Heading
+                      isColorInverted={false}
+                      size="small"
+                      textAlign={null}
+                    >
+                      <Header
+                        as="h4"
+                        inverted={false}
+                        textAlign={null}
+                      >
+                        <h4
+                          className="ui header"
+                        >
+                          Cleaning Charge
+                        </h4>
+                      </Header>
+                    </Heading>
+                    <Statistic
+                      horizontal={true}
+                      size="mini"
+                      text={true}
+                      value="25$ (USD)"
+                    >
+                      <div
+                        className="ui mini horizontal statistic"
+                      >
+                        <StatisticValue
+                          content="25$ (USD)"
+                          key="25$ (USD)"
+                          text={true}
+                        >
+                          <div
+                            className="text value"
+                          >
+                            25$ (USD)
+                          </div>
+                        </StatisticValue>
+                      </div>
+                    </Statistic>
+                  </div>
+                </GridColumn>
+              </GridColumn>
+            </div>
+          </GridRow>
+        </GridRow>
+      </div>
+    </Grid>
+  </Grid>
+</PaymentInformation>
+`;
+
+exports[`<PaymentInformation /> if \`props.damageDepositText\` is passed should have the right structure 1`] = `
+<PaymentInformation
+  cancellationPolicyHeadingText="Cancellation Policy"
+  cancellationPolicyText={null}
+  cleaningCharge={null}
+  cleaningChargeHeadingText="Cleaning Charge"
+  damageDepositHeadingText="Damage Deposit"
+  damageDepositText="A refundable damage deposit of 200.00 € (EUR) is due."
+  extraNotesText={null}
+  headingText="Payment Information"
+  modalTriggerText="View more"
+  notesHeadingText="Notes"
+  notesText={null}
+  paymentScheduleHeadingText="Payment Schedule"
+  paymentScheduleText={null}
+  taxesDescriptionText={null}
+  taxesHeadingText="Taxes"
+  taxesText={null}
+>
+  <Grid
+    areColumnsCentered={false}
+    stackable={true}
+  >
+    <Grid
+      centered={false}
+      stackable={true}
+    >
+      <div
+        className="ui stackable grid"
+      >
+        <GridRow
+          horizontalAlignContent="left"
+        >
+          <GridRow
+            textAlign="left"
+          >
+            <div
+              className="left aligned row"
+            >
+              <GridColumn
+                verticalAlignContent="top"
+                width={12}
+              >
+                <GridColumn
+                  verticalAlign="top"
+                  width={12}
+                >
+                  <div
+                    className="top aligned twelve wide column"
+                  >
+                    <Heading
+                      isColorInverted={false}
+                      size="medium"
+                      textAlign={null}
+                    >
+                      <Header
+                        as="h3"
+                        inverted={false}
+                        textAlign={null}
+                      >
+                        <h3
+                          className="ui header"
+                        >
+                          Payment Information
+                        </h3>
+                      </Header>
+                    </Heading>
+                  </div>
+                </GridColumn>
+              </GridColumn>
+            </div>
+          </GridRow>
+        </GridRow>
+        <GridRow
+          horizontalAlignContent="left"
+        >
+          <GridRow
+            textAlign="left"
+          >
+            <div
+              className="left aligned row"
+            >
+              <GridColumn
+                verticalAlignContent="top"
+                width={12}
+              >
+                <GridColumn
+                  verticalAlign="top"
+                  width={12}
+                >
+                  <div
+                    className="top aligned twelve wide column"
+                  >
+                    <Heading
+                      isColorInverted={false}
+                      size="small"
+                      textAlign={null}
+                    >
+                      <Header
+                        as="h4"
+                        inverted={false}
+                        textAlign={null}
+                      >
+                        <h4
+                          className="ui header"
+                        >
+                          Damage Deposit
+                        </h4>
+                      </Header>
+                    </Heading>
+                    <Paragraph
+                      size="medium"
+                      weight={null}
+                    >
+                      <p
+                        className=""
+                      >
+                        A refundable damage deposit of 200.00 € (EUR) is due.
+                      </p>
+                    </Paragraph>
+                  </div>
+                </GridColumn>
+              </GridColumn>
+            </div>
+          </GridRow>
+        </GridRow>
+      </div>
+    </Grid>
+  </Grid>
+</PaymentInformation>
+`;
+
+exports[`<PaymentInformation /> if \`props.extraNotesText\` is passed should have the right structure 1`] = `
+<PaymentInformation
+  cancellationPolicyHeadingText="Cancellation Policy"
+  cancellationPolicyText={null}
+  cleaningCharge={null}
+  cleaningChargeHeadingText="Cleaning Charge"
+  damageDepositHeadingText="Damage Deposit"
+  damageDepositText={null}
+  extraNotesText="
+  Livingstone is a modern website template with clean and straight lines. Its special feature is a wide horizontal header photo slideshow in which logo and header navigation nicely blend in.
+
+  Maecenas et efficitur diam. Etiam non ante urna. Donec imperdiet cursus lectus, luctus vestibulum urna aliquet vel. Donec non vehicula est. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos.
+
+  Livingstone is a modern website template with clean and straight lines. Its special feature is a wide horizontal header photo slideshow in which logo and header navigation nicely blend in.
+
+  Maecenas et efficitur diam. Etiam non ante urna. Donec imperdiet cursus lectus, luctus vestibulum urna aliquet vel. Donec non vehicula est. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos.
+"
+  headingText="Payment Information"
+  modalTriggerText="View more"
+  notesHeadingText="Notes"
+  notesText={null}
+  paymentScheduleHeadingText="Payment Schedule"
+  paymentScheduleText={null}
+  taxesDescriptionText={null}
+  taxesHeadingText="Taxes"
+  taxesText={null}
+>
+  <Grid
+    areColumnsCentered={false}
+    stackable={true}
+  >
+    <Grid
+      centered={false}
+      stackable={true}
+    >
+      <div
+        className="ui stackable grid"
+      >
+        <GridRow
+          horizontalAlignContent="left"
+        >
+          <GridRow
+            textAlign="left"
+          >
+            <div
+              className="left aligned row"
+            >
+              <GridColumn
+                verticalAlignContent="top"
+                width={12}
+              >
+                <GridColumn
+                  verticalAlign="top"
+                  width={12}
+                >
+                  <div
+                    className="top aligned twelve wide column"
+                  >
+                    <Heading
+                      isColorInverted={false}
+                      size="medium"
+                      textAlign={null}
+                    >
+                      <Header
+                        as="h3"
+                        inverted={false}
+                        textAlign={null}
+                      >
+                        <h3
+                          className="ui header"
+                        >
+                          Payment Information
+                        </h3>
+                      </Header>
+                    </Heading>
+                  </div>
+                </GridColumn>
+              </GridColumn>
+            </div>
+          </GridRow>
+        </GridRow>
+        <GridRow
+          horizontalAlignContent="left"
+        >
+          <GridRow
+            textAlign="left"
+          >
+            <div
+              className="left aligned row"
+            >
+              <GridColumn
+                verticalAlignContent="top"
+                width={12}
+              >
+                <GridColumn
+                  verticalAlign="top"
+                  width={12}
+                >
+                  <div
+                    className="top aligned twelve wide column"
+                  >
+                    <Modal
+                      isFullscreen={false}
+                      size="tiny"
+                      trigger={
+                        <Link
+                          href={null}
+                          isPositionedRight={false}
+                          onClick={[Function]}
+                          willOpenInNewTab={false}
+                        >
+                          View more
+                        </Link>
+                      }
+                    >
+                      <Modal
+                        closeIcon={
+                          <Icon
+                            color={null}
+                            hasBorder={false}
+                            isCircular={false}
+                            isColorInverted={false}
+                            isDisabled={false}
+                            isLabelLeft={false}
+                            labelText={null}
+                            labelWeight={null}
+                            name="close"
+                            path={null}
+                            size={null}
+                          />
+                        }
+                        closeOnDimmerClick={true}
+                        closeOnDocumentClick={false}
+                        content={
+                          Array [
+                            <Paragraph
+                              size="medium"
+                              weight={null}
+                            >
+                              Livingstone is a modern website template with clean and straight lines. Its special feature is a wide horizontal header photo slideshow in which logo and header navigation nicely blend in.
+                            </Paragraph>,
+                            <Paragraph
+                              size="medium"
+                              weight={null}
+                            >
+                              Maecenas et efficitur diam. Etiam non ante urna. Donec imperdiet cursus lectus, luctus vestibulum urna aliquet vel. Donec non vehicula est. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos.
+                            </Paragraph>,
+                            <Paragraph
+                              size="medium"
+                              weight={null}
+                            >
+                              Livingstone is a modern website template with clean and straight lines. Its special feature is a wide horizontal header photo slideshow in which logo and header navigation nicely blend in.
+                            </Paragraph>,
+                            <Paragraph
+                              size="medium"
+                              weight={null}
+                            >
+                              Maecenas et efficitur diam. Etiam non ante urna. Donec imperdiet cursus lectus, luctus vestibulum urna aliquet vel. Donec non vehicula est. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos.
+                            </Paragraph>,
+                          ]
+                        }
+                        dimmer="inverted"
+                        eventPool="Modal"
+                        size="tiny"
+                        trigger={
+                          <Link
+                            href={null}
+                            isPositionedRight={false}
+                            onClick={[Function]}
+                            willOpenInNewTab={false}
+                          >
+                            View more
+                          </Link>
+                        }
+                      >
+                        <Portal
+                          className="ui inverted page modals dimmer transition visible active"
+                          closeOnDocumentClick={false}
+                          closeOnEscape={true}
+                          closeOnRootNodeClick={true}
+                          eventPool="Modal"
+                          mountNode={<body />}
+                          onClose={[Function]}
+                          onMount={[Function]}
+                          onOpen={[Function]}
+                          onUnmount={[Function]}
+                          openOnTriggerClick={true}
+                          trigger={
+                            <Link
+                              href={null}
+                              isPositionedRight={false}
+                              onClick={[Function]}
+                              willOpenInNewTab={false}
+                            >
+                              View more
+                            </Link>
+                          }
+                        >
+                          <Ref
+                            innerRef={[Function]}
+                          >
+                            <Link
+                              href={null}
+                              isPositionedRight={false}
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                              willOpenInNewTab={false}
+                            >
+                              <Button
+                                as={null}
+                                basic={true}
+                                floated="left"
+                                href={null}
+                                onClick={[Function]}
+                                target="_self"
+                              >
+                                <button
+                                  className="ui basic left floated button"
+                                  href={null}
+                                  onClick={[Function]}
+                                  role="button"
+                                  target="_self"
+                                >
+                                  View more
+                                </button>
+                              </Button>
+                            </Link>
+                          </Ref>
+                        </Portal>
+                      </Modal>
+                    </Modal>
+                  </div>
+                </GridColumn>
+              </GridColumn>
+            </div>
+          </GridRow>
+        </GridRow>
+      </div>
+    </Grid>
+  </Grid>
+</PaymentInformation>
+`;
+
+exports[`<PaymentInformation /> if \`props.notesText\` is passed should have the right structure 1`] = `
+<PaymentInformation
+  cancellationPolicyHeadingText="Cancellation Policy"
+  cancellationPolicyText={null}
+  cleaningCharge={null}
+  cleaningChargeHeadingText="Cleaning Charge"
+  damageDepositHeadingText="Damage Deposit"
+  damageDepositText={null}
+  extraNotesText={null}
+  headingText="Payment Information"
+  modalTriggerText="View more"
+  notesHeadingText="Notes"
+  notesText="
+  Livingstone is a modern website template with clean and straight lines. Its special feature is a wide horizontal header photo slideshow in which logo and header navigation nicely blend in.
+
+  Maecenas et efficitur diam. Etiam non ante urna. Donec imperdiet cursus lectus, luctus vestibulum urna aliquet vel. Donec non vehicula est. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos.
+"
+  paymentScheduleHeadingText="Payment Schedule"
+  paymentScheduleText={null}
+  taxesDescriptionText={null}
+  taxesHeadingText="Taxes"
+  taxesText={null}
+>
+  <Grid
+    areColumnsCentered={false}
+    stackable={true}
+  >
+    <Grid
+      centered={false}
+      stackable={true}
+    >
+      <div
+        className="ui stackable grid"
+      >
+        <GridRow
+          horizontalAlignContent="left"
+        >
+          <GridRow
+            textAlign="left"
+          >
+            <div
+              className="left aligned row"
+            >
+              <GridColumn
+                verticalAlignContent="top"
+                width={12}
+              >
+                <GridColumn
+                  verticalAlign="top"
+                  width={12}
+                >
+                  <div
+                    className="top aligned twelve wide column"
+                  >
+                    <Heading
+                      isColorInverted={false}
+                      size="medium"
+                      textAlign={null}
+                    >
+                      <Header
+                        as="h3"
+                        inverted={false}
+                        textAlign={null}
+                      >
+                        <h3
+                          className="ui header"
+                        >
+                          Payment Information
+                        </h3>
+                      </Header>
+                    </Heading>
+                  </div>
+                </GridColumn>
+              </GridColumn>
+            </div>
+          </GridRow>
+        </GridRow>
+        <GridRow
+          horizontalAlignContent="left"
+        >
+          <GridRow
+            textAlign="left"
+          >
+            <div
+              className="left aligned row"
+            >
+              <GridColumn
+                verticalAlignContent="top"
+                width={12}
+              >
+                <GridColumn
+                  verticalAlign="top"
+                  width={12}
+                >
+                  <div
+                    className="top aligned twelve wide column"
+                  >
+                    <Heading
+                      isColorInverted={false}
+                      size="small"
+                      textAlign={null}
+                    >
+                      <Header
+                        as="h4"
+                        inverted={false}
+                        textAlign={null}
+                      >
+                        <h4
+                          className="ui header"
+                        >
+                          Notes
+                        </h4>
+                      </Header>
+                    </Heading>
+                    <Paragraph
+                      size="medium"
+                      weight={null}
+                    >
+                      <p
+                        className=""
+                      >
+                        
+  Livingstone is a modern website template with clean and straight lines. Its special feature is a wide horizontal header photo slideshow in which logo and header navigation nicely blend in.
+
+  Maecenas et efficitur diam. Etiam non ante urna. Donec imperdiet cursus lectus, luctus vestibulum urna aliquet vel. Donec non vehicula est. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos.
+
+                      </p>
+                    </Paragraph>
+                  </div>
+                </GridColumn>
+              </GridColumn>
+            </div>
+          </GridRow>
+        </GridRow>
+      </div>
+    </Grid>
+  </Grid>
+</PaymentInformation>
+`;
+
+exports[`<PaymentInformation /> if \`props.paymentScheduleText\` is passed should have the right structure 1`] = `
+<PaymentInformation
+  cancellationPolicyHeadingText="Cancellation Policy"
+  cancellationPolicyText={null}
+  cleaningCharge={null}
+  cleaningChargeHeadingText="Cleaning Charge"
+  damageDepositHeadingText="Damage Deposit"
+  damageDepositText={null}
+  extraNotesText={null}
+  headingText="Payment Information"
+  modalTriggerText="View more"
+  notesHeadingText="Notes"
+  notesText={null}
+  paymentScheduleHeadingText="Payment Schedule"
+  paymentScheduleText="50% due at time of booking. Remaining balance: Due later."
+  taxesDescriptionText={null}
+  taxesHeadingText="Taxes"
+  taxesText={null}
+>
+  <Grid
+    areColumnsCentered={false}
+    stackable={true}
+  >
+    <Grid
+      centered={false}
+      stackable={true}
+    >
+      <div
+        className="ui stackable grid"
+      >
+        <GridRow
+          horizontalAlignContent="left"
+        >
+          <GridRow
+            textAlign="left"
+          >
+            <div
+              className="left aligned row"
+            >
+              <GridColumn
+                verticalAlignContent="top"
+                width={12}
+              >
+                <GridColumn
+                  verticalAlign="top"
+                  width={12}
+                >
+                  <div
+                    className="top aligned twelve wide column"
+                  >
+                    <Heading
+                      isColorInverted={false}
+                      size="medium"
+                      textAlign={null}
+                    >
+                      <Header
+                        as="h3"
+                        inverted={false}
+                        textAlign={null}
+                      >
+                        <h3
+                          className="ui header"
+                        >
+                          Payment Information
+                        </h3>
+                      </Header>
+                    </Heading>
+                  </div>
+                </GridColumn>
+              </GridColumn>
+            </div>
+          </GridRow>
+        </GridRow>
+        <GridRow
+          horizontalAlignContent="left"
+        >
+          <GridRow
+            textAlign="left"
+          >
+            <div
+              className="left aligned row"
+            >
+              <GridColumn
+                verticalAlignContent="top"
+                width={6}
+              >
+                <GridColumn
+                  verticalAlign="top"
+                  width={6}
+                >
+                  <div
+                    className="top aligned six wide column"
+                  >
+                    <Heading
+                      isColorInverted={false}
+                      size="small"
+                      textAlign={null}
+                    >
+                      <Header
+                        as="h4"
+                        inverted={false}
+                        textAlign={null}
+                      >
+                        <h4
+                          className="ui header"
+                        >
+                          Payment Schedule
+                        </h4>
+                      </Header>
+                    </Heading>
+                    <Paragraph
+                      size="medium"
+                      weight={null}
+                    >
+                      <p
+                        className=""
+                      >
+                        50% due at time of booking. Remaining balance: Due later.
+                      </p>
+                    </Paragraph>
+                  </div>
+                </GridColumn>
+              </GridColumn>
+            </div>
+          </GridRow>
+        </GridRow>
+      </div>
+    </Grid>
+  </Grid>
+</PaymentInformation>
+`;
+
+exports[`<PaymentInformation /> if \`props.taxesText\` and \`props.taxesDescriptionText\` are passed should have the right structure 1`] = `
+<PaymentInformation
+  cancellationPolicyHeadingText="Cancellation Policy"
+  cancellationPolicyText={null}
+  cleaningCharge={null}
+  cleaningChargeHeadingText="Cleaning Charge"
+  damageDepositHeadingText="Damage Deposit"
+  damageDepositText={null}
+  extraNotesText={null}
+  headingText="Payment Information"
+  modalTriggerText="View more"
+  notesHeadingText="Notes"
+  notesText={null}
+  paymentScheduleHeadingText="Payment Schedule"
+  paymentScheduleText={null}
+  taxesDescriptionText="of total booking value"
+  taxesHeadingText="Taxes"
+  taxesText="1%"
+>
+  <Grid
+    areColumnsCentered={false}
+    stackable={true}
+  >
+    <Grid
+      centered={false}
+      stackable={true}
+    >
+      <div
+        className="ui stackable grid"
+      >
+        <GridRow
+          horizontalAlignContent="left"
+        >
+          <GridRow
+            textAlign="left"
+          >
+            <div
+              className="left aligned row"
+            >
+              <GridColumn
+                verticalAlignContent="top"
+                width={12}
+              >
+                <GridColumn
+                  verticalAlign="top"
+                  width={12}
+                >
+                  <div
+                    className="top aligned twelve wide column"
+                  >
+                    <Heading
+                      isColorInverted={false}
+                      size="medium"
+                      textAlign={null}
+                    >
+                      <Header
+                        as="h3"
+                        inverted={false}
+                        textAlign={null}
+                      >
+                        <h3
+                          className="ui header"
+                        >
+                          Payment Information
+                        </h3>
+                      </Header>
+                    </Heading>
+                  </div>
+                </GridColumn>
+              </GridColumn>
+            </div>
+          </GridRow>
+        </GridRow>
+        <GridRow
+          horizontalAlignContent="left"
+        >
+          <GridRow
+            textAlign="left"
+          >
+            <div
+              className="left aligned row"
+            >
+              <GridColumn
+                verticalAlignContent="top"
+                width={6}
+              >
+                <GridColumn
+                  verticalAlign="top"
+                  width={6}
+                >
+                  <div
+                    className="top aligned six wide column"
+                  >
+                    <Heading
+                      isColorInverted={false}
+                      size="small"
+                      textAlign={null}
+                    >
+                      <Header
+                        as="h4"
+                        inverted={false}
+                        textAlign={null}
+                      >
+                        <h4
+                          className="ui header"
+                        >
+                          Taxes
+                        </h4>
+                      </Header>
+                    </Heading>
+                    <Statistic
+                      horizontal={true}
+                      label="of total booking value"
+                      size="tiny"
+                      text={true}
+                      value="1%"
+                    >
+                      <div
+                        className="ui tiny horizontal statistic"
+                      >
+                        <StatisticValue
+                          content="1%"
+                          key="1%"
+                          text={true}
+                        >
+                          <div
+                            className="text value"
+                          >
+                            1%
+                          </div>
+                        </StatisticValue>
+                        <StatisticLabel
+                          content="of total booking value"
+                          key="of total booking value"
+                        >
+                          <div
+                            className="label"
+                          >
+                            of total booking value
+                          </div>
+                        </StatisticLabel>
+                      </div>
+                    </Statistic>
+                  </div>
+                </GridColumn>
+              </GridColumn>
+            </div>
+          </GridRow>
+        </GridRow>
+      </div>
+    </Grid>
+  </Grid>
+</PaymentInformation>
+`;
+
+exports[`<PaymentInformation /> should have the right structure 1`] = `
+<PaymentInformation
+  cancellationPolicyHeadingText="Cancellation Policy"
+  cancellationPolicyText={null}
+  cleaningCharge={null}
+  cleaningChargeHeadingText="Cleaning Charge"
+  damageDepositHeadingText="Damage Deposit"
+  damageDepositText={null}
+  extraNotesText={null}
+  headingText="Payment Information"
+  modalTriggerText="View more"
+  notesHeadingText="Notes"
+  notesText={null}
+  paymentScheduleHeadingText="Payment Schedule"
+  paymentScheduleText={null}
+  taxesDescriptionText={null}
+  taxesHeadingText="Taxes"
+  taxesText={null}
+>
+  <Grid
+    areColumnsCentered={false}
+    stackable={true}
+  >
+    <Grid
+      centered={false}
+      stackable={true}
+    >
+      <div
+        className="ui stackable grid"
+      >
+        <GridRow
+          horizontalAlignContent="left"
+        >
+          <GridRow
+            textAlign="left"
+          >
+            <div
+              className="left aligned row"
+            >
+              <GridColumn
+                verticalAlignContent="top"
+                width={12}
+              >
+                <GridColumn
+                  verticalAlign="top"
+                  width={12}
+                >
+                  <div
+                    className="top aligned twelve wide column"
+                  >
+                    <Heading
+                      isColorInverted={false}
+                      size="medium"
+                      textAlign={null}
+                    >
+                      <Header
+                        as="h3"
+                        inverted={false}
+                        textAlign={null}
+                      >
+                        <h3
+                          className="ui header"
+                        >
+                          Payment Information
+                        </h3>
+                      </Header>
+                    </Heading>
+                  </div>
+                </GridColumn>
+              </GridColumn>
+            </div>
+          </GridRow>
+        </GridRow>
+      </div>
+    </Grid>
+  </Grid>
+</PaymentInformation>
+`;

--- a/src/components/property-page-widgets/PaymentInformation/component.js
+++ b/src/components/property-page-widgets/PaymentInformation/component.js
@@ -50,40 +50,44 @@ export const Component = ({
         <Heading>{headingText}</Heading>
       </GridColumn>
     </GridRow>
-    <GridRow>
-      {!!paymentScheduleText && (
-        <GridColumn width={6}>
-          <Heading size="small">{paymentScheduleHeadingText}</Heading>
-          <Paragraph size="medium">{paymentScheduleText}</Paragraph>
-        </GridColumn>
-      )}
-      {!!cancellationPolicyText && (
-        <GridColumn width={6}>
-          <Heading size="small">{cancellationPolicyHeadingText}</Heading>
-          <Paragraph size="medium">{cancellationPolicyText}</Paragraph>
-        </GridColumn>
-      )}
-    </GridRow>
-    <GridRow>
-      {!!cleaningCharge && (
-        <GridColumn width={6}>
-          <Heading size="small">{cleaningChargeHeadingText}</Heading>
-          <Statistic horizontal size="mini" text value={cleaningCharge} />
-        </GridColumn>
-      )}
-      {!!taxesText && (
-        <GridColumn width={6}>
-          <Heading size="small">{taxesHeadingText}</Heading>
-          <Statistic
-            horizontal
-            label={taxesDescriptionText}
-            size="tiny"
-            text
-            value={taxesText}
-          />
-        </GridColumn>
-      )}
-    </GridRow>
+    {(!!paymentScheduleText || !!cancellationPolicyText) && (
+      <GridRow>
+        {!!paymentScheduleText && (
+          <GridColumn width={6}>
+            <Heading size="small">{paymentScheduleHeadingText}</Heading>
+            <Paragraph size="medium">{paymentScheduleText}</Paragraph>
+          </GridColumn>
+        )}
+        {!!cancellationPolicyText && (
+          <GridColumn width={6}>
+            <Heading size="small">{cancellationPolicyHeadingText}</Heading>
+            <Paragraph size="medium">{cancellationPolicyText}</Paragraph>
+          </GridColumn>
+        )}
+      </GridRow>
+    )}
+    {(!!cleaningCharge || !!taxesText) && (
+      <GridRow>
+        {!!cleaningCharge && (
+          <GridColumn width={6}>
+            <Heading size="small">{cleaningChargeHeadingText}</Heading>
+            <Statistic horizontal size="mini" text value={cleaningCharge} />
+          </GridColumn>
+        )}
+        {!!taxesText && (
+          <GridColumn width={6}>
+            <Heading size="small">{taxesHeadingText}</Heading>
+            <Statistic
+              horizontal
+              label={taxesDescriptionText}
+              size="tiny"
+              text
+              value={taxesText}
+            />
+          </GridColumn>
+        )}
+      </GridRow>
+    )}
     {!!damageDepositText && (
       <GridRow>
         <GridColumn width={12}>

--- a/src/components/property-page-widgets/PaymentInformation/component.spec.js
+++ b/src/components/property-page-widgets/PaymentInformation/component.spec.js
@@ -1,31 +1,6 @@
 import React from 'react';
-import { shallow } from 'enzyme';
-import { Statistic } from 'semantic-ui-react';
-import {
-  expectComponentToBe,
-  expectComponentToHaveChildren,
-  expectComponentToHaveDisplayName,
-  expectComponentToHaveProps,
-} from '@lodgify/enzyme-jest-expect-helpers';
-
-import {
-  PAYMENT_SCHEDULE,
-  CANCELLATION_POLICY,
-  CLEANING_CHARGE,
-  TAXES,
-  DAMAGE_DEPOSIT,
-  NOTES,
-  VIEW_MORE,
-} from 'utils/default-strings';
-import { getArrayOfLengthOfItem } from 'utils/get-array-of-length-of-item';
-import { getParagraphsFromStrings } from 'utils/get-paragraphs-from-strings';
-import { Grid } from 'layout/Grid';
-import { GridColumn } from 'layout/GridColumn';
-import { GridRow } from 'layout/GridRow';
-import { Paragraph } from 'typography/Paragraph';
-import { Heading } from 'typography/Heading';
-import { Link } from 'elements/Link';
-import { Modal } from 'elements/Modal';
+import { mount } from 'enzyme';
+import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
 
 import { Component as PaymentInformation } from './component';
 
@@ -53,579 +28,77 @@ const extraNotesText = `
 const props = {};
 
 const getPaymentInformation = extraProps =>
-  shallow(<PaymentInformation {...props} {...extraProps} />);
+  mount(<PaymentInformation {...props} {...extraProps} />);
 
 describe('<PaymentInformation />', () => {
-  it('should have `Grid` component as a wrapper', () => {
+  it('should have the right structure', () => {
     const wrapper = getPaymentInformation();
 
-    expectComponentToBe(wrapper, Grid);
-  });
-
-  describe('the first `Grid` component', () => {
-    it('should have the right props', () => {
-      const wrapper = getPaymentInformation().find(Grid);
-
-      expectComponentToHaveProps(wrapper, {
-        stackable: true,
-      });
-    });
-
-    it('should render the right children', () => {
-      const wrapper = getPaymentInformation().find(Grid);
-
-      expectComponentToHaveChildren(
-        wrapper,
-        ...getArrayOfLengthOfItem(3, GridRow)
-      );
-    });
-  });
-
-  describe('the first `GridRow` component', () => {
-    describe('the first `GridColumn` component', () => {
-      const getFirstGridColumn = () =>
-        getPaymentInformation()
-          .find(GridRow)
-          .first()
-          .find(GridColumn)
-          .first();
-
-      it('should have the right props', () => {
-        const wrapper = getFirstGridColumn();
-
-        expectComponentToHaveProps(wrapper, {
-          width: 12,
-        });
-      });
-
-      it('should render the right children', () => {
-        const wrapper = getFirstGridColumn();
-
-        expectComponentToHaveChildren(
-          wrapper,
-          ...getArrayOfLengthOfItem(1, Heading)
-        );
-      });
-    });
+    expect(wrapper).toMatchSnapshot();
   });
 
   describe('if `props.paymentScheduleText` is passed', () => {
-    describe('the second `GridRow` component', () => {
-      it('should render another `GridColumn`', () => {
-        const wrapper = getPaymentInformation({ paymentScheduleText })
-          .find(GridRow)
-          .at(1);
+    it('should have the right structure', () => {
+      const wrapper = getPaymentInformation({ paymentScheduleText });
 
-        expectComponentToHaveChildren(wrapper, GridColumn);
-      });
-    });
-
-    describe('the conditional `GridColumn` component', () => {
-      const getConditionalGridColumn = () =>
-        getPaymentInformation({ paymentScheduleText })
-          .find(GridRow)
-          .at(1)
-          .find(GridColumn)
-          .first();
-
-      it('should have the right props', () => {
-        const wrapper = getConditionalGridColumn();
-
-        expectComponentToHaveProps(wrapper, {
-          width: 6,
-        });
-      });
-
-      it('should render the right children', () => {
-        const wrapper = getConditionalGridColumn();
-
-        expectComponentToHaveChildren(wrapper, Heading, Paragraph);
-      });
-
-      describe('the `Heading` component', () => {
-        const getHeader = () =>
-          getConditionalGridColumn()
-            .find(Heading)
-            .first();
-
-        it('should have the right props', () => {
-          const wrapper = getHeader();
-
-          expectComponentToHaveProps(wrapper, {
-            size: 'small',
-          });
-        });
-
-        it('should render the right children', () => {
-          const wrapper = getHeader();
-
-          expectComponentToHaveChildren(wrapper, PAYMENT_SCHEDULE);
-        });
-      });
-
-      describe('the `Paragraph` component', () => {
-        const getParagraph = () =>
-          getConditionalGridColumn()
-            .find(Paragraph)
-            .first();
-
-        it('should have the right props', () => {
-          const wrapper = getParagraph();
-
-          expectComponentToHaveProps(wrapper, {
-            size: 'medium',
-          });
-        });
-
-        it('should render the right children', () => {
-          const wrapper = getParagraph();
-
-          expectComponentToHaveChildren(wrapper, paymentScheduleText);
-        });
-      });
+      expect(wrapper).toMatchSnapshot();
     });
   });
 
   describe('if `props.cancellationPolicyText` is passed', () => {
-    describe('the second `GridRow` component', () => {
-      it('should render another `GridColumn`', () => {
-        const wrapper = getPaymentInformation({ cancellationPolicyText })
-          .find(GridRow)
-          .at(1);
+    it('should have the right structure', () => {
+      const wrapper = getPaymentInformation({ cancellationPolicyText });
 
-        expectComponentToHaveChildren(wrapper, GridColumn);
-      });
-    });
-
-    describe('the conditional `GridColumn` component', () => {
-      const getConditionalGridColumn = () =>
-        getPaymentInformation({ cancellationPolicyText })
-          .find(GridRow)
-          .at(1)
-          .find(GridColumn)
-          .first();
-
-      it('should have the right props', () => {
-        const wrapper = getConditionalGridColumn();
-
-        expectComponentToHaveProps(wrapper, {
-          width: 6,
-        });
-      });
-
-      it('should render the right children', () => {
-        const wrapper = getConditionalGridColumn();
-
-        expectComponentToHaveChildren(wrapper, Heading, Paragraph);
-      });
-
-      describe('the `Heading` component', () => {
-        const getHeader = () =>
-          getConditionalGridColumn()
-            .find(Heading)
-            .first();
-
-        it('should have the right props', () => {
-          const wrapper = getHeader();
-
-          expectComponentToHaveProps(wrapper, {
-            size: 'small',
-          });
-        });
-
-        it('should render the right children', () => {
-          const wrapper = getHeader();
-
-          expectComponentToHaveChildren(wrapper, CANCELLATION_POLICY);
-        });
-      });
-
-      describe('the `Paragraph` component', () => {
-        const getParagraph = () =>
-          getConditionalGridColumn()
-            .find(Paragraph)
-            .first();
-
-        it('should have the right props', () => {
-          const wrapper = getParagraph();
-
-          expectComponentToHaveProps(wrapper, {
-            size: 'medium',
-          });
-        });
-
-        it('should render the right children', () => {
-          const wrapper = getParagraph();
-
-          expectComponentToHaveChildren(wrapper, cancellationPolicyText);
-        });
-      });
+      expect(wrapper).toMatchSnapshot();
     });
   });
 
   describe('if `props.cleaningCharge` is passed', () => {
-    describe('the third `GridRow` component', () => {
-      it('should render another `GridColumn`', () => {
-        const wrapper = getPaymentInformation({ cleaningCharge })
-          .find(GridRow)
-          .at(2);
+    it('should have the right structure', () => {
+      const wrapper = getPaymentInformation({ cleaningCharge });
 
-        expectComponentToHaveChildren(wrapper, GridColumn);
-      });
-    });
-
-    describe('the conditional `GridColumn` component', () => {
-      const getConditionalGridColumn = () =>
-        getPaymentInformation({ cleaningCharge })
-          .find(GridRow)
-          .at(2)
-          .find(GridColumn)
-          .first();
-
-      it('should have the right props', () => {
-        const wrapper = getConditionalGridColumn();
-
-        expectComponentToHaveProps(wrapper, {
-          width: 6,
-        });
-      });
-
-      it('should render the right children', () => {
-        const wrapper = getConditionalGridColumn();
-
-        expectComponentToHaveChildren(wrapper, Heading, Statistic);
-      });
-
-      describe('the `Heading` component', () => {
-        const getHeader = () =>
-          getConditionalGridColumn()
-            .find(Heading)
-            .first();
-
-        it('should have the right props', () => {
-          const wrapper = getHeader();
-
-          expectComponentToHaveProps(wrapper, {
-            size: 'small',
-          });
-        });
-
-        it('should render the right children', () => {
-          const wrapper = getHeader();
-
-          expectComponentToHaveChildren(wrapper, CLEANING_CHARGE);
-        });
-      });
-
-      describe('the `Statistic` component', () => {
-        const getStatistic = () =>
-          getConditionalGridColumn()
-            .find(Statistic)
-            .first();
-
-        it('should have the right props', () => {
-          const wrapper = getStatistic();
-
-          expectComponentToHaveProps(wrapper, {
-            horizontal: true,
-            size: 'mini',
-            text: true,
-            value: cleaningCharge,
-          });
-        });
-      });
+      expect(wrapper).toMatchSnapshot();
     });
   });
 
   describe('if `props.taxesText` and `props.taxesDescriptionText` are passed', () => {
-    describe('the third `GridRow` component', () => {
-      it('should render another `GridColumn`', () => {
-        const wrapper = getPaymentInformation({
-          taxesText,
-          taxesDescriptionText,
-        })
-          .find(GridRow)
-          .at(2);
-
-        expectComponentToHaveChildren(wrapper, GridColumn);
-      });
-    });
-
-    describe('the conditional `GridColumn` component', () => {
-      const getConditionalGridColumn = () =>
-        getPaymentInformation({ taxesText, taxesDescriptionText })
-          .find(GridRow)
-          .at(2)
-          .find(GridColumn)
-          .first();
-
-      it('should have the right props', () => {
-        const wrapper = getConditionalGridColumn();
-
-        expectComponentToHaveProps(wrapper, {
-          width: 6,
-        });
+    it('should have the right structure', () => {
+      const wrapper = getPaymentInformation({
+        taxesDescriptionText,
+        taxesText,
       });
 
-      it('should render the right children', () => {
-        const wrapper = getConditionalGridColumn();
-
-        expectComponentToHaveChildren(wrapper, Heading, Statistic);
-      });
-
-      describe('the `Heading` component', () => {
-        const getHeader = () =>
-          getConditionalGridColumn()
-            .find(Heading)
-            .first();
-
-        it('should have the right props', () => {
-          const wrapper = getHeader();
-
-          expectComponentToHaveProps(wrapper, {
-            size: 'small',
-          });
-        });
-
-        it('should render the right children', () => {
-          const wrapper = getHeader();
-
-          expectComponentToHaveChildren(wrapper, TAXES);
-        });
-      });
-
-      describe('the `Statistic` component', () => {
-        const getStatistic = () =>
-          getConditionalGridColumn()
-            .find(Statistic)
-            .first();
-
-        it('should have the right props', () => {
-          const wrapper = getStatistic();
-
-          expectComponentToHaveProps(wrapper, {
-            horizontal: true,
-            text: true,
-            size: 'tiny',
-            label: taxesDescriptionText,
-            value: taxesText,
-          });
-        });
-      });
+      expect(wrapper).toMatchSnapshot();
     });
   });
 
   describe('if `props.damageDepositText` is passed', () => {
-    it('should render another `GridRow`', () => {
-      const wrapper = getPaymentInformation({ damageDepositText })
-        .find(GridRow)
-        .at(3);
-
-      expectComponentToHaveChildren(wrapper, GridColumn);
-    });
-
-    describe('the conditional `GridRow` component', () => {
-      const getConditionalGridColumn = () =>
-        getPaymentInformation({ damageDepositText })
-          .find(GridRow)
-          .at(3)
-          .find(GridColumn)
-          .first();
-
-      describe('the first `GridColumn` component', () => {
-        it('should have the right props', () => {
-          const wrapper = getConditionalGridColumn();
-
-          expectComponentToHaveProps(wrapper, {
-            width: 12,
-          });
-        });
-
-        it('should render the right children', () => {
-          const wrapper = getConditionalGridColumn();
-
-          expectComponentToHaveChildren(wrapper, Heading, Paragraph);
-        });
-
-        describe('the `Heading` component', () => {
-          const getHeader = () =>
-            getConditionalGridColumn()
-              .find(Heading)
-              .first();
-
-          it('should have the right props', () => {
-            const wrapper = getHeader();
-
-            expectComponentToHaveProps(wrapper, {
-              size: 'small',
-            });
-          });
-
-          it('should render the right children', () => {
-            const wrapper = getHeader();
-
-            expectComponentToHaveChildren(wrapper, DAMAGE_DEPOSIT);
-          });
-        });
-
-        describe('the `Paragraph` component', () => {
-          const getParagraph = () =>
-            getConditionalGridColumn()
-              .find(Paragraph)
-              .first();
-
-          it('should have the right props', () => {
-            const wrapper = getParagraph();
-
-            expectComponentToHaveProps(wrapper, {
-              size: 'medium',
-            });
-          });
-
-          it('should render the right children', () => {
-            const wrapper = getParagraph();
-
-            expectComponentToHaveChildren(wrapper, damageDepositText);
-          });
-        });
+    it('should have the right structure', () => {
+      const wrapper = getPaymentInformation({
+        damageDepositText,
       });
+
+      expect(wrapper).toMatchSnapshot();
     });
   });
 
   describe('if `props.notesText` is passed', () => {
-    it('should render another `GridRow`', () => {
-      const wrapper = getPaymentInformation({ notesText })
-        .find(GridRow)
-        .at(3);
-
-      expectComponentToHaveChildren(wrapper, GridColumn);
-    });
-
-    describe('the conditional `GridRow` component', () => {
-      const getConditionalGridColumn = () =>
-        getPaymentInformation({ notesText })
-          .find(GridRow)
-          .at(3)
-          .find(GridColumn)
-          .first();
-
-      describe('the first `GridColumn` component', () => {
-        it('should have the right props', () => {
-          const wrapper = getConditionalGridColumn();
-
-          expectComponentToHaveProps(wrapper, {
-            width: 12,
-          });
-        });
-
-        it('should render the right children', () => {
-          const wrapper = getConditionalGridColumn();
-
-          expectComponentToHaveChildren(wrapper, Heading, Paragraph);
-        });
-
-        describe('the `Heading` component', () => {
-          const getHeader = () =>
-            getConditionalGridColumn()
-              .find(Heading)
-              .first();
-
-          it('should have the right props', () => {
-            const wrapper = getHeader();
-
-            expectComponentToHaveProps(wrapper, {
-              size: 'small',
-            });
-          });
-
-          it('should render the right children', () => {
-            const wrapper = getHeader();
-
-            expectComponentToHaveChildren(wrapper, NOTES);
-          });
-        });
-
-        describe('the `Paragraph` component', () => {
-          const getParagraph = () =>
-            getConditionalGridColumn()
-              .find(Paragraph)
-              .first();
-
-          it('should have the right props', () => {
-            const wrapper = getParagraph();
-
-            expectComponentToHaveProps(wrapper, {
-              size: 'medium',
-            });
-          });
-
-          it('should render the right children', () => {
-            const wrapper = getParagraph();
-
-            expectComponentToHaveChildren(wrapper, notesText);
-          });
-        });
+    it('should have the right structure', () => {
+      const wrapper = getPaymentInformation({
+        notesText,
       });
+
+      expect(wrapper).toMatchSnapshot();
     });
   });
 
   describe('if `props.extraNotesText` is passed', () => {
-    it('should render another `GridRow`', () => {
-      const wrapper = getPaymentInformation({ extraNotesText })
-        .find(GridRow)
-        .at(3);
-
-      expectComponentToHaveChildren(wrapper, GridColumn);
-    });
-
-    describe('the conditional `GridRow` component', () => {
-      const getConditionalGridColumn = () =>
-        getPaymentInformation({ extraNotesText })
-          .find(GridRow)
-          .at(3)
-          .find(GridColumn)
-          .first();
-
-      describe('the first `GridColumn` component', () => {
-        it('should have the right props', () => {
-          const wrapper = getConditionalGridColumn();
-
-          expectComponentToHaveProps(wrapper, {
-            width: 12,
-          });
-        });
-
-        it('should render the right children', () => {
-          const wrapper = getConditionalGridColumn();
-
-          expectComponentToHaveChildren(wrapper, Modal);
-        });
+    it('should have the right structure', () => {
+      const wrapper = getPaymentInformation({
+        extraNotesText,
       });
 
-      describe('the `Modal` component', () => {
-        it('should have the right props', () => {
-          const wrapper = getConditionalGridColumn().find(Modal);
-
-          expectComponentToHaveProps(wrapper, {
-            children: expect.any(Array),
-            trigger: <Link>{VIEW_MORE}</Link>,
-          });
-        });
-      });
-
-      describe('the other `Paragraph` components', () => {
-        it('should render the right children', () => {
-          getParagraphsFromStrings(extraNotesText).forEach(
-            (paragraphText, index) => {
-              const wrapper = getConditionalGridColumn()
-                .find(Paragraph)
-                .at(index);
-
-              expectComponentToHaveChildren(wrapper, paragraphText);
-            }
-          );
-        });
-      });
+      expect(wrapper).toMatchSnapshot();
     });
   });
 


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1447)

### What **one** thing does this PR do?
If the relevant props for the row are undefined, then the row will not be rendered.

### Any other notes
- Also refactored the `PaymentInformation` specs to use snapshot testing

### Before
<img width="1144" alt="screen shot 2018-11-22 at 11 13 33" src="https://user-images.githubusercontent.com/25742275/48898213-7dc83c80-ee4c-11e8-9e62-867dd2696b27.png">

### After
<img width="1133" alt="screen shot 2018-11-22 at 11 12 42" src="https://user-images.githubusercontent.com/25742275/48898225-8751a480-ee4c-11e8-8eb4-0b92997fa4a1.png">

