### PR TITLE
TE-1533 Pictures: use imageUrl to build key

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "build:js": "BABEL_ENV=production babel src/ -d lib/",
     "commit": "git-cz",
     "install:peers": "npm install react@^16.3.2 react-dom@^16.3.2 moment@^2.18.1 --no-save",
-    "lint": "run-p lint:js lint:less",
+    "lint": "run-p lint:js:fix lint:less",
     "lint:js": "eslint . --ext .js,.jsx",
     "lint:js:debug": "npm run lint:js -- --debug",
     "lint:js:fix": "npm run lint:js -- --fix",

--- a/src/components/property-page-widgets/Pictures/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Pictures/__snapshots__/component.spec.js.snap
@@ -88,7 +88,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
               className="left aligned row"
             >
               <GridColumn
-                key="Entrance0"
+                key="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max0"
                 verticalAlignContent="top"
                 width={null}
               >
@@ -278,7 +278,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                 </GridColumn>
               </GridColumn>
               <GridColumn
-                key="Kitchen1"
+                key="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max1"
                 verticalAlignContent="top"
                 width={null}
               >
@@ -468,7 +468,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                 </GridColumn>
               </GridColumn>
               <GridColumn
-                key="Living room2"
+                key="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max2"
                 verticalAlignContent="top"
                 width={null}
               >
@@ -658,7 +658,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                 </GridColumn>
               </GridColumn>
               <GridColumn
-                key="Studio3"
+                key="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max3"
                 verticalAlignContent="top"
                 width={null}
               >
@@ -848,7 +848,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                 </GridColumn>
               </GridColumn>
               <GridColumn
-                key="Garden room4"
+                key="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max4"
                 verticalAlignContent="top"
                 width={null}
               >

--- a/src/components/property-page-widgets/Pictures/component.js
+++ b/src/components/property-page-widgets/Pictures/component.js
@@ -33,7 +33,7 @@ export const Component = ({
     <GridRow>
       {getFirstSixItems(pictures).map(
         ({ imageUrl, imageSizes, imageSrcSet, label }, index) => (
-          <GridColumn key={buildKeyFromStrings(label, index)}>
+          <GridColumn key={buildKeyFromStrings(imageUrl, index)}>
             <ShowOn computer parent="div" tablet widescreen>
               <Thumbnail
                 imageSizes={imageSizes}


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-X)

### What **one** thing does this PR do?
Use `props.pictures.imageUrl`, which is required by the child `Thumbnail` to build key.

### Any other notes
This will fix the following breaking bug in staging:

```
Uncaught TypeError: Cannot read property 'toString' of undefined
    at buildKeyFromStrings.js:14
    at Array.map (<anonymous>)
    at buildKeyFromStrings (buildKeyFromStrings.js:13)
    at component.js:58
    at Array.map (<anonymous>)
    at Component (component.js:52)
    at mountIndeterminateComponent (react-dom.development.js:14563)
    at beginWork (react-dom.development.js:15063)
    at performUnitOfWork (react-dom.development.js:17820)
    at workLoop (react-dom.development.js:17860)
```
