### PR TITLE
TE-1538 ShowOn: remove `display: flex`

### DIFF
--- a/src/components/collections/Header/__snapshots__/component.spec.js.snap
+++ b/src/components/collections/Header/__snapshots__/component.spec.js.snap
@@ -101,11 +101,11 @@ exports[`<Header /> by default should render the right structure 1`] = `
               widescreen={false}
             >
               <MenuMenu
-                className="hide-on-all-devices show-on-mobile"
+                className="show-on-mobile"
                 position="right"
               >
                 <div
-                  className="right menu hide-on-all-devices show-on-mobile"
+                  className="right menu show-on-mobile"
                 >
                   <MenuItem>
                     <div
@@ -329,11 +329,11 @@ exports[`<Header /> by default should render the right structure 1`] = `
               widescreen={true}
             >
               <MenuMenu
-                className="hide-on-all-devices show-on-tablet show-on-computer show-on-widescreen"
+                className="show-on-tablet show-on-computer show-on-widescreen"
                 position="right"
               >
                 <div
-                  className="right menu hide-on-all-devices show-on-tablet show-on-computer show-on-widescreen"
+                  className="right menu show-on-tablet show-on-computer show-on-widescreen"
                 >
                   <MenuItem
                     active={false}
@@ -741,11 +741,11 @@ exports[`<Header /> if \`props.isBackgroundFilled\` is true should render the ri
               widescreen={false}
             >
               <MenuMenu
-                className="hide-on-all-devices show-on-mobile"
+                className="show-on-mobile"
                 position="right"
               >
                 <div
-                  className="right menu hide-on-all-devices show-on-mobile"
+                  className="right menu show-on-mobile"
                 >
                   <MenuItem>
                     <div
@@ -969,11 +969,11 @@ exports[`<Header /> if \`props.isBackgroundFilled\` is true should render the ri
               widescreen={true}
             >
               <MenuMenu
-                className="hide-on-all-devices show-on-tablet show-on-computer show-on-widescreen"
+                className="show-on-tablet show-on-computer show-on-widescreen"
                 position="right"
               >
                 <div
-                  className="right menu hide-on-all-devices show-on-tablet show-on-computer show-on-widescreen"
+                  className="right menu show-on-tablet show-on-computer show-on-widescreen"
                 >
                   <MenuItem
                     active={false}

--- a/src/components/collections/Header/utils/__snapshots__/getDesktopMenuMarkup.spec.js.snap
+++ b/src/components/collections/Header/utils/__snapshots__/getDesktopMenuMarkup.spec.js.snap
@@ -15,11 +15,11 @@ exports[`getDesktopMenuMarkup by default should render the right structure 1`] =
     widescreen={true}
   >
     <MenuMenu
-      className="hide-on-all-devices show-on-tablet show-on-computer show-on-widescreen"
+      className="show-on-tablet show-on-computer show-on-widescreen"
       position="right"
     >
       <div
-        className="right menu hide-on-all-devices show-on-tablet show-on-computer show-on-widescreen"
+        className="right menu show-on-tablet show-on-computer show-on-widescreen"
       >
         <MenuItem
           active={false}
@@ -336,11 +336,11 @@ exports[`getDesktopMenuMarkup if \`props.primaryCTA\` is passed should render th
     widescreen={true}
   >
     <MenuMenu
-      className="hide-on-all-devices show-on-tablet show-on-computer show-on-widescreen"
+      className="show-on-tablet show-on-computer show-on-widescreen"
       position="right"
     >
       <div
-        className="right menu hide-on-all-devices show-on-tablet show-on-computer show-on-widescreen"
+        className="right menu show-on-tablet show-on-computer show-on-widescreen"
       >
         <MenuItem
           active={false}

--- a/src/components/collections/Header/utils/__snapshots__/getMobileMenuMarkup.spec.js.snap
+++ b/src/components/collections/Header/utils/__snapshots__/getMobileMenuMarkup.spec.js.snap
@@ -14,11 +14,11 @@ exports[`getMobileMenuMarkup by default should render the right structure 1`] = 
   widescreen={false}
 >
   <MenuMenu
-    className="hide-on-all-devices show-on-mobile"
+    className="show-on-mobile"
     position="right"
   >
     <div
-      className="right menu hide-on-all-devices show-on-mobile"
+      className="right menu show-on-mobile"
     >
       <MenuItem>
         <div
@@ -244,11 +244,11 @@ exports[`getMobileMenuMarkup if \`props.searchBarGuestsOptions\` and \`props.sea
   widescreen={false}
 >
   <MenuMenu
-    className="hide-on-all-devices show-on-mobile"
+    className="show-on-mobile"
     position="right"
   >
     <div
-      className="right menu hide-on-all-devices show-on-mobile"
+      className="right menu show-on-mobile"
     >
       <MenuItem>
         <div

--- a/src/components/collections/Hero/__snapshots__/component.spec.js.snap
+++ b/src/components/collections/Hero/__snapshots__/component.spec.js.snap
@@ -208,11 +208,11 @@ exports[`<Hero /> by default should render the right structure 1`] = `
                       widescreen={false}
                     >
                       <MenuMenu
-                        className="hide-on-all-devices show-on-mobile"
+                        className="show-on-mobile"
                         position="right"
                       >
                         <div
-                          className="right menu hide-on-all-devices show-on-mobile"
+                          className="right menu show-on-mobile"
                         >
                           <MenuItem>
                             <div
@@ -677,11 +677,11 @@ exports[`<Hero /> by default should render the right structure 1`] = `
                       widescreen={true}
                     >
                       <MenuMenu
-                        className="hide-on-all-devices show-on-tablet show-on-computer show-on-widescreen"
+                        className="show-on-tablet show-on-computer show-on-widescreen"
                         position="right"
                       >
                         <div
-                          className="right menu hide-on-all-devices show-on-tablet show-on-computer show-on-widescreen"
+                          className="right menu show-on-tablet show-on-computer show-on-widescreen"
                         >
                           <MenuItem
                             active={false}

--- a/src/components/elements/Submenu/component.spec.js
+++ b/src/components/elements/Submenu/component.spec.js
@@ -6,6 +6,7 @@ import {
   expectComponentToHaveDisplayName,
   expectComponentToHaveProps,
 } from '@lodgify/enzyme-jest-expect-helpers';
+
 import { Icon, ICON_NAMES } from 'elements/Icon';
 
 import { Component as Submenu } from './component';

--- a/src/components/general-widgets/HomepageHero/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/HomepageHero/__snapshots__/component.spec.js.snap
@@ -268,11 +268,11 @@ exports[`HomepageHero by default should render the right structure 1`] = `
                         widescreen={false}
                       >
                         <MenuMenu
-                          className="hide-on-all-devices show-on-mobile"
+                          className="show-on-mobile"
                           position="right"
                         >
                           <div
-                            className="right menu hide-on-all-devices show-on-mobile"
+                            className="right menu show-on-mobile"
                           >
                             <MenuItem>
                               <div
@@ -715,11 +715,11 @@ exports[`HomepageHero by default should render the right structure 1`] = `
                         widescreen={true}
                       >
                         <MenuMenu
-                          className="hide-on-all-devices show-on-tablet show-on-computer show-on-widescreen"
+                          className="show-on-tablet show-on-computer show-on-widescreen"
                           position="right"
                         >
                           <div
-                            className="right menu hide-on-all-devices show-on-tablet show-on-computer show-on-widescreen"
+                            className="right menu show-on-tablet show-on-computer show-on-widescreen"
                           >
                             <MenuItem
                               active={false}
@@ -842,13 +842,13 @@ exports[`HomepageHero by default should render the right structure 1`] = `
                 widescreen={true}
               >
                 <HorizontalGutters
-                  className="hide-on-all-devices show-on-tablet show-on-computer show-on-widescreen"
+                  className="show-on-tablet show-on-computer show-on-widescreen"
                 >
                   <Container
-                    className="hide-on-all-devices show-on-tablet show-on-computer show-on-widescreen"
+                    className="show-on-tablet show-on-computer show-on-widescreen"
                   >
                     <div
-                      className="ui container hide-on-all-devices show-on-tablet show-on-computer show-on-widescreen"
+                      className="ui container show-on-tablet show-on-computer show-on-widescreen"
                     >
                       <Grid
                         areColumnsCentered={true}

--- a/src/components/general-widgets/Promotion/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/Promotion/__snapshots__/component.spec.js.snap
@@ -145,19 +145,19 @@ exports[`The \`Promotion\` component should have the right structure 1`] = `
                                       widescreen={true}
                                     >
                                       <GridColumn
-                                        className="hide-on-all-devices show-on-tablet show-on-computer show-on-widescreen"
+                                        className="show-on-tablet show-on-computer show-on-widescreen"
                                         textAlign="left"
                                         verticalAlignContent="top"
                                         width={12}
                                       >
                                         <GridColumn
-                                          className="hide-on-all-devices show-on-tablet show-on-computer show-on-widescreen"
+                                          className="show-on-tablet show-on-computer show-on-widescreen"
                                           textAlign="left"
                                           verticalAlign="top"
                                           width={12}
                                         >
                                           <div
-                                            className="left aligned top aligned twelve wide column hide-on-all-devices show-on-tablet show-on-computer show-on-widescreen"
+                                            className="left aligned top aligned twelve wide column show-on-tablet show-on-computer show-on-widescreen"
                                           >
                                             <Heading
                                               isColorInverted={false}
@@ -194,19 +194,19 @@ exports[`The \`Promotion\` component should have the right structure 1`] = `
                                       widescreen={false}
                                     >
                                       <GridColumn
-                                        className="hide-on-all-devices show-on-mobile"
+                                        className="show-on-mobile"
                                         textAlign="center"
                                         verticalAlignContent="top"
                                         width={12}
                                       >
                                         <GridColumn
-                                          className="hide-on-all-devices show-on-mobile"
+                                          className="show-on-mobile"
                                           textAlign="center"
                                           verticalAlign="top"
                                           width={12}
                                         >
                                           <div
-                                            className="center aligned top aligned twelve wide column hide-on-all-devices show-on-mobile"
+                                            className="center aligned top aligned twelve wide column show-on-mobile"
                                           >
                                             <Heading
                                               isColorInverted={false}
@@ -245,15 +245,15 @@ exports[`The \`Promotion\` component should have the right structure 1`] = `
                                 widescreen={true}
                               >
                                 <GridRow
-                                  className="book-now-button-container hide-on-all-devices show-on-tablet show-on-computer show-on-widescreen"
+                                  className="book-now-button-container show-on-tablet show-on-computer show-on-widescreen"
                                   horizontalAlignContent="left"
                                 >
                                   <GridRow
-                                    className="book-now-button-container hide-on-all-devices show-on-tablet show-on-computer show-on-widescreen"
+                                    className="book-now-button-container show-on-tablet show-on-computer show-on-widescreen"
                                     textAlign="left"
                                   >
                                     <div
-                                      className="left aligned row book-now-button-container hide-on-all-devices show-on-tablet show-on-computer show-on-widescreen"
+                                      className="left aligned row book-now-button-container show-on-tablet show-on-computer show-on-widescreen"
                                     >
                                       <GridColumn
                                         textAlign="center"
@@ -321,17 +321,17 @@ exports[`The \`Promotion\` component should have the right structure 1`] = `
                                 widescreen={false}
                               >
                                 <GridRow
-                                  className="hide-on-all-devices show-on-mobile"
+                                  className="show-on-mobile"
                                   horizontalAlignContent="left"
                                   verticalAlign="top"
                                 >
                                   <GridRow
-                                    className="hide-on-all-devices show-on-mobile"
+                                    className="show-on-mobile"
                                     textAlign="left"
                                     verticalAlign="top"
                                   >
                                     <div
-                                      className="left aligned top aligned row hide-on-all-devices show-on-mobile"
+                                      className="left aligned top aligned row show-on-mobile"
                                     >
                                       <GridColumn
                                         floated="right"
@@ -414,17 +414,17 @@ exports[`The \`Promotion\` component should have the right structure 1`] = `
                                 widescreen={false}
                               >
                                 <GridRow
-                                  className="hide-on-all-devices show-on-tablet show-on-computer"
+                                  className="show-on-tablet show-on-computer"
                                   horizontalAlignContent="left"
                                   verticalAlign="bottom"
                                 >
                                   <GridRow
-                                    className="hide-on-all-devices show-on-tablet show-on-computer"
+                                    className="show-on-tablet show-on-computer"
                                     textAlign="left"
                                     verticalAlign="bottom"
                                   >
                                     <div
-                                      className="left aligned bottom aligned row hide-on-all-devices show-on-tablet show-on-computer"
+                                      className="left aligned bottom aligned row show-on-tablet show-on-computer"
                                     >
                                       <GridColumn
                                         floated="right"

--- a/src/components/layout/ShowOn/__snapshots__/component.spec.js.snap
+++ b/src/components/layout/ShowOn/__snapshots__/component.spec.js.snap
@@ -1,43 +1,76 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<ShowOn /> if all devices are set as false should only return \`hide-on-all-devices\` as default class for the wrapper 1`] = `
+exports[`<ShowOn /> if \`props.computer\` is \`true\` should render the right structure 1`] = `
 <ShowOn
-  computer={false}
+  computer={true}
   mobile={false}
-  parent="section"
-  parentProps={
-    Object {
-      "className": "",
-    }
-  }
+  parent="div"
+  parentProps={Object {}}
   tablet={false}
   widescreen={false}
 >
-  <section
-    className="hide-on-all-devices"
-  >
-    div
-  </section>
+  <div
+    className="show-on-computer"
+  />
 </ShowOn>
 `;
 
-exports[`<ShowOn /> it should render the right structure 1`] = `
+exports[`<ShowOn /> if \`props.mobile\` is \`true\` should render the right structure 1`] = `
 <ShowOn
-  computer={true}
+  computer={false}
   mobile={true}
-  parent="section"
-  parentProps={
-    Object {
-      "className": "",
-    }
-  }
+  parent="div"
+  parentProps={Object {}}
+  tablet={false}
+  widescreen={false}
+>
+  <div
+    className="show-on-mobile"
+  />
+</ShowOn>
+`;
+
+exports[`<ShowOn /> if \`props.tablet\` is \`true\` should render the right structure 1`] = `
+<ShowOn
+  computer={false}
+  mobile={false}
+  parent="div"
+  parentProps={Object {}}
   tablet={true}
+  widescreen={false}
+>
+  <div
+    className="show-on-tablet"
+  />
+</ShowOn>
+`;
+
+exports[`<ShowOn /> if \`props.widescreen\` is \`true\` should render the right structure 1`] = `
+<ShowOn
+  computer={false}
+  mobile={false}
+  parent="div"
+  parentProps={Object {}}
+  tablet={false}
   widescreen={true}
 >
-  <section
-    className="hide-on-all-devices show-on-mobile show-on-tablet show-on-computer show-on-widescreen"
-  >
-    div
-  </section>
+  <div
+    className="show-on-widescreen"
+  />
+</ShowOn>
+`;
+
+exports[`<ShowOn /> should render the right structure 1`] = `
+<ShowOn
+  computer={false}
+  mobile={false}
+  parent="div"
+  parentProps={Object {}}
+  tablet={false}
+  widescreen={false}
+>
+  <div
+    className=""
+  />
 </ShowOn>
 `;

--- a/src/components/layout/ShowOn/component.js
+++ b/src/components/layout/ShowOn/component.js
@@ -4,7 +4,6 @@ import getClassNames from 'classnames';
 
 /**
  * Shows child components on specified screen sizes.
- * Hides child components otherwise.
  */
 // eslint-disable-next-line jsdoc/require-jsdoc
 export const Component = ({
@@ -20,7 +19,7 @@ export const Component = ({
     parent,
     {
       ...parentProps,
-      className: getClassNames(parentProps.className, 'hide-on-all-devices', {
+      className: getClassNames(parentProps.className, {
         'show-on-mobile': mobile,
         'show-on-tablet': tablet,
         'show-on-computer': computer,

--- a/src/components/layout/ShowOn/component.spec.js
+++ b/src/components/layout/ShowOn/component.spec.js
@@ -4,42 +4,42 @@ import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-he
 
 import { Component as ShowOn } from './component';
 
-const propsWithDevices = {
-  children: 'div',
-  parent: 'section',
-  parentProps: {
-    className: '',
-  },
-  mobile: true,
-  tablet: true,
-  computer: true,
-  widescreen: true,
-};
-
-const propsWithoutDevices = {
-  children: 'div',
-  parent: 'section',
-  parentProps: {
-    className: '',
-  },
-  mobile: false,
-  tablet: false,
-  computer: false,
-  widescreen: false,
-};
-
 const getShowOn = props => mount(<ShowOn {...props} />);
 
 describe('<ShowOn />', () => {
-  it('it should render the right structure', () => {
-    const actual = getShowOn(propsWithDevices);
+  it('should render the right structure', () => {
+    const actual = getShowOn();
 
     expect(actual).toMatchSnapshot();
   });
 
-  describe('if all devices are set as false', () => {
-    it('should only return `hide-on-all-devices` as default class for the wrapper', () => {
-      const actual = getShowOn(propsWithoutDevices);
+  describe('if `props.mobile` is `true`', () => {
+    it('should render the right structure', () => {
+      const actual = getShowOn({ mobile: true });
+
+      expect(actual).toMatchSnapshot();
+    });
+  });
+
+  describe('if `props.tablet` is `true`', () => {
+    it('should render the right structure', () => {
+      const actual = getShowOn({ tablet: true });
+
+      expect(actual).toMatchSnapshot();
+    });
+  });
+
+  describe('if `props.computer` is `true`', () => {
+    it('should render the right structure', () => {
+      const actual = getShowOn({ computer: true });
+
+      expect(actual).toMatchSnapshot();
+    });
+  });
+
+  describe('if `props.widescreen` is `true`', () => {
+    it('should render the right structure', () => {
+      const actual = getShowOn({ widescreen: true });
 
       expect(actual).toMatchSnapshot();
     });

--- a/src/components/property-page-widgets/Description/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Description/__snapshots__/component.spec.js.snap
@@ -138,11 +138,11 @@ exports[`<Description /> if \`props.extraDescriptionText\` is passed the last \`
                 widescreen={true}
               >
                 <List
-                  className="hide-on-all-devices show-on-tablet show-on-computer show-on-widescreen"
+                  className="show-on-tablet show-on-computer show-on-widescreen"
                   horizontal={true}
                 >
                   <div
-                    className="ui horizontal list hide-on-all-devices show-on-tablet show-on-computer show-on-widescreen"
+                    className="ui horizontal list show-on-tablet show-on-computer show-on-widescreen"
                     role="list"
                   >
                     <ListItem
@@ -346,16 +346,16 @@ exports[`<Description /> if \`props.extraDescriptionText\` is passed the last \`
               >
                 <Grid
                   areColumnsCentered={false}
-                  className="hide-on-all-devices show-on-mobile"
+                  className="show-on-mobile"
                   columns={1}
                 >
                   <Grid
                     centered={false}
-                    className="hide-on-all-devices show-on-mobile"
+                    className="show-on-mobile"
                     columns={1}
                   >
                     <div
-                      className="ui one column grid hide-on-all-devices show-on-mobile"
+                      className="ui one column grid show-on-mobile"
                     >
                       <GridColumn
                         computer={3}
@@ -981,11 +981,11 @@ exports[`<Description /> if \`props.homeHighlights\` is empty should not render 
                 widescreen={true}
               >
                 <List
-                  className="hide-on-all-devices show-on-tablet show-on-computer show-on-widescreen"
+                  className="show-on-tablet show-on-computer show-on-widescreen"
                   horizontal={true}
                 >
                   <div
-                    className="ui horizontal list hide-on-all-devices show-on-tablet show-on-computer show-on-widescreen"
+                    className="ui horizontal list show-on-tablet show-on-computer show-on-widescreen"
                     role="list"
                   >
                     <ListItem
@@ -1189,16 +1189,16 @@ exports[`<Description /> if \`props.homeHighlights\` is empty should not render 
               >
                 <Grid
                   areColumnsCentered={false}
-                  className="hide-on-all-devices show-on-mobile"
+                  className="show-on-mobile"
                   columns={1}
                 >
                   <Grid
                     centered={false}
-                    className="hide-on-all-devices show-on-mobile"
+                    className="show-on-mobile"
                     columns={1}
                   >
                     <div
-                      className="ui one column grid hide-on-all-devices show-on-mobile"
+                      className="ui one column grid show-on-mobile"
                     >
                       <GridColumn
                         computer={3}
@@ -1601,11 +1601,11 @@ exports[`<Description /> should have the correct structure 1`] = `
                 widescreen={true}
               >
                 <List
-                  className="hide-on-all-devices show-on-tablet show-on-computer show-on-widescreen"
+                  className="show-on-tablet show-on-computer show-on-widescreen"
                   horizontal={true}
                 >
                   <div
-                    className="ui horizontal list hide-on-all-devices show-on-tablet show-on-computer show-on-widescreen"
+                    className="ui horizontal list show-on-tablet show-on-computer show-on-widescreen"
                     role="list"
                   >
                     <ListItem
@@ -1809,16 +1809,16 @@ exports[`<Description /> should have the correct structure 1`] = `
               >
                 <Grid
                   areColumnsCentered={false}
-                  className="hide-on-all-devices show-on-mobile"
+                  className="show-on-mobile"
                   columns={1}
                 >
                   <Grid
                     centered={false}
-                    className="hide-on-all-devices show-on-mobile"
+                    className="show-on-mobile"
                     columns={1}
                   >
                     <div
-                      className="ui one column grid hide-on-all-devices show-on-mobile"
+                      className="ui one column grid show-on-mobile"
                     >
                       <GridColumn
                         computer={3}

--- a/src/components/property-page-widgets/Location/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Location/__snapshots__/component.spec.js.snap
@@ -129,21 +129,21 @@ exports[`<Location /> the \`Child\` of the \`Location\` component should have th
           widescreen={true}
         >
           <GridColumn
-            className="hide-on-all-devices show-on-tablet show-on-computer show-on-widescreen"
+            className="show-on-tablet show-on-computer show-on-widescreen"
             computer={6}
             tablet={12}
             verticalAlignContent="top"
             width={null}
           >
             <GridColumn
-              className="hide-on-all-devices show-on-tablet show-on-computer show-on-widescreen"
+              className="show-on-tablet show-on-computer show-on-widescreen"
               computer={6}
               tablet={12}
               verticalAlign="top"
               width={null}
             >
               <div
-                className="top aligned six wide computer twelve wide tablet column hide-on-all-devices show-on-tablet show-on-computer show-on-widescreen"
+                className="top aligned six wide computer twelve wide tablet column show-on-tablet show-on-computer show-on-widescreen"
               >
                 <LabelGroup>
                   <div
@@ -529,17 +529,17 @@ exports[`<Location /> the \`Child\` of the \`Location\` component should have th
           widescreen={false}
         >
           <GridColumn
-            className="hide-on-all-devices show-on-mobile"
+            className="show-on-mobile"
             verticalAlignContent="top"
             width={12}
           >
             <GridColumn
-              className="hide-on-all-devices show-on-mobile"
+              className="show-on-mobile"
               verticalAlign="top"
               width={12}
             >
               <div
-                className="top aligned twelve wide column hide-on-all-devices show-on-mobile"
+                className="top aligned twelve wide column show-on-mobile"
               >
                 <Divider
                   className=""

--- a/src/components/property-page-widgets/Pictures/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Pictures/__snapshots__/component.spec.js.snap
@@ -108,7 +108,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                       widescreen={true}
                     >
                       <div
-                        className="hide-on-all-devices show-on-tablet show-on-computer show-on-widescreen"
+                        className="show-on-tablet show-on-computer show-on-widescreen"
                       >
                         <Thumbnail
                           className=""
@@ -188,7 +188,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                       widescreen={false}
                     >
                       <div
-                        className="hide-on-all-devices show-on-mobile"
+                        className="show-on-mobile"
                       >
                         <Thumbnail
                           className=""
@@ -298,7 +298,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                       widescreen={true}
                     >
                       <div
-                        className="hide-on-all-devices show-on-tablet show-on-computer show-on-widescreen"
+                        className="show-on-tablet show-on-computer show-on-widescreen"
                       >
                         <Thumbnail
                           className=""
@@ -378,7 +378,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                       widescreen={false}
                     >
                       <div
-                        className="hide-on-all-devices show-on-mobile"
+                        className="show-on-mobile"
                       >
                         <Thumbnail
                           className=""
@@ -488,7 +488,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                       widescreen={true}
                     >
                       <div
-                        className="hide-on-all-devices show-on-tablet show-on-computer show-on-widescreen"
+                        className="show-on-tablet show-on-computer show-on-widescreen"
                       >
                         <Thumbnail
                           className=""
@@ -568,7 +568,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                       widescreen={false}
                     >
                       <div
-                        className="hide-on-all-devices show-on-mobile"
+                        className="show-on-mobile"
                       >
                         <Thumbnail
                           className=""
@@ -678,7 +678,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                       widescreen={true}
                     >
                       <div
-                        className="hide-on-all-devices show-on-tablet show-on-computer show-on-widescreen"
+                        className="show-on-tablet show-on-computer show-on-widescreen"
                       >
                         <Thumbnail
                           className=""
@@ -758,7 +758,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                       widescreen={false}
                     >
                       <div
-                        className="hide-on-all-devices show-on-mobile"
+                        className="show-on-mobile"
                       >
                         <Thumbnail
                           className=""
@@ -868,7 +868,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                       widescreen={true}
                     >
                       <div
-                        className="hide-on-all-devices show-on-tablet show-on-computer show-on-widescreen"
+                        className="show-on-tablet show-on-computer show-on-widescreen"
                       >
                         <Thumbnail
                           className=""
@@ -948,7 +948,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                       widescreen={false}
                     >
                       <div
-                        className="hide-on-all-devices show-on-mobile"
+                        className="show-on-mobile"
                       >
                         <Thumbnail
                           className=""

--- a/src/components/property-page-widgets/PropertyPageHero/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/PropertyPageHero/__snapshots__/component.spec.js.snap
@@ -266,11 +266,11 @@ exports[`PropertyPageHero by default should render the right structure 1`] = `
                         widescreen={false}
                       >
                         <MenuMenu
-                          className="hide-on-all-devices show-on-mobile"
+                          className="show-on-mobile"
                           position="right"
                         >
                           <div
-                            className="right menu hide-on-all-devices show-on-mobile"
+                            className="right menu show-on-mobile"
                           >
                             <MenuItem>
                               <div
@@ -707,11 +707,11 @@ exports[`PropertyPageHero by default should render the right structure 1`] = `
                         widescreen={true}
                       >
                         <MenuMenu
-                          className="hide-on-all-devices show-on-tablet show-on-computer show-on-widescreen"
+                          className="show-on-tablet show-on-computer show-on-widescreen"
                           position="right"
                         >
                           <div
-                            className="right menu hide-on-all-devices show-on-tablet show-on-computer show-on-widescreen"
+                            className="right menu show-on-tablet show-on-computer show-on-widescreen"
                           >
                             <MenuItem
                               active={false}

--- a/src/components/property-page-widgets/PropertyPageSearchBar/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/PropertyPageSearchBar/__snapshots__/component.spec.js.snap
@@ -75,7 +75,7 @@ exports[`<PropertyPageSearchBar /> should have the right structure 1`] = `
       widescreen={true}
     >
       <div
-        className="hide-on-all-devices show-on-computer show-on-widescreen"
+        className="show-on-computer show-on-widescreen"
       >
         <SearchBar
           getIsDayBlocked={[Function]}
@@ -2558,7 +2558,7 @@ exports[`<PropertyPageSearchBar /> should have the right structure 1`] = `
       widescreen={false}
     >
       <div
-        className="hide-on-all-devices show-on-mobile show-on-tablet"
+        className="show-on-mobile show-on-tablet"
       >
         <SearchBar
           getIsDayBlocked={[Function]}

--- a/src/components/property-page-widgets/Rates/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Rates/__snapshots__/component.spec.js.snap
@@ -92,7 +92,7 @@ exports[`<Rates /> by default should have the right structure 1`] = `
           widescreen={false}
         >
           <div
-            className="hide-on-all-devices show-on-mobile"
+            className="show-on-mobile"
           >
             <Grid
               areColumnsCentered={false}
@@ -1419,7 +1419,7 @@ exports[`<Rates /> by default should have the right structure 1`] = `
     widescreen={true}
   >
     <div
-      className="hide-on-all-devices show-on-tablet show-on-computer show-on-widescreen"
+      className="show-on-tablet show-on-computer show-on-widescreen"
     >
       <Table
         tableBody={
@@ -2897,7 +2897,7 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
           widescreen={false}
         >
           <div
-            className="hide-on-all-devices show-on-mobile"
+            className="show-on-mobile"
           >
             <Grid
               areColumnsCentered={false}
@@ -4224,7 +4224,7 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
     widescreen={true}
   >
     <div
-      className="hide-on-all-devices show-on-tablet show-on-computer show-on-widescreen"
+      className="show-on-tablet show-on-computer show-on-widescreen"
     >
       <Table
         tableBody={

--- a/src/components/property-page-widgets/RoomType/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/RoomType/__snapshots__/component.spec.js.snap
@@ -1108,17 +1108,17 @@ exports[`<RoomType /> by default should render the correct structure 1`] = `
                                             widescreen={false}
                                           >
                                             <Divider
-                                              className="hide-on-all-devices show-on-mobile"
+                                              className="show-on-mobile"
                                               hasLine={false}
                                               size="medium"
                                             >
                                               <Divider
-                                                className="hide-on-all-devices show-on-mobile"
+                                                className="show-on-mobile"
                                                 hidden={true}
                                                 section={false}
                                               >
                                                 <div
-                                                  className="ui hidden divider hide-on-all-devices show-on-mobile"
+                                                  className="ui hidden divider show-on-mobile"
                                                 />
                                               </Divider>
                                             </Divider>
@@ -2228,17 +2228,17 @@ exports[`<RoomType /> if \`isUserOnMobile === true\` should render the correct s
                                             widescreen={false}
                                           >
                                             <Divider
-                                              className="hide-on-all-devices show-on-mobile"
+                                              className="show-on-mobile"
                                               hasLine={false}
                                               size="medium"
                                             >
                                               <Divider
-                                                className="hide-on-all-devices show-on-mobile"
+                                                className="show-on-mobile"
                                                 hidden={true}
                                                 section={false}
                                               >
                                                 <div
-                                                  className="ui hidden divider hide-on-all-devices show-on-mobile"
+                                                  className="ui hidden divider show-on-mobile"
                                                 />
                                               </Divider>
                                             </Divider>

--- a/src/components/property-page-widgets/RoomTypes/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/RoomTypes/__snapshots__/component.spec.js.snap
@@ -1416,17 +1416,17 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                                   widescreen={false}
                                                 >
                                                   <Divider
-                                                    className="hide-on-all-devices show-on-mobile"
+                                                    className="show-on-mobile"
                                                     hasLine={false}
                                                     size="medium"
                                                   >
                                                     <Divider
-                                                      className="hide-on-all-devices show-on-mobile"
+                                                      className="show-on-mobile"
                                                       hidden={true}
                                                       section={false}
                                                     >
                                                       <div
-                                                        className="ui hidden divider hide-on-all-devices show-on-mobile"
+                                                        className="ui hidden divider show-on-mobile"
                                                       />
                                                     </Divider>
                                                   </Divider>
@@ -2711,17 +2711,17 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                                   widescreen={false}
                                                 >
                                                   <Divider
-                                                    className="hide-on-all-devices show-on-mobile"
+                                                    className="show-on-mobile"
                                                     hasLine={false}
                                                     size="medium"
                                                   >
                                                     <Divider
-                                                      className="hide-on-all-devices show-on-mobile"
+                                                      className="show-on-mobile"
                                                       hidden={true}
                                                       section={false}
                                                     >
                                                       <div
-                                                        className="ui hidden divider hide-on-all-devices show-on-mobile"
+                                                        className="ui hidden divider show-on-mobile"
                                                       />
                                                     </Divider>
                                                   </Divider>

--- a/src/styles/semantic/themes/livingstone/globals/site.overrides
+++ b/src/styles/semantic/themes/livingstone/globals/site.overrides
@@ -448,42 +448,58 @@ blockquote.ui.quote .row {
 }
 
 /*----------------------
-    Show on devices
+    Hide on devices
 -----------------------*/
 
-.hide-on-all-devices {
-  display: none !important;
-}
-
-/* Shown on mobileViewport */
+/* Hide on mobileViewport */
 @media @mobileViewport {
 
-  .show-on-mobile {
-    display: flex !important;
+  .show-on-tablet,
+  .show-on-computer,
+  .show-on-widescreen {
+
+    &:not(.show-on-mobile) {
+      display: none !important;
+    }
   }
 }
 
-/* Shown on tabletViewport */
+/* Hide on tabletViewport */
 @media @tabletViewport {
 
-  .show-on-tablet {
-    display: flex !important;
+  .show-on-mobile,
+  .show-on-computer,
+  .show-on-widescreen {
+
+    &:not(.show-on-tablet) {
+      display: none !important;
+    }
   }
 }
 
-/* Shown on computerViewport */
+/* Hide on computerViewport */
 @media @computerViewport {
 
-  .show-on-computer {
-    display: flex !important;
+  .show-on-mobile,
+  .show-on-tablet,
+  .show-on-widescreen {
+
+    &:not(.show-on-computer) {
+      display: none !important;
+    }
   }
 }
 
-/* Shown on widescreenViewport */
+/* Hide on widescreenViewport */
 @media @widescreenViewport {
 
-  .show-on-widescreen {
-    display: flex !important;
+  .show-on-mobile,
+  .show-on-tablet,
+  .show-on-computer {
+
+    &:not(.show-on-widescreen) {
+      display: none !important;
+    }
   }
 }
 


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1538)

### What **one** thing does this PR do?
Removes `display: flex` which was disrupting a number of components.

### Any other notes
The styles are flipped from hiding by default to showing by default.
