### PR TITLE
TE-1426: In the Form, handle the required validation onChange

### DIFF
--- a/src/components/collections/Form/Readme.md
+++ b/src/components/collections/Form/Readme.md
@@ -156,6 +156,9 @@ const dropdownOptions = [{
 }, {
   text: 'Is valid',
   value: 'valid'
+}, {
+  text: 'Is empty string',
+  value: ''
 }];
 
 <Form

--- a/src/components/collections/Form/component.js
+++ b/src/components/collections/Form/component.js
@@ -8,7 +8,7 @@ import { Heading } from 'typography/Heading';
 import { Link } from 'elements/Link';
 
 import { getValidationWithDefaults } from './utils/getValidationWithDefaults';
-import { getIsRequiredError } from './utils/getIsRequiredError';
+import { getIsRequiredErrorThenSetState } from './utils/getIsRequiredErrorThenSetState';
 import { getIsValidError } from './utils/getIsValidError';
 import { getEmptyRequiredInputs } from './utils/getEmptyRequiredInputs';
 import { getFormChild } from './utils/getFormChild';
@@ -21,15 +21,26 @@ import { getIsSubmitButtonDisabled } from './utils/getIsSubmitButtonDisabled';
 export class Component extends PureComponent {
   state = {};
 
-  handleInputBlur = name => {
-    const validation = getValidationWithDefaults(this.props.validation[name]);
-    const hasError = getIsRequiredError(validation, this.state[name]);
-
-    hasError &&
-      this.setState({ [name]: { error: validation.isRequiredMessage } });
-  };
+  handleInputBlur = name =>
+    getIsRequiredErrorThenSetState(
+      this.setState.bind(this),
+      this.props.validation[name],
+      name,
+      this.state[name]
+    );
 
   handleInputChange = (name, value) => {
+    const hasIsRequiredError = getIsRequiredErrorThenSetState(
+      this.setState.bind(this),
+      this.props.validation[name],
+      name,
+      { value }
+    );
+
+    if (hasIsRequiredError) {
+      return;
+    }
+
     const { invalidMessage, getIsValid } = getValidationWithDefaults(
       this.props.validation[name]
     );

--- a/src/components/collections/Form/component.spec.js
+++ b/src/components/collections/Form/component.spec.js
@@ -155,6 +155,24 @@ describe('<Form />', () => {
         [name]: { error: false, isValid: undefined, value: '🌴' },
       });
     });
+
+    describe('if there is an `is required` type error', () => {
+      it('should set the error to component state', () => {
+        const name = '🐸';
+        const value = '';
+        const wrapper = getForm(<input />, {
+          validation: { [name]: { isRequired: true } },
+        });
+
+        wrapper.instance().handleInputChange(name, value);
+
+        const actual = wrapper.state();
+
+        expect(actual).toEqual({
+          [name]: { error: DEFAULT_IS_REQUIRED_MESSAGE },
+        });
+      });
+    });
   });
 
   describe('`handleSubmit`', () => {

--- a/src/components/collections/Form/utils/getIsRequiredErrorThenSetState.js
+++ b/src/components/collections/Form/utils/getIsRequiredErrorThenSetState.js
@@ -1,0 +1,31 @@
+import { getValidationWithDefaults } from './getValidationWithDefaults';
+import { getIsRequiredError } from './getIsRequiredError';
+
+/**
+ * @param {Function} setState
+ * @param {Object}   fieldValidation
+ * @param {string}   name
+ * @param {Object}   [inputState={}]
+ * @param {any}      [inputState.value]
+ */
+export const getIsRequiredErrorThenSetState = (
+  setState,
+  fieldValidation,
+  name,
+  inputState = {}
+) => {
+  const { isRequiredMessage, ...validation } = getValidationWithDefaults(
+    fieldValidation
+  );
+  const hasError = getIsRequiredError(validation, inputState);
+
+  if (hasError) {
+    setState({
+      [name]: {
+        error: isRequiredMessage,
+      },
+    });
+  }
+
+  return hasError;
+};

--- a/src/components/collections/Form/utils/getIsRequiredErrorThenSetState.spec.js
+++ b/src/components/collections/Form/utils/getIsRequiredErrorThenSetState.spec.js
@@ -1,0 +1,52 @@
+import { DEFAULT_IS_REQUIRED_MESSAGE } from '../constants';
+
+import { getIsRequiredErrorThenSetState } from './getIsRequiredErrorThenSetState';
+
+describe('getIsRequiredErrorThenSetState', () => {
+  describe('if there is an `is required` type error', () => {
+    it('should set the error to component state and return true', () => {
+      const name = '🐸';
+      const value = '';
+      const fieldValidation = {
+        isRequired: true,
+      };
+      const setState = jest.fn();
+
+      const hasError = getIsRequiredErrorThenSetState(
+        setState,
+        fieldValidation,
+        name,
+        value
+      );
+
+      expect(setState).toBeCalledWith({
+        [name]: {
+          error: DEFAULT_IS_REQUIRED_MESSAGE,
+        },
+      });
+      expect(hasError).toBe(true);
+    });
+  });
+
+  describe('if the field is not empty', () => {
+    it('should not set the state and return false', () => {
+      const name = '🐸';
+      const value = 'defined';
+      const fieldValidation = {
+        isRequired: true,
+        getIsEmpty: () => false,
+      };
+      const setState = jest.fn();
+
+      const hasError = getIsRequiredErrorThenSetState(
+        setState,
+        fieldValidation,
+        name,
+        value
+      );
+
+      expect(hasError).toBe(false);
+      expect(setState).not.toBeCalled();
+    });
+  });
+});


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1426)

### What **one** thing does this PR do?
Applies the `isRequired` error validation to the `handleInputChange`.

### Any other notes
- Also updated the Form documentation to have an empty string option for the `Dropdown` to demonstrate the required state.

### Why this was occurring?
- This bug is specific to the Dropdown.
- We only rely on the blur event to handle the required state, and the change event is only used to handle the isValid state.
- So when a value was changed in the `Dropdown`, the change event would override the state to set the field as valid without taking the required state into account.
- Once the user interacted with the Dropdown again without changing the value, the blur event would then apply the required state if the value was an empty string.

### Before
![kapture 2018-11-23 at 11 57 21](https://user-images.githubusercontent.com/25742275/48940239-2ba01d80-ef17-11e8-8fb2-4267e8f40985.gif)

### After
![kapture 2018-11-23 at 11 58 51](https://user-images.githubusercontent.com/25742275/48940245-3064d180-ef17-11e8-88ff-f76811954f12.gif)
