### PR TITLE
TE-1460: Reduce the PropertyPageHero height

### DIFF
--- a/src/components/collections/Hero/Readme.md
+++ b/src/components/collections/Hero/Readme.md
@@ -2,7 +2,7 @@
 const logoSrc = require('./mock-data/livingstoneLogo.png');
 const { backgroundImageUrl, navigationItems } = require('./mock-data/mock-data');
 
-<Hero     
+<Hero
   backgroundImageUrl={backgroundImageUrl}
   headerLogoSrc={logoSrc}
   headerLogoText="Livingstone Cottage"
@@ -19,7 +19,7 @@ const { backgroundImageUrl, navigationItems } = require('./mock-data/mock-data')
 const logoSrc = require('./mock-data/livingstoneLogo.png');
 const { backgroundImageUrl, navigationItems } = require('./mock-data/mock-data');
 
-<Hero     
+<Hero
   activeNavigationItemIndex={0}
   backgroundImageUrl={backgroundImageUrl}
   headerLogoSrc={logoSrc}
@@ -30,6 +30,24 @@ const { backgroundImageUrl, navigationItems } = require('./mock-data/mock-data')
 />
 ```
 
+#### With bottom offset
+
+```jsx
+const logoSrc = require('./mock-data/livingstoneLogo.png');
+const { backgroundImageUrl, navigationItems } = require('./mock-data/mock-data');
+
+<Hero
+  backgroundImageUrl={backgroundImageUrl}
+  bottomOffset="150px"
+  headerLogoSrc={logoSrc}
+  headerLogoText="Livingstone Cottage"
+  headerNavigationItems={navigationItems}
+  headerPrimaryCTA={{ onClick: console.log, text: 'Book now'}}
+  heading="Super Interesting Heading"
+/>
+```
+
+
 ### Content
 
 #### Children
@@ -37,7 +55,7 @@ const { backgroundImageUrl, navigationItems } = require('./mock-data/mock-data')
 const logoSrc = require('./mock-data/livingstoneLogo.png');
 const { backgroundImageUrl, navigationItems } = require('./mock-data/mock-data');
 
-<Hero     
+<Hero
   backgroundImageUrl={backgroundImageUrl}
   headerLogoSrc={logoSrc}
   headerLogoText="Livingstone Cottage"
@@ -51,23 +69,4 @@ const { backgroundImageUrl, navigationItems } = require('./mock-data/mock-data')
     <Heading size="huge">The Cat House</Heading>
   </FlexContainer>
 </Hero>
-```
-
-#### Search bar
-
-```jsx
-const logoSrc = require('./mock-data/livingstoneLogo.png');
-const { backgroundImageUrl, navigationItems } = require('./mock-data/mock-data');
-
-<Hero     
-  backgroundImageUrl={backgroundImageUrl}
-  headerLogoSrc={logoSrc}
-  headerLogoText="Livingstone Cottage"
-  headerNavigationItems={navigationItems}
-  headerPrimaryCTA={{ onClick: console.log, text: 'Book now'}}
-  headerSearchBarGuestsOptions={[{ text: '1', value: '1' }]}
-  headerSearchBarLocationOptions={[{ text: 'New York', value: '2' }]}
-  headerSearchBarModalHeadingText="Custom heading"
-  headerSearchBarSearchButton={<Button>Check now!</Button>}
-/>
 ```

--- a/src/components/collections/Hero/__snapshots__/component.spec.js.snap
+++ b/src/components/collections/Hero/__snapshots__/component.spec.js.snap
@@ -4,6 +4,7 @@ exports[`<Hero /> by default should render the right structure 1`] = `
 <Hero
   activeNavigationItemIndex={1}
   backgroundImageUrl="https://darkpurple.com"
+  bottomOffset="0px"
   headerLogoSrc="https://darkgreen.com"
   headerLogoText="Livingstone Cottage"
   headerNavigationItems={

--- a/src/components/collections/Hero/__snapshots__/component.spec.js.snap
+++ b/src/components/collections/Hero/__snapshots__/component.spec.js.snap
@@ -42,16 +42,27 @@ exports[`<Hero /> by default should render the right structure 1`] = `
   searchBarOnSubmit={[Function]}
 >
   <FullBleed
+    bottomOffset="0px"
     hasGradient={true}
     imageUrl="https://darkpurple.com"
     placeholderImageUrl={null}
   >
     <Segment
       className="full-bleed has-gradient has-children"
+      style={
+        Object {
+          "--full-bleed-bottom-offset": "0px",
+        }
+      }
       vertical={true}
     >
       <div
         className="ui vertical segment full-bleed has-gradient has-children"
+        style={
+          Object {
+            "--full-bleed-bottom-offset": "0px",
+          }
+        }
       >
         <ResponsiveImage
           alternativeText="Image Widget"

--- a/src/components/collections/Hero/component.js
+++ b/src/components/collections/Hero/component.js
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types';
 import { Header } from 'collections/Header';
 import { FullBleed } from 'media/FullBleed';
 
+import { DEFAULT_BOTTOM_OFFSET } from './constants';
+
 /**
  * A hero displays a header and optional children with a full bleed image background
  */
@@ -11,6 +13,7 @@ import { FullBleed } from 'media/FullBleed';
 export const Component = ({
   activeNavigationItemIndex,
   backgroundImageUrl,
+  bottomOffset,
   children,
   headerLogoSrc,
   headerLogoText,
@@ -26,6 +29,7 @@ export const Component = ({
   searchBarOnSubmit,
 }) => (
   <FullBleed
+    bottomOffset={bottomOffset}
     hasGradient
     imageUrl={backgroundImageUrl}
     placeholderImageUrl={placeholderBackgroundImageUrl}
@@ -52,6 +56,7 @@ Component.displayName = 'Hero';
 
 Component.defaultProps = {
   activeNavigationItemIndex: null,
+  bottomOffset: DEFAULT_BOTTOM_OFFSET,
   children: null,
   headerLogoSrc: null,
   headerPrimaryCTA: null,
@@ -70,6 +75,8 @@ Component.propTypes = {
   activeNavigationItemIndex: PropTypes.number,
   /** The background image url of the hero. */
   backgroundImageUrl: PropTypes.string.isRequired,
+  /** Reduce the height of the Hero with an offset, supports CSS dimensions. */
+  bottomOffset: PropTypes.string,
   /** The children displayed between the header and the bottom of the hero. */
   children: PropTypes.node,
   /** The src url for the logo in the header. */

--- a/src/components/collections/Hero/constants.js
+++ b/src/components/collections/Hero/constants.js
@@ -1,0 +1,1 @@
+export const DEFAULT_BOTTOM_OFFSET = '0px';

--- a/src/components/general-widgets/HomepageHero/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/HomepageHero/__snapshots__/component.spec.js.snap
@@ -95,16 +95,27 @@ exports[`HomepageHero by default should render the right structure 1`] = `
     searchBarOnSubmit={[Function]}
   >
     <FullBleed
+      bottomOffset="0px"
       hasGradient={true}
       imageUrl="url"
       placeholderImageUrl={null}
     >
       <Segment
         className="full-bleed has-gradient has-children"
+        style={
+          Object {
+            "--full-bleed-bottom-offset": "0px",
+          }
+        }
         vertical={true}
       >
         <div
           className="ui vertical segment full-bleed has-gradient has-children"
+          style={
+            Object {
+              "--full-bleed-bottom-offset": "0px",
+            }
+          }
         >
           <ResponsiveImage
             alternativeText="Image Widget"

--- a/src/components/general-widgets/HomepageHero/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/HomepageHero/__snapshots__/component.spec.js.snap
@@ -51,6 +51,7 @@ exports[`HomepageHero by default should render the right structure 1`] = `
   <Hero
     activeNavigationItemIndex={1}
     backgroundImageUrl="url"
+    bottomOffset="0px"
     headerLogoSrc="src"
     headerLogoText="text"
     headerNavigationItems={

--- a/src/components/media/FullBleed/Readme.md
+++ b/src/components/media/FullBleed/Readme.md
@@ -13,3 +13,12 @@
   hasGradient
 />
 ```
+
+#### With bottom offset
+
+```jsx
+<FullBleed
+  bottomOffset="150px"
+  imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
+/>
+```

--- a/src/components/media/FullBleed/__snapshots__/component.spec.js.snap
+++ b/src/components/media/FullBleed/__snapshots__/component.spec.js.snap
@@ -2,16 +2,27 @@
 
 exports[`<FullBleed /> by default should have the right structure 1`] = `
 <FullBleed
+  bottomOffset="0px"
   hasGradient={false}
   imageUrl="🐱🐱"
   placeholderImageUrl={null}
 >
   <Segment
     className="full-bleed"
+    style={
+      Object {
+        "--full-bleed-bottom-offset": "0px",
+      }
+    }
     vertical={true}
   >
     <div
       className="ui vertical segment full-bleed"
+      style={
+        Object {
+          "--full-bleed-bottom-offset": "0px",
+        }
+      }
     >
       <ResponsiveImage
         alternativeText="Image Widget"
@@ -57,16 +68,27 @@ exports[`<FullBleed /> by default should have the right structure 1`] = `
 
 exports[`<FullBleed /> if \`hasGradient\` is passed should have the right structure 1`] = `
 <FullBleed
+  bottomOffset="0px"
   hasGradient={true}
   imageUrl="🐱🐱"
   placeholderImageUrl={null}
 >
   <Segment
     className="full-bleed has-gradient"
+    style={
+      Object {
+        "--full-bleed-bottom-offset": "0px",
+      }
+    }
     vertical={true}
   >
     <div
       className="ui vertical segment full-bleed has-gradient"
+      style={
+        Object {
+          "--full-bleed-bottom-offset": "0px",
+        }
+      }
     >
       <ResponsiveImage
         alternativeText="Image Widget"
@@ -112,16 +134,27 @@ exports[`<FullBleed /> if \`hasGradient\` is passed should have the right struct
 
 exports[`<FullBleed /> if \`props.children > 0\` should have the right structure 1`] = `
 <FullBleed
+  bottomOffset="0px"
   hasGradient={false}
   imageUrl="🐱🐱"
   placeholderImageUrl={null}
 >
   <Segment
     className="full-bleed has-children"
+    style={
+      Object {
+        "--full-bleed-bottom-offset": "0px",
+      }
+    }
     vertical={true}
   >
     <div
       className="ui vertical segment full-bleed has-children"
+      style={
+        Object {
+          "--full-bleed-bottom-offset": "0px",
+        }
+      }
     >
       <ResponsiveImage
         alternativeText="Image Widget"

--- a/src/components/media/FullBleed/component.js
+++ b/src/components/media/FullBleed/component.js
@@ -6,12 +6,15 @@ import { size } from 'lodash';
 
 import { ResponsiveImage } from 'media/ResponsiveImage';
 
+import { DEFAULT_BOTTOM_OFFSET } from './constants';
+
 /**
  * A full bleed takes up the width of its containing element
  * and the height of the viewport.
  */
 // eslint-disable-next-line jsdoc/require-jsdoc
 export const Component = ({
+  bottomOffset,
   children,
   hasGradient,
   imageUrl,
@@ -22,6 +25,9 @@ export const Component = ({
       'has-gradient': hasGradient,
       'has-children': size(children) > 0,
     })}
+    style={{
+      '--full-bleed-bottom-offset': bottomOffset,
+    }}
     vertical
   >
     <ResponsiveImage
@@ -36,6 +42,7 @@ export const Component = ({
 Component.displayName = 'FullBleed';
 
 Component.defaultProps = {
+  bottomOffset: DEFAULT_BOTTOM_OFFSET,
   children: null,
   hasGradient: false,
   imageUrl: null,
@@ -43,6 +50,8 @@ Component.defaultProps = {
 };
 
 Component.propTypes = {
+  /** Reduce the height of the FullBleed with an offset, supports CSS dimensions. */
+  bottomOffset: PropTypes.string,
   /** The children to render inside the full bleed. */
   children: PropTypes.node,
   /** Is there a gradient overlaying the full bleed.  */

--- a/src/components/media/FullBleed/constants.js
+++ b/src/components/media/FullBleed/constants.js
@@ -1,0 +1,1 @@
+export const DEFAULT_BOTTOM_OFFSET = '0px';

--- a/src/components/property-page-widgets/PropertyPageHero/component.js
+++ b/src/components/property-page-widgets/PropertyPageHero/component.js
@@ -13,6 +13,8 @@ import { ICON_NAMES } from 'elements/Icon';
 import { VIEW_MORE_PICTURES } from 'utils/default-strings';
 import { Divider } from 'elements/Divider';
 
+import { BOTTOM_OFFSET } from './constants';
+
 /**
  * A homepage hero displays a hero with heading and a search bar on desktop screens.
  */
@@ -38,6 +40,7 @@ const Component = ({
   <Hero
     activeNavigationItemIndex={activeNavigationItemIndex}
     backgroundImageUrl={images[0].imageUrl}
+    bottomOffset={BOTTOM_OFFSET}
     headerLogoSrc={headerLogoSrc}
     headerLogoText={headerLogoText}
     headerNavigationItems={headerNavigationItems}
@@ -46,6 +49,7 @@ const Component = ({
     headerSearchBarLocationOptions={searchBarLocationOptions}
     headerSearchBarModalHeadingText={searchBarModalHeadingText}
     headerSearchBarSearchButton={searchBarSearchButton}
+    isFixedSearchBarDisplayed
     placeholderBackgroundImageUrl={images[0].placeholderImageUrl}
     searchBarGetIsDayBlocked={searchBarGetIsDayBlocked}
     searchBarOnChangeInput={searchBarOnChangeInput}

--- a/src/components/property-page-widgets/PropertyPageHero/constants.js
+++ b/src/components/property-page-widgets/PropertyPageHero/constants.js
@@ -1,0 +1,1 @@
+export const BOTTOM_OFFSET = '85px';

--- a/src/styles/semantic/themes/livingstone/elements/segment.overrides
+++ b/src/styles/semantic/themes/livingstone/elements/segment.overrides
@@ -112,7 +112,7 @@
   background-position: center;
   background-size: cover;
   display: flex;
-  height: 100vh;
+  height: ~"calc(100vh - var(@{fullBleedBottomOffsetIdentifier}, 0))";
   padding: 0;
 
   picture.responsive-image,

--- a/src/styles/semantic/themes/livingstone/elements/segment.variables
+++ b/src/styles/semantic/themes/livingstone/elements/segment.variables
@@ -63,6 +63,7 @@
 
 /* Full bleed */
 @backgroundImageGradient: linear-gradient(0deg, rgba(255, 255, 255, 0) 51%, rgba(0, 0, 0, 0.5) 100%);
+@fullBleedBottomOffsetIdentifier: '--full-bleed-bottom-offset';
 
 /* Is Summary */
 @summaryLocationNameMaxWidth: 185px;


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1460)

### What **one** thing does this PR do?
Reduce the height of the `PropertyPageHero` to accommodate the fixed search bar

### Any other notes
- Updated the `Hero` and the `FullBleed` to support a prop called `bottomOffset`. The purpose of `bottomOffset` is to reduce the height of the `FullBleed`.
- Relies on CSS variables 

### Preview 
- The height of the hero has been reduced by `85px`
<img width="1167" alt="screen shot 2018-11-22 at 17 15 30" src="https://user-images.githubusercontent.com/25742275/48914538-027e7f00-ee7c-11e8-9a06-e0345f83e007.png">

