### PR TITLE
TE-1489 Switch `source` for `srcset` in `ResponsiveImage` 

### DIFF
--- a/src/components/collections/Hero/__snapshots__/component.spec.js.snap
+++ b/src/components/collections/Hero/__snapshots__/component.spec.js.snap
@@ -47,6 +47,8 @@ exports[`<Hero /> by default should render the right structure 1`] = `
     hasGradient={true}
     imageUrl="https://darkpurple.com"
     placeholderImageUrl={null}
+    sizes={null}
+    srcSet={null}
   >
     <Segment
       className="full-bleed has-gradient has-children"
@@ -78,29 +80,35 @@ exports[`<Hero /> by default should render the right structure 1`] = `
           isFluid={true}
           label={null}
           placeholderImageUrl={null}
-          sources={Array []}
+          sizes={null}
+          srcSet={null}
         >
-          <picture
+          <figure
             className="responsive-image is-fluid"
-            role="figure"
           >
             <Image
               alt="Image Widget"
               as="img"
               avatar={false}
               fluid={true}
+              onLoad={[Function]}
+              sizes={null}
               src="https://darkpurple.com"
+              srcSet={null}
               title="Image Title"
               ui={true}
             >
               <img
                 alt="Image Widget"
                 className="ui fluid image"
+                onLoad={[Function]}
+                sizes={null}
                 src="https://darkpurple.com"
+                srcSet={null}
                 title="Image Title"
               />
             </Image>
-          </picture>
+          </figure>
         </ResponsiveImage>
         <Header
           activeNavigationItemIndex={1}

--- a/src/components/general-widgets/FeaturedProperty/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/FeaturedProperty/__snapshots__/component.spec.js.snap
@@ -17,7 +17,8 @@ exports[`<FeaturedProperty /> should render the right structure 1`] = `
     isCircular={false}
     isFluid={true}
     label={null}
-    sources={Array []}
+    sizes={null}
+    srcSet={null}
   />
   <CardContent>
     <CardMeta>

--- a/src/components/general-widgets/FeaturedRoomType/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/FeaturedRoomType/__snapshots__/component.spec.js.snap
@@ -17,7 +17,8 @@ exports[`<FeaturedRoomType /> should render the right structure 1`] = `
     isCircular={false}
     isFluid={true}
     label={null}
-    sources={Array []}
+    sizes={null}
+    srcSet={null}
   />
   <CardContent>
     <CardHeader>

--- a/src/components/general-widgets/HomepageHero/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/HomepageHero/__snapshots__/component.spec.js.snap
@@ -100,6 +100,8 @@ exports[`HomepageHero by default should render the right structure 1`] = `
       hasGradient={true}
       imageUrl="url"
       placeholderImageUrl={null}
+      sizes={null}
+      srcSet={null}
     >
       <Segment
         className="full-bleed has-gradient has-children"
@@ -131,29 +133,35 @@ exports[`HomepageHero by default should render the right structure 1`] = `
             isFluid={true}
             label={null}
             placeholderImageUrl={null}
-            sources={Array []}
+            sizes={null}
+            srcSet={null}
           >
-            <picture
+            <figure
               className="responsive-image is-fluid"
-              role="figure"
             >
               <Image
                 alt="Image Widget"
                 as="img"
                 avatar={false}
                 fluid={true}
+                onLoad={[Function]}
+                sizes={null}
                 src="url"
+                srcSet={null}
                 title="Image Title"
                 ui={true}
               >
                 <img
                   alt="Image Widget"
                   className="ui fluid image"
+                  onLoad={[Function]}
+                  sizes={null}
                   src="url"
+                  srcSet={null}
                   title="Image Title"
                 />
               </Image>
-            </picture>
+            </figure>
           </ResponsiveImage>
           <Header
             activeNavigationItemIndex={1}

--- a/src/components/general-widgets/Promotion/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/Promotion/__snapshots__/component.spec.js.snap
@@ -3,6 +3,8 @@
 exports[`The \`Promotion\` component should have the right structure 1`] = `
 <Promotion
   backgroundImage="testimage"
+  backgroundImageSizes={null}
+  backgroundImageSrcSet={null}
   discountAmount="100%"
   discountAmountParagraphText="Save up to"
   discountCode="123"
@@ -79,29 +81,35 @@ exports[`The \`Promotion\` component should have the right structure 1`] = `
                           isFluid={false}
                           label={null}
                           placeholderImageUrl={null}
-                          sources={Array []}
+                          sizes={null}
+                          srcSet={null}
                         >
-                          <picture
+                          <figure
                             className="responsive-image"
-                            role="figure"
                           >
                             <Image
                               alt="Image Widget"
                               as="img"
                               avatar={false}
                               fluid={true}
+                              onLoad={[Function]}
+                              sizes={null}
                               src="testimage"
+                              srcSet={null}
                               title="Image Title"
                               ui={true}
                             >
                               <img
                                 alt="Image Widget"
                                 className="ui fluid image"
+                                onLoad={[Function]}
+                                sizes={null}
                                 src="testimage"
+                                srcSet={null}
                                 title="Image Title"
                               />
                             </Image>
-                          </picture>
+                          </figure>
                         </ResponsiveImage>
                         <Grid
                           areColumnsCentered={false}

--- a/src/components/general-widgets/Promotion/component.js
+++ b/src/components/general-widgets/Promotion/component.js
@@ -24,6 +24,8 @@ import { Button } from 'elements/Button';
 export const Component = ({
   backgroundImage,
   backgroundImageHeight,
+  backgroundImageSizes,
+  backgroundImageSrcSet,
   backgroundImageWidth,
   discountAmount,
   discountAmountParagraphText,
@@ -48,6 +50,8 @@ export const Component = ({
             imageUrl={backgroundImage}
             imageWidth={backgroundImageWidth}
             placeholderImageUrl={placeholderBackgroundImage}
+            sizes={backgroundImageSizes}
+            srcSet={backgroundImageSrcSet}
           />
           <Grid padded>
             <GridRow verticalAlign="top">
@@ -128,6 +132,8 @@ Component.displayName = 'Promotion';
 
 Component.defaultProps = {
   backgroundImageHeight: undefined,
+  backgroundImageSizes: null,
+  backgroundImageSrcSet: null,
   backgroundImageWidth: undefined,
   discountAmountParagraphText: SAVE_UP_TO,
   discountCodeParagraphText: USE_COUPON_CODE,
@@ -141,6 +147,10 @@ Component.propTypes = {
   /** The natural height of the background image in px. */
   backgroundImageHeight: PropTypes.number,
   /** The natural width of the background image in px. */
+  backgroundImageSizes: PropTypes.string,
+  /** A list of one or more strings separated by commas indicating a set of source sizes for the background image. See [the MDN docs for more information](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img). */
+  backgroundImageSrcSet: PropTypes.string,
+  /** A list of one or more strings separated by commas indicating a set of possible image sources for the user agent to use for the background image. See [the MDN docs for more information](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img). */
   backgroundImageWidth: PropTypes.number,
   /** The discount amount to be displayed. */
   discountAmount: PropTypes.string.isRequired,

--- a/src/components/media/FullBleed/__snapshots__/component.spec.js.snap
+++ b/src/components/media/FullBleed/__snapshots__/component.spec.js.snap
@@ -6,6 +6,8 @@ exports[`<FullBleed /> by default should have the right structure 1`] = `
   hasGradient={false}
   imageUrl="🐱🐱"
   placeholderImageUrl={null}
+  sizes={null}
+  srcSet={null}
 >
   <Segment
     className="full-bleed"
@@ -37,29 +39,35 @@ exports[`<FullBleed /> by default should have the right structure 1`] = `
         isFluid={true}
         label={null}
         placeholderImageUrl={null}
-        sources={Array []}
+        sizes={null}
+        srcSet={null}
       >
-        <picture
+        <figure
           className="responsive-image is-fluid"
-          role="figure"
         >
           <Image
             alt="Image Widget"
             as="img"
             avatar={false}
             fluid={true}
+            onLoad={[Function]}
+            sizes={null}
             src="🐱🐱"
+            srcSet={null}
             title="Image Title"
             ui={true}
           >
             <img
               alt="Image Widget"
               className="ui fluid image"
+              onLoad={[Function]}
+              sizes={null}
               src="🐱🐱"
+              srcSet={null}
               title="Image Title"
             />
           </Image>
-        </picture>
+        </figure>
       </ResponsiveImage>
     </div>
   </Segment>
@@ -72,6 +80,8 @@ exports[`<FullBleed /> if \`hasGradient\` is passed should have the right struct
   hasGradient={true}
   imageUrl="🐱🐱"
   placeholderImageUrl={null}
+  sizes={null}
+  srcSet={null}
 >
   <Segment
     className="full-bleed has-gradient"
@@ -103,29 +113,35 @@ exports[`<FullBleed /> if \`hasGradient\` is passed should have the right struct
         isFluid={true}
         label={null}
         placeholderImageUrl={null}
-        sources={Array []}
+        sizes={null}
+        srcSet={null}
       >
-        <picture
+        <figure
           className="responsive-image is-fluid"
-          role="figure"
         >
           <Image
             alt="Image Widget"
             as="img"
             avatar={false}
             fluid={true}
+            onLoad={[Function]}
+            sizes={null}
             src="🐱🐱"
+            srcSet={null}
             title="Image Title"
             ui={true}
           >
             <img
               alt="Image Widget"
               className="ui fluid image"
+              onLoad={[Function]}
+              sizes={null}
               src="🐱🐱"
+              srcSet={null}
               title="Image Title"
             />
           </Image>
-        </picture>
+        </figure>
       </ResponsiveImage>
     </div>
   </Segment>
@@ -138,6 +154,8 @@ exports[`<FullBleed /> if \`props.children > 0\` should have the right structure
   hasGradient={false}
   imageUrl="🐱🐱"
   placeholderImageUrl={null}
+  sizes={null}
+  srcSet={null}
 >
   <Segment
     className="full-bleed has-children"
@@ -169,29 +187,35 @@ exports[`<FullBleed /> if \`props.children > 0\` should have the right structure
         isFluid={true}
         label={null}
         placeholderImageUrl={null}
-        sources={Array []}
+        sizes={null}
+        srcSet={null}
       >
-        <picture
+        <figure
           className="responsive-image is-fluid"
-          role="figure"
         >
           <Image
             alt="Image Widget"
             as="img"
             avatar={false}
             fluid={true}
+            onLoad={[Function]}
+            sizes={null}
             src="🐱🐱"
+            srcSet={null}
             title="Image Title"
             ui={true}
           >
             <img
               alt="Image Widget"
               className="ui fluid image"
+              onLoad={[Function]}
+              sizes={null}
               src="🐱🐱"
+              srcSet={null}
               title="Image Title"
             />
           </Image>
-        </picture>
+        </figure>
       </ResponsiveImage>
       🏛
     </div>

--- a/src/components/media/FullBleed/component.js
+++ b/src/components/media/FullBleed/component.js
@@ -19,6 +19,8 @@ export const Component = ({
   hasGradient,
   imageUrl,
   placeholderImageUrl,
+  sizes,
+  srcSet,
 }) => (
   <Segment
     className={getClassNames('full-bleed', {
@@ -34,6 +36,8 @@ export const Component = ({
       imageUrl={imageUrl}
       isFluid
       placeholderImageUrl={placeholderImageUrl}
+      sizes={sizes}
+      srcSet={srcSet}
     />
     {children}
   </Segment>
@@ -47,6 +51,8 @@ Component.defaultProps = {
   hasGradient: false,
   imageUrl: null,
   placeholderImageUrl: null,
+  sizes: null,
+  srcSet: null,
 };
 
 Component.propTypes = {
@@ -60,4 +66,8 @@ Component.propTypes = {
   imageUrl: PropTypes.string,
   /** URL pointing to the placeholder image to render. */
   placeholderImageUrl: PropTypes.string,
+  /** A list of one or more strings separated by commas indicating a set of source sizes for the image. See [the MDN docs for more information](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img). */
+  sizes: PropTypes.string,
+  /** A list of one or more strings separated by commas indicating a set of possible image sources for the user agent to use for the image. See [the MDN docs for more information](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img). */
+  srcSet: PropTypes.string,
 };

--- a/src/components/media/Gallery/component.js
+++ b/src/components/media/Gallery/component.js
@@ -50,36 +50,8 @@ Component.defaultProps = {
 Component.propTypes = {
   /** The content to display as a heading at the top of the gallery. */
   heading: PropTypes.node,
-  /** The images to display. */
-  images: PropTypes.arrayOf(
-    PropTypes.shape({
-      /** Alternative text to show if the image can't be loaded by the browser */
-      alternativeText: PropTypes.string,
-      /** The natural height of the image in px. */
-      imageHeight: PropTypes.number,
-      /** The label text for the when the image is not found. */
-      imageNotFoundLabelText: PropTypes.string,
-      /** Title of the image to show when hovering it on desktop browsers */
-      imageTitle: PropTypes.string,
-      /** URL pointing to the image to display. */
-      imageUrl: PropTypes.string.isRequired,
-      /** The natural width of the image in px. */
-      imageWidth: PropTypes.number,
-      /** A visible label for the image. */
-      label: PropTypes.string.isRequired,
-      /** URL pointing to the placeholder image to render. */
-      placeholderImageUrl: PropTypes.string,
-      /** Collection of objects to specify different image sources
-       *  [See this for more info](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images)
-       */
-      sources: PropTypes.arrayOf(
-        PropTypes.shape({
-          media: PropTypes.string.isRequired,
-          srcset: PropTypes.string.isRequired,
-        })
-      ),
-    })
-  ).isRequired,
+  /** The images to display. See [the `ResponsiveImage` component for valid props](#/Media/ResponsiveImage).  */
+  images: PropTypes.arrayOf(PropTypes.object).isRequired,
   /** The element to be clicked to display the gallery. */
   trigger: PropTypes.node.isRequired,
 };

--- a/src/components/media/ResponsiveImage/Readme.md
+++ b/src/components/media/ResponsiveImage/Readme.md
@@ -29,18 +29,12 @@
 #### Responsive
 
 ```jsx
+const getSrc = width => `https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=${width}`;
+
 <ResponsiveImage
-  imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=640&mode=max"
-  sources={[
-    {
-      srcset: 'https://si5.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=2400&mode=max',
-      media: '(min-width: 1200px)'
-    },
-    {
-      srcset: 'https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max',
-      media: '(min-width: 1024px)'
-    }
-  ]}
+  imageUrl={getSrc(1200)}
+  sizes="(max-width: 800px) 500px, (max-width: 1000px) 800px, 100vw"
+  srcSet={`${getSrc(500)} 500w, ${getSrc(800)} 800w, ${getSrc(1200)} 1200w`}
 />
 ```
 
@@ -48,7 +42,7 @@
 
 ```jsx
 <ResponsiveImage
-  placeholderImageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=20&mode=max" 
+  placeholderImageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=20&mode=max"
   imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
   imageWidth={1024}
   imageHeight={683}

--- a/src/components/media/ResponsiveImage/__snapshots__/component.spec.js.snap
+++ b/src/components/media/ResponsiveImage/__snapshots__/component.spec.js.snap
@@ -14,25 +14,32 @@ exports[`<ResponsiveImage /> by default should have the right structure 1`] = `
   isFluid={true}
   label={null}
   onLoad={[Function]}
+  sizes={null}
   sources={Array []}
+  srcSet={null}
 >
-  <picture
+  <figure
     className="responsive-image is-fluid"
-    role="figure"
   >
     <Image
       alt="Alternative Text 😝"
       as="img"
       avatar={false}
       fluid={true}
+      onLoad={[Function]}
+      sizes={null}
       src=""
+      srcSet={null}
       title="ResponsiveImage title"
       ui={true}
     >
       <div
         alt="Alternative Text 😝"
         className="ui fluid image"
+        onLoad={[Function]}
+        sizes={null}
         src=""
+        srcSet={null}
         title="ResponsiveImage title"
       >
         <Label
@@ -47,7 +54,7 @@ exports[`<ResponsiveImage /> by default should have the right structure 1`] = `
         </Label>
       </div>
     </Image>
-  </picture>
+  </figure>
 </ResponsiveImage>
 `;
 
@@ -65,25 +72,32 @@ exports[`<ResponsiveImage /> if \`props.label\` is passed should have the right 
   isFluid={true}
   label="🔷"
   onLoad={[Function]}
+  sizes={null}
   sources={Array []}
+  srcSet={null}
 >
-  <picture
+  <figure
     className="responsive-image is-fluid"
-    role="figure"
   >
     <Image
       alt="Alternative Text 😝"
       as="img"
       avatar={false}
       fluid={true}
+      onLoad={[Function]}
+      sizes={null}
       src=""
+      srcSet={null}
       title="ResponsiveImage title"
       ui={true}
     >
       <div
         alt="Alternative Text 😝"
         className="ui fluid image"
+        onLoad={[Function]}
+        sizes={null}
         src=""
+        srcSet={null}
         title="ResponsiveImage title"
       >
         <Label
@@ -108,62 +122,7 @@ exports[`<ResponsiveImage /> if \`props.label\` is passed should have the right 
         🔷
       </p>
     </Paragraph>
-  </picture>
-</ResponsiveImage>
-`;
-
-exports[`<ResponsiveImage /> if \`props.placeholderImageUrl\` and \`props.imageUrl\` are passed should have the right structure 1`] = `
-<ResponsiveImage
-  alternativeText="Alternative Text 😝"
-  hasRoundedCorners={false}
-  imageHeight={null}
-  imageNotFoundLabelText="Image not found!"
-  imageTitle="ResponsiveImage title"
-  imageUrl="yooo"
-  imageWidth={null}
-  isAvatar={false}
-  isCircular={false}
-  isFluid={true}
-  label={null}
-  onLoad={[Function]}
-  placeholderImageUrl="ayyy"
-  sources={Array []}
->
-  <picture
-    className="responsive-image is-fluid"
-    role="figure"
-  >
-    <div
-      className="image-with-placeholder-container has-blurred-children is-visible"
-    >
-      <Image
-        alt="Alternative Text 😝"
-        as="img"
-        avatar={false}
-        fluid={true}
-        onLoad={[Function]}
-        src="yooo"
-        title="ResponsiveImage title"
-        ui={true}
-      >
-        <img
-          alt="Alternative Text 😝"
-          className="ui fluid image"
-          onLoad={[Function]}
-          src="yooo"
-          title="ResponsiveImage title"
-        />
-      </Image>
-      <div
-        className="placeholder-image-container"
-      >
-        <img
-          className="placeholder-image ui image fluid"
-          src="ayyy"
-        />
-      </div>
-    </div>
-  </picture>
+  </figure>
 </ResponsiveImage>
 `;
 
@@ -182,25 +141,32 @@ exports[`<ResponsiveImage /> if \`props.placeholderImageUrl\` is passed should h
   label={null}
   onLoad={[Function]}
   placeholderImageUrl="ayyy"
+  sizes={null}
   sources={Array []}
+  srcSet={null}
 >
-  <picture
-    className="responsive-image is-fluid"
-    role="figure"
+  <figure
+    className="responsive-image has-blurred-children has-placeholder is-fluid"
   >
     <Image
       alt="Alternative Text 😝"
       as="img"
       avatar={false}
       fluid={true}
+      onLoad={[Function]}
+      sizes={null}
       src=""
+      srcSet={null}
       title="ResponsiveImage title"
       ui={true}
     >
       <div
         alt="Alternative Text 😝"
         className="ui fluid image"
+        onLoad={[Function]}
+        sizes={null}
         src=""
+        srcSet={null}
         title="ResponsiveImage title"
       >
         <Label
@@ -215,78 +181,17 @@ exports[`<ResponsiveImage /> if \`props.placeholderImageUrl\` is passed should h
         </Label>
       </div>
     </Image>
-  </picture>
-</ResponsiveImage>
-`;
-
-exports[`<ResponsiveImage /> if \`props.sources\` is passed should have the right structure 1`] = `
-<ResponsiveImage
-  alternativeText="Alternative Text 😝"
-  hasRoundedCorners={false}
-  imageHeight={null}
-  imageNotFoundLabelText="Image not found!"
-  imageTitle="ResponsiveImage title"
-  imageUrl=""
-  imageWidth={null}
-  isAvatar={false}
-  isCircular={false}
-  isFluid={true}
-  label={null}
-  onLoad={[Function]}
-  sources={
-    Array [
-      Object {
-        "media": "(min-width: 1200px)",
-        "srcset": "https://si5.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=2400&mode=max",
-      },
-      Object {
-        "media": "(min-width: 1024px)",
-        "srcset": "https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max",
-      },
-    ]
-  }
->
-  <picture
-    className="responsive-image is-fluid"
-    role="figure"
-  >
-    <source
-      key="https://si5.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=2400&mode=max0"
-      media="(min-width: 1200px)"
-      srcSet="https://si5.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=2400&mode=max"
-    />
-    <source
-      key="https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max1"
-      media="(min-width: 1024px)"
-      srcSet="https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max"
-    />
     <Image
-      alt="Alternative Text 😝"
       as="img"
-      avatar={false}
       fluid={true}
-      src=""
-      title="ResponsiveImage title"
+      src="ayyy"
       ui={true}
     >
-      <div
-        alt="Alternative Text 😝"
+      <img
         className="ui fluid image"
-        src=""
-        title="ResponsiveImage title"
-      >
-        <Label
-          content="Image not found!"
-        >
-          <div
-            className="ui label"
-            onClick={[Function]}
-          >
-            Image not found!
-          </div>
-        </Label>
-      </div>
+        src="ayyy"
+      />
     </Image>
-  </picture>
+  </figure>
 </ResponsiveImage>
 `;

--- a/src/components/media/ResponsiveImage/component.spec.js
+++ b/src/components/media/ResponsiveImage/component.spec.js
@@ -33,40 +33,9 @@ describe('<ResponsiveImage />', () => {
     });
   });
 
-  describe('if `props.placeholderImageUrl` and `props.imageUrl` are passed', () => {
-    it('should have the right structure', () => {
-      const actual = getResponsiveImage({
-        placeholderImageUrl: 'ayyy',
-        imageUrl: 'yooo',
-      });
-
-      expect(actual).toMatchSnapshot();
-    });
-  });
-
   describe('if `props.label` is passed', () => {
     it('should have the right structure', () => {
       const actual = getResponsiveImage({ label: '🔷' });
-
-      expect(actual).toMatchSnapshot();
-    });
-  });
-
-  describe('if `props.sources` is passed', () => {
-    it('should have the right structure', () => {
-      const sources = [
-        {
-          srcset:
-            'https://si5.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=2400&mode=max',
-          media: '(min-width: 1200px)',
-        },
-        {
-          srcset:
-            'https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max',
-          media: '(min-width: 1024px)',
-        },
-      ];
-      const actual = getResponsiveImage({ sources });
 
       expect(actual).toMatchSnapshot();
     });
@@ -81,7 +50,6 @@ describe('<ResponsiveImage />', () => {
 
       expect(actual).toEqual({
         isImageLoaded: false,
-        isImageLoadedFromCache: false,
         shouldImageLoad: true,
       });
     });
@@ -96,7 +64,6 @@ describe('<ResponsiveImage />', () => {
 
       expect(actual).toEqual({
         isImageLoaded: true,
-        isImageLoadedFromCache: false,
         shouldImageLoad: true,
       });
     });

--- a/src/components/media/ResponsiveImage/utils/__snapshots__/getImageMarkup.spec.js.snap
+++ b/src/components/media/ResponsiveImage/utils/__snapshots__/getImageMarkup.spec.js.snap
@@ -1,19 +1,61 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`\`getImageMarkup\` if no \`imageUrl\` is passed should render the right structure 1`] = `
+<Image
+  alt="someAltText"
+  as="img"
+  avatar={false}
+  fluid={false}
+  onLoad={[Function]}
+  sizes="someSizes"
+  src={null}
+  srcSet="someSrcs"
+  title="someTitle"
+  ui={true}
+>
+  <div
+    alt="someAltText"
+    className="ui image"
+    onLoad={[Function]}
+    sizes="someSizes"
+    src={null}
+    srcSet="someSrcs"
+    title="someTitle"
+  >
+    <Label
+      content="someLabel"
+    >
+      <div
+        className="ui label"
+        onClick={[Function]}
+      >
+        someLabel
+      </div>
+    </Label>
+  </div>
+</Image>
+`;
+
 exports[`\`getImageMarkup\` should render the right structure 1`] = `
 <Image
   alt="someAltText"
   as="img"
   avatar={false}
-  fluid={true}
+  fluid={false}
+  onLoad={[Function]}
+  sizes="someSizes"
   src="someUrl"
+  srcSet="someSrcs"
   title="someTitle"
   ui={true}
 >
   <img
     alt="someAltText"
-    className="ui fluid image"
+    className="ui image"
+    onLoad={[Function]}
+    sizes="someSizes"
     src="someUrl"
+    srcSet="someSrcs"
     title="someTitle"
   />
 </Image>

--- a/src/components/media/ResponsiveImage/utils/__snapshots__/getPlaceHolderImageMarkup.spec.js.snap
+++ b/src/components/media/ResponsiveImage/utils/__snapshots__/getPlaceHolderImageMarkup.spec.js.snap
@@ -1,247 +1,34 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`\`getPlaceholderImageMarkup\` by default should render the right structure 1`] = `
-<div
-  className="image-with-placeholder-container"
->
+exports[`\`getPlaceholderImageMarkup\` if \`isImageLoaded\` is \`false\` should render the right structure 1`] = `
+Array [
   <div
-    className="placeholder-image-container"
-  >
-    <img
-      className="placeholder-image ui image fluid"
-      src="anotherUrl"
-    />
-    <Label
-      content="someLabel"
-    >
-      <div
-        className="ui label"
-        onClick={[Function]}
-      >
-        someLabel
-      </div>
-    </Label>
-  </div>
-</div>
-`;
-
-exports[`\`getPlaceholderImageMarkup\` if \`isImageLoaded === false\` should render the right structure 1`] = `
-<div
-  className="image-with-placeholder-container has-blurred-children"
->
-  <div
-    className="placeholder-image-container"
-  >
-    <img
-      className="placeholder-image ui image fluid"
-      src="anotherUrl"
-    />
-    <Label
-      content="someLabel"
-    >
-      <div
-        className="ui label"
-        onClick={[Function]}
-      >
-        someLabel
-      </div>
-    </Label>
-  </div>
-</div>
-`;
-
-exports[`\`getPlaceholderImageMarkup\` if \`isImageLoadedFromCache === false\` should render the right structure 1`] = `
-<div
-  className="image-with-placeholder-container is-visible"
->
+    style={
+      Object {
+        "paddingBottom": "undefined%",
+      }
+    }
+  />,
   <Image
-    alt="someAltText"
     as="img"
-    avatar={false}
-    fluid={true}
-    onLoad={[Function]}
-    title="someTitle"
-    ui={true}
-  >
-    <div
-      alt="someAltText"
-      className="ui fluid image"
-      onLoad={[Function]}
-      title="someTitle"
-    >
-      <Label
-        content="someLabel"
-      >
-        <div
-          className="ui label"
-          onClick={[Function]}
-        >
-          someLabel
-        </div>
-      </Label>
-    </div>
-  </Image>
-  <div
-    className="placeholder-image-container"
-  >
-    <img
-      className="placeholder-image ui image fluid"
-      src="anotherUrl"
-    />
-    <Label
-      content="someLabel"
-    >
-      <div
-        className="ui label"
-        onClick={[Function]}
-      >
-        someLabel
-      </div>
-    </Label>
-  </div>
-</div>
-`;
-
-exports[`\`getPlaceholderImageMarkup\` if \`isImageLoadedFromCache === true\` should render the right structure 1`] = `
-<div
-  className="image-with-placeholder-container is-visible"
->
-  <Image
-    alt="someAltText"
-    as="img"
-    avatar={false}
-    fluid={true}
-    onLoad={[Function]}
-    title="someTitle"
-    ui={true}
-  >
-    <div
-      alt="someAltText"
-      className="ui fluid image"
-      onLoad={[Function]}
-      title="someTitle"
-    >
-      <Label
-        content="someLabel"
-      >
-        <div
-          className="ui label"
-          onClick={[Function]}
-        >
-          someLabel
-        </div>
-      </Label>
-    </div>
-  </Image>
-</div>
-`;
-
-exports[`\`getPlaceholderImageMarkup\` if \`shouldImageLoad === false\` should render the right structure 1`] = `
-<div
-  className="image-with-placeholder-container"
->
-  <div
-    className="placeholder-image-container"
-  >
-    <img
-      className="placeholder-image ui image fluid"
-      src="anotherUrl"
-    />
-    <Label
-      content="someLabel"
-    >
-      <div
-        className="ui label"
-        onClick={[Function]}
-      >
-        someLabel
-      </div>
-    </Label>
-  </div>
-</div>
-`;
-
-exports[`\`getPlaceholderImageMarkup\` if \`shouldImageLoad === true\` if \`imageUrl\` is passed should render the right structure 1`] = `
-<div
-  className="image-with-placeholder-container is-visible"
->
-  <Image
-    alt="someAltText"
-    as="img"
-    avatar={false}
-    fluid={true}
-    onLoad={[Function]}
-    src="yoyoUrl"
-    title="someTitle"
+    fluid={false}
+    src="anotherUrl"
     ui={true}
   >
     <img
-      alt="someAltText"
-      className="ui fluid image"
-      onLoad={[Function]}
-      src="yoyoUrl"
-      title="someTitle"
-    />
-  </Image>
-  <div
-    className="placeholder-image-container"
-  >
-    <img
-      className="placeholder-image ui image fluid"
+      className="ui image"
       src="anotherUrl"
     />
-  </div>
-</div>
+  </Image>,
+]
 `;
 
-exports[`\`getPlaceholderImageMarkup\` if \`shouldImageLoad === true\` should render the right structure 1`] = `
+exports[`\`getPlaceholderImageMarkup\` if \`isImageLoaded\` is \`true\` should render the right structure 1`] = `
 <div
-  className="image-with-placeholder-container is-visible"
->
-  <Image
-    alt="someAltText"
-    as="img"
-    avatar={false}
-    fluid={true}
-    onLoad={[Function]}
-    title="someTitle"
-    ui={true}
-  >
-    <div
-      alt="someAltText"
-      className="ui fluid image"
-      onLoad={[Function]}
-      title="someTitle"
-    >
-      <Label
-        content="someLabel"
-      >
-        <div
-          className="ui label"
-          onClick={[Function]}
-        >
-          someLabel
-        </div>
-      </Label>
-    </div>
-  </Image>
-  <div
-    className="placeholder-image-container"
-  >
-    <img
-      className="placeholder-image ui image fluid"
-      src="anotherUrl"
-    />
-    <Label
-      content="someLabel"
-    >
-      <div
-        className="ui label"
-        onClick={[Function]}
-      >
-        someLabel
-      </div>
-    </Label>
-  </div>
-</div>
+  style={
+    Object {
+      "paddingBottom": "undefined%",
+    }
+  }
+/>
 `;

--- a/src/components/media/ResponsiveImage/utils/getImageMarkup.js
+++ b/src/components/media/ResponsiveImage/utils/getImageMarkup.js
@@ -12,24 +12,33 @@ import { getIsFluid } from './getIsFluid';
  * @param  {string}        imageProps.imageUrl
  * @param  {number|string} imageProps.imageWidth
  * @param  {boolean}       imageProps.isAvatar
- * @return {Function}
+ * @param  {Function}      handleImageLoad
+ * @return {Object}
  */
-export const getImageMarkup = ({
-  /* eslint-disable react/prop-types */
-  alternativeText,
-  imageHeight,
-  imageNotFoundLabelText,
-  imageTitle,
-  imageUrl,
-  imageWidth,
-  isAvatar,
-  /* eslint-enable react/prop-types */
-}) => (
+export const getImageMarkup = (
+  {
+    /* eslint-disable react/prop-types */
+    alternativeText,
+    imageHeight,
+    imageNotFoundLabelText,
+    imageTitle,
+    imageUrl,
+    imageWidth,
+    isAvatar,
+    sizes,
+    srcSet,
+    /* eslint-enable react/prop-types */
+  },
+  handleImageLoad
+) => (
   <Image
     alt={alternativeText}
     avatar={isAvatar}
     fluid={getIsFluid(imageWidth, imageHeight)}
+    onLoad={handleImageLoad}
+    sizes={sizes}
     src={imageUrl}
+    srcSet={srcSet}
     title={imageTitle}
   >
     {!imageUrl ? <Label content={imageNotFoundLabelText} /> : null}

--- a/src/components/media/ResponsiveImage/utils/getImageMarkup.spec.js
+++ b/src/components/media/ResponsiveImage/utils/getImageMarkup.spec.js
@@ -2,20 +2,34 @@ import { mount } from 'enzyme';
 
 import { getImageMarkup } from './getImageMarkup';
 
-const getImage = () => mount(getImageMarkup(imageProps));
-
-const imageProps = {
+const props = {
   alternativeText: 'someAltText',
-  isAvatar: false,
+  imageHeight: 'someHeight',
+  imageNotFoundLabelText: 'someLabel',
   imageTitle: 'someTitle',
   imageUrl: 'someUrl',
-  imageNotFoundLabelText: 'someLabel',
+  imageWidth: 'someWidth',
+  isAvatar: false,
+  sizes: 'someSizes',
+  srcSet: 'someSrcs',
 };
+const handleImageLoad = () => {};
+
+const getImage = extraProps =>
+  mount(getImageMarkup({ ...props, ...extraProps }, handleImageLoad));
 
 describe('`getImageMarkup`', () => {
   it('should render the right structure', () => {
     const actual = getImage();
 
     expect(actual).toMatchSnapshot();
+  });
+
+  describe('if no `imageUrl` is passed', () => {
+    it('should render the right structure', () => {
+      const actual = getImage({ imageUrl: null });
+
+      expect(actual).toMatchSnapshot();
+    });
   });
 });

--- a/src/components/media/ResponsiveImage/utils/getPlaceHolderImageMarkup.spec.js
+++ b/src/components/media/ResponsiveImage/utils/getPlaceHolderImageMarkup.spec.js
@@ -2,82 +2,27 @@ import { mount } from 'enzyme';
 
 import { getPlaceholderImageMarkup } from './getPlaceholderImageMarkup';
 
-const getPlaceholderImage = extraProps =>
-  mount(getPlaceholderImageMarkup({ ...imageProps, ...extraProps }));
-
-const imageProps = {
-  alternativeText: 'someAltText',
-  handleImageLoad: Function.prototype,
-  imageNotFoundLabelText: 'someLabel',
-  imageTitle: 'someTitle',
-  isAvatar: false,
-  isImageLoaded: true,
+const props = {
+  imageHeight: 'someHeight',
+  imageWidth: 'someWidth',
   placeholderImageUrl: 'anotherUrl',
 };
 
+const getPlaceholderImage = isImageLoaded =>
+  mount(getPlaceholderImageMarkup(props, isImageLoaded));
+
 describe('`getPlaceholderImageMarkup`', () => {
-  describe('by default', () => {
+  describe('if `isImageLoaded` is `false`', () => {
     it('should render the right structure', () => {
-      const actual = getPlaceholderImage();
+      const actual = getPlaceholderImage(false);
 
       expect(actual).toMatchSnapshot();
     });
   });
 
-  describe('if `shouldImageLoad === true`', () => {
-    const getPlaceholderWithImageLoad = extraProps =>
-      getPlaceholderImage({ shouldImageLoad: true, ...extraProps });
-
+  describe('if `isImageLoaded` is `true`', () => {
     it('should render the right structure', () => {
-      const actual = getPlaceholderWithImageLoad();
-
-      expect(actual).toMatchSnapshot();
-    });
-
-    describe('if `imageUrl` is passed', () => {
-      it('should render the right structure', () => {
-        const actual = getPlaceholderWithImageLoad({
-          imageUrl: 'yoyoUrl',
-        });
-
-        expect(actual).toMatchSnapshot();
-      });
-    });
-  });
-
-  describe('if `shouldImageLoad === false`', () => {
-    it('should render the right structure', () => {
-      const actual = getPlaceholderImage({ shouldImageLoad: false });
-
-      expect(actual).toMatchSnapshot();
-    });
-  });
-
-  describe('if `isImageLoaded === false`', () => {
-    it('should render the right structure', () => {
-      const actual = getPlaceholderImage({ isImageLoaded: false });
-
-      expect(actual).toMatchSnapshot();
-    });
-  });
-
-  describe('if `isImageLoadedFromCache === true`', () => {
-    it('should render the right structure', () => {
-      const actual = getPlaceholderImage({
-        isImageLoadedFromCache: true,
-        shouldImageLoad: true,
-      });
-
-      expect(actual).toMatchSnapshot();
-    });
-  });
-
-  describe('if `isImageLoadedFromCache === false`', () => {
-    it('should render the right structure', () => {
-      const actual = getPlaceholderImage({
-        isImageLoadedFromCache: false,
-        shouldImageLoad: true,
-      });
+      const actual = getPlaceholderImage(true);
 
       expect(actual).toMatchSnapshot();
     });

--- a/src/components/media/ResponsiveImage/utils/getPlaceholderImageMarkup.js
+++ b/src/components/media/ResponsiveImage/utils/getPlaceholderImageMarkup.js
@@ -1,71 +1,34 @@
-import React from 'react';
-import { Image, Label } from 'semantic-ui-react';
-import getClassNames from 'classnames';
+import React, { Fragment } from 'react';
+import { Image } from 'semantic-ui-react';
 
 import { getIsFluid } from './getIsFluid';
 import { getAspectRatioPlaceholderMarkup } from './getAspectRatioPlaceholderMarkup';
 
 /**
  * @param  {Object}        imageProps
- * @param  {string}        imageProps.alternativeText
- * @param  {Function}      imageProps.handleImageLoad
  * @param  {string|number} imageProps.imageHeight
- * @param  {string}        imageProps.imageNotFoundLabelText
- * @param  {string}        imageProps.imageTitle
- * @param  {string}        imageProps.imageUrl
  * @param  {string|number} imageProps.imageWidth
- * @param  {boolean}       imageProps.isAvatar
- * @param  {boolean}       imageProps.isImageLoaded
- * @param  {boolean}       imageProps.isImageLoadedFromCache
  * @param  {string}        imageProps.placeholderImageUrl
- * @param  {boolean}       imageProps.shouldImageLoad
- * @return {Function}
+ * @param  {boolean}       isImageLoaded
+ * @return {Object}
  */
-export const getPlaceholderImageMarkup = ({
-  /* eslint-disable react/prop-types */
-  alternativeText,
-  handleImageLoad,
-  imageHeight,
-  imageNotFoundLabelText,
-  imageTitle,
-  imageUrl,
-  imageWidth,
-  isAvatar,
-  isImageLoaded,
-  isImageLoadedFromCache,
-  placeholderImageUrl,
-  shouldImageLoad,
-  /* eslint-enable react/prop-types */
-}) => (
-  <div
-    className={getClassNames('image-with-placeholder-container', {
-      'has-blurred-children': !isImageLoaded && !isImageLoadedFromCache,
-      'is-visible': shouldImageLoad,
-    })}
-  >
+export const getPlaceholderImageMarkup = (
+  {
+    /* eslint-disable react/prop-types */
+    imageHeight,
+    imageWidth,
+    placeholderImageUrl,
+    /* eslint-enable react/prop-types */
+  },
+  isImageLoaded
+) => (
+  <Fragment>
     {getAspectRatioPlaceholderMarkup(imageWidth, imageHeight)}
-    {shouldImageLoad && (
+    {!isImageLoaded && (
       <Image
-        alt={alternativeText}
-        avatar={isAvatar}
         fluid={getIsFluid(imageWidth, imageHeight)}
-        onLoad={handleImageLoad}
-        src={imageUrl}
-        title={imageTitle}
-      >
-        {!imageUrl ? <Label content={imageNotFoundLabelText} /> : null}
-      </Image>
+        src={placeholderImageUrl}
+      />
     )}
-    {!isImageLoadedFromCache && (
-      <div className="placeholder-image-container">
-        <img
-          className={getClassNames('placeholder-image', {
-            'ui image fluid': getIsFluid(imageWidth, imageHeight),
-          })}
-          src={placeholderImageUrl}
-        />
-        {!imageUrl && <Label content={imageNotFoundLabelText} />}
-      </div>
-    )}
-  </div>
+  </Fragment>
 );

--- a/src/components/property-page-widgets/Pictures/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Pictures/__snapshots__/component.spec.js.snap
@@ -823,7 +823,8 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                                 isCircular={false}
                                 isFluid={false}
                                 label={null}
-                                sources={Array []}
+                                sizes={null}
+                                srcSet={null}
                               />
                               <Divider
                                 className=""
@@ -854,7 +855,8 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                                 isCircular={false}
                                 isFluid={false}
                                 label={null}
-                                sources={Array []}
+                                sizes={null}
+                                srcSet={null}
                               />
                               <Divider
                                 className=""
@@ -885,7 +887,8 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                                 isCircular={false}
                                 isFluid={false}
                                 label={null}
-                                sources={Array []}
+                                sizes={null}
+                                srcSet={null}
                               />
                               <Divider
                                 className=""
@@ -916,7 +919,8 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                                 isCircular={false}
                                 isFluid={false}
                                 label={null}
-                                sources={Array []}
+                                sizes={null}
+                                srcSet={null}
                               />
                               <Divider
                                 className=""
@@ -947,7 +951,8 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                                 isCircular={false}
                                 isFluid={false}
                                 label={null}
-                                sources={Array []}
+                                sizes={null}
+                                srcSet={null}
                               />
                               <Divider
                                 className=""

--- a/src/components/property-page-widgets/Pictures/component.js
+++ b/src/components/property-page-widgets/Pictures/component.js
@@ -80,21 +80,8 @@ Component.propTypes = {
   headingText: PropTypes.string,
   /** The text to display on the link at the bottom of the widget. */
   linkText: PropTypes.string,
-  /** The pictures to display as responsive images. */
-  pictures: PropTypes.arrayOf(
-    PropTypes.shape({
-      /** The natural height of the image in px. */
-      imageHeight: PropTypes.number,
-      /** URL pointing to the image to display. */
-      imageUrl: PropTypes.string.isRequired,
-      /** The natural width of the image in px. */
-      imageWidth: PropTypes.number,
-      /** A visible label for the image. */
-      label: PropTypes.string.isRequired,
-      /** URL pointing to the image to display. */
-      placeholderImageUrl: PropTypes.string,
-    })
-  ).isRequired,
+  /** The pictures to display. See [the `ResponsiveImage` component for valid props](#/Media/ResponsiveImage).  */
+  pictures: PropTypes.arrayOf(PropTypes.object).isRequired,
   /** The name of the property to display in the gallery modal. */
   propertyName: PropTypes.string,
   /** The numeral rating for the property, out of 5 */

--- a/src/styles/semantic/themes/livingstone/elements/image.overrides
+++ b/src/styles/semantic/themes/livingstone/elements/image.overrides
@@ -14,58 +14,41 @@
       Variations
 --------------------*/
 
-/* Placeholder image */
+/* Responsive Image */
 
-.image-with-placeholder-container {
-  position: relative;
-  display: inline-block;
+figure.responsive-image {
+  margin: 0;
   overflow: hidden;
-  width: 100%;
-  height: 100%;
-  opacity: 0;
-  transition: @imageWithPlaceholderContainerTransition;
+  position: relative;
 
-  &.is-visible {
-    opacity: 1;
+  > .ui.image {
+    transform: none;
+    transition: @imageWithPlaceholderTransition;
   }
 
   &.has-blurred-children {
 
-    > img,
-    .placeholder-image-container {
-      opacity: 1;
+    > .ui.image {
       filter: @imageWithPlaceholderBlur;
       -ms-filter: @imageWithPlaceholderBlur;
       transform: @imageWithPlaceholderTransformScale;
     }
   }
 
-  .placeholder-image-container {
-    opacity: 0;
+  &.has-placeholder {
+
+    > .ui.image {
+      height: 100%;
+      left: 0;
+      position: absolute;
+      top: 0;
+      width: 100%;
+    }
   }
-
-  .placeholder-image-container,
-  .placeholder-image,
-  img.ui.image {
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    width: 100%;
-    transition: @imageWithPlaceholderTransition;
-  }
-}
-
-/* Responsive Image */
-
-picture.responsive-image {
 
   &.is-fluid {
     height: 100%;
     width: 100%;
-    position: relative;
-    overflow: hidden;
 
     /* Object fit cover Fallback */
     .ui.fluid.image {
@@ -79,18 +62,10 @@ picture.responsive-image {
       transform: translate(-50%, -50%);
     }
 
-    .image-with-placeholder-container {
+    &.has-blurred-children {
 
-      .ui.fluid.image {
-        width: auto;
-        max-width: none;
-      }
-
-      &.has-blurred-children {
-
-        > .ui.fluid.image {
-          transform: translate(-50%, -50%) @imageWithPlaceholderTransformScale;
-        }
+      > .ui.fluid.image {
+        transform: translate(-50%, -50%) @imageWithPlaceholderTransformScale;
       }
     }
 
@@ -104,18 +79,10 @@ picture.responsive-image {
         transform: none;
       }
 
-      .image-with-placeholder-container {
+      &.has-blurred-children {
 
-        .ui.fluid.image {
-          width: inherit;
-          max-width: inherit;
-        }
-
-        &.has-blurred-children {
-
-          > .ui.fluid.image {
-            transform: @imageWithPlaceholderTransformScale;
-          }
+        > .ui.fluid.image {
+          transform: @imageWithPlaceholderTransformScale;
         }
       }
     }

--- a/src/styles/semantic/themes/livingstone/elements/segment.overrides
+++ b/src/styles/semantic/themes/livingstone/elements/segment.overrides
@@ -115,8 +115,7 @@
   height: ~"calc(100vh - var(@{fullBleedBottomOffsetIdentifier}, 0))";
   padding: 0;
 
-  picture.responsive-image,
-  .image-with-placeholder-container {
+  figure.responsive-image {
     position: absolute;
     top: 0;
     bottom: 0;
@@ -167,7 +166,7 @@
     padding: 0;
   }
 
-  .responsive-image img {
+  .responsive-image .ui.image {
     min-height: 100%;
   }
 
@@ -209,7 +208,7 @@
       p,
       p + .button,
       .header,
-      > picture.responsive-image .ui.image {
+      > figure.responsive-image .ui.image {
         filter: @promotionHoverBlur;
         -ms-filter: @promotionHoverBlur;
         pointer-events: none;
@@ -247,7 +246,7 @@
       z-index: @promotionAfterLayerZIndex;
     }
 
-    > picture.responsive-image {
+    > figure.responsive-image {
       z-index: @promotionBeforeLayerZIndex;
       position: absolute;
       top: 0;
@@ -259,7 +258,7 @@
     p,
     .button,
     &:after,
-    > picture.responsive-image .ui.image,
+    > figure.responsive-image .ui.image,
     .ui.header {
       transition: filter @promotionOverlayTransitionTime, -ms-filter @promotionOverlayTransitionTime;
     }


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1489)

### What **one** thing does this PR do?
Switches `source` for `srcSet` in `ResponsiveImage`. This removes the awkward `picture` element and plays nicely with the graceful loading functionality.

##### Graceful loading with `srcSet`

![graceful](https://user-images.githubusercontent.com/8591501/49030398-8059c780-f1a7-11e8-9eda-8d1621174433.gif)

##### Different sources loading for different screen sizes (see 'currentSrc')

![screenshot 2018-11-26 at 17 10 07](https://user-images.githubusercontent.com/8591501/49030407-8485e500-f1a7-11e8-8b94-f6f7a000d703.png)

![screenshot 2018-11-26 at 17 09 17](https://user-images.githubusercontent.com/8591501/49030408-8485e500-f1a7-11e8-9c50-05d262bb6803.png)

