### PR TITLE
TE-1548 Fix Header logo image

### DIFF
--- a/src/components/collections/Header/utils/__snapshots__/getLogoMarkup.spec.js.snap
+++ b/src/components/collections/Header/utils/__snapshots__/getLogoMarkup.spec.js.snap
@@ -41,49 +41,22 @@ exports[`getLogoMarkup if \`logoSrc\`, \`logoSizes\` and \`logoSrcSet\` are pass
     href="/"
     onClick={[Function]}
   >
-    <ResponsiveImage
+    <Image
       alt="someLogoText"
-      alternativeText="Image Widget"
-      hasRoundedCorners={false}
-      imageHeight={null}
-      imageNotFoundLabelText="Image not found!"
-      imageTitle="Image Title"
-      imageUrl="someLogoSrc"
-      imageWidth={null}
-      isAvatar={false}
-      isCircular={false}
-      isFluid={false}
-      label={null}
+      as="img"
       sizes="someSizes"
+      src="someLogoSrc"
       srcSet="someSrcSet"
+      ui={true}
     >
-      <figure
-        className="responsive-image"
-      >
-        <Image
-          alt="Image Widget"
-          as="img"
-          avatar={false}
-          fluid={true}
-          onLoad={[Function]}
-          sizes="someSizes"
-          src="someLogoSrc"
-          srcSet="someSrcSet"
-          title="Image Title"
-          ui={true}
-        >
-          <img
-            alt="Image Widget"
-            className="ui fluid image"
-            onLoad={[Function]}
-            sizes="someSizes"
-            src="someLogoSrc"
-            srcSet="someSrcSet"
-            title="Image Title"
-          />
-        </Image>
-      </figure>
-    </ResponsiveImage>
+      <img
+        alt="someLogoText"
+        className="ui image"
+        sizes="someSizes"
+        src="someLogoSrc"
+        srcSet="someSrcSet"
+      />
+    </Image>
   </a>
 </MenuItem>
 `;

--- a/src/components/collections/Header/utils/__snapshots__/getMobileMenuMarkup.spec.js.snap
+++ b/src/components/collections/Header/utils/__snapshots__/getMobileMenuMarkup.spec.js.snap
@@ -71,21 +71,13 @@ exports[`getMobileMenuMarkup by default should render the right structure 1`] = 
                     href="/"
                     link={true}
                   >
-                    <ResponsiveImage
+                    <Image
                       alt="someLogoText"
-                      alternativeText="Image Widget"
-                      hasRoundedCorners={false}
-                      imageHeight={null}
-                      imageNotFoundLabelText="Image not found!"
-                      imageTitle="Image Title"
-                      imageUrl="someLogoSrc"
-                      imageWidth={null}
-                      isAvatar={false}
-                      isCircular={false}
-                      isFluid={false}
-                      label={null}
+                      as="img"
                       sizes="someLogoSizes"
+                      src="someLogoSrc"
                       srcSet="someLogoSrcSet"
+                      ui={true}
                     />
                   </MenuItem>
                   <MenuItem
@@ -571,21 +563,13 @@ exports[`getMobileMenuMarkup if \`props.searchBarGuestsOptions\` and \`props.sea
                     href="/"
                     link={true}
                   >
-                    <ResponsiveImage
+                    <Image
                       alt="someLogoText"
-                      alternativeText="Image Widget"
-                      hasRoundedCorners={false}
-                      imageHeight={null}
-                      imageNotFoundLabelText="Image not found!"
-                      imageTitle="Image Title"
-                      imageUrl="someLogoSrc"
-                      imageWidth={null}
-                      isAvatar={false}
-                      isCircular={false}
-                      isFluid={false}
-                      label={null}
+                      as="img"
                       sizes="someLogoSizes"
+                      src="someLogoSrc"
                       srcSet="someLogoSrcSet"
+                      ui={true}
                     />
                   </MenuItem>
                   <MenuItem

--- a/src/components/collections/Header/utils/getLogoMarkup.js
+++ b/src/components/collections/Header/utils/getLogoMarkup.js
@@ -1,7 +1,6 @@
 import React from 'react';
-import { Menu } from 'semantic-ui-react';
+import { Menu, Image } from 'semantic-ui-react';
 
-import { ResponsiveImage } from 'media/ResponsiveImage';
 import { Heading } from 'typography/Heading';
 
 /**
@@ -14,10 +13,10 @@ import { Heading } from 'typography/Heading';
 export const getLogoMarkup = (logoText, logoSrc, logoSizes, logoSrcSet) => (
   <Menu.Item href="/" link>
     {logoSrc ? (
-      <ResponsiveImage
+      <Image
         alt={logoText}
-        imageUrl={logoSrc}
         sizes={logoSizes}
+        src={logoSrc}
         srcSet={logoSrcSet}
       />
     ) : (

--- a/src/components/collections/Hero/__snapshots__/component.spec.js.snap
+++ b/src/components/collections/Hero/__snapshots__/component.spec.js.snap
@@ -185,49 +185,22 @@ exports[`<Hero /> by default should render the right structure 1`] = `
                         href="/"
                         onClick={[Function]}
                       >
-                        <ResponsiveImage
+                        <Image
                           alt="Livingstone Cottage"
-                          alternativeText="Image Widget"
-                          hasRoundedCorners={false}
-                          imageHeight={null}
-                          imageNotFoundLabelText="Image not found!"
-                          imageTitle="Image Title"
-                          imageUrl="https://darkgreen.com"
-                          imageWidth={null}
-                          isAvatar={false}
-                          isCircular={false}
-                          isFluid={false}
-                          label={null}
+                          as="img"
                           sizes="a load of logo sizes"
+                          src="https://darkgreen.com"
                           srcSet="a load of logo src sets"
+                          ui={true}
                         >
-                          <figure
-                            className="responsive-image"
-                          >
-                            <Image
-                              alt="Image Widget"
-                              as="img"
-                              avatar={false}
-                              fluid={true}
-                              onLoad={[Function]}
-                              sizes="a load of logo sizes"
-                              src="https://darkgreen.com"
-                              srcSet="a load of logo src sets"
-                              title="Image Title"
-                              ui={true}
-                            >
-                              <img
-                                alt="Image Widget"
-                                className="ui fluid image"
-                                onLoad={[Function]}
-                                sizes="a load of logo sizes"
-                                src="https://darkgreen.com"
-                                srcSet="a load of logo src sets"
-                                title="Image Title"
-                              />
-                            </Image>
-                          </figure>
-                        </ResponsiveImage>
+                          <img
+                            alt="Livingstone Cottage"
+                            className="ui image"
+                            sizes="a load of logo sizes"
+                            src="https://darkgreen.com"
+                            srcSet="a load of logo src sets"
+                          />
+                        </Image>
                       </a>
                     </MenuItem>
                     <ShowOn
@@ -588,21 +561,13 @@ exports[`<Hero /> by default should render the right structure 1`] = `
                                         href="/"
                                         link={true}
                                       >
-                                        <ResponsiveImage
+                                        <Image
                                           alt="Livingstone Cottage"
-                                          alternativeText="Image Widget"
-                                          hasRoundedCorners={false}
-                                          imageHeight={null}
-                                          imageNotFoundLabelText="Image not found!"
-                                          imageTitle="Image Title"
-                                          imageUrl="https://darkgreen.com"
-                                          imageWidth={null}
-                                          isAvatar={false}
-                                          isCircular={false}
-                                          isFluid={false}
-                                          label={null}
+                                          as="img"
                                           sizes="a load of logo sizes"
+                                          src="https://darkgreen.com"
                                           srcSet="a load of logo src sets"
+                                          ui={true}
                                         />
                                       </MenuItem>
                                       <MenuItem

--- a/src/components/general-widgets/HomepageHero/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/HomepageHero/__snapshots__/component.spec.js.snap
@@ -247,49 +247,22 @@ exports[`HomepageHero by default should render the right structure 1`] = `
                           href="/"
                           onClick={[Function]}
                         >
-                          <ResponsiveImage
+                          <Image
                             alt="text"
-                            alternativeText="Image Widget"
-                            hasRoundedCorners={false}
-                            imageHeight={null}
-                            imageNotFoundLabelText="Image not found!"
-                            imageTitle="Image Title"
-                            imageUrl="src"
-                            imageWidth={null}
-                            isAvatar={false}
-                            isCircular={false}
-                            isFluid={false}
-                            label={null}
+                            as="img"
                             sizes="a load of logo sizes"
+                            src="src"
                             srcSet="a load of logo src sets"
+                            ui={true}
                           >
-                            <figure
-                              className="responsive-image"
-                            >
-                              <Image
-                                alt="Image Widget"
-                                as="img"
-                                avatar={false}
-                                fluid={true}
-                                onLoad={[Function]}
-                                sizes="a load of logo sizes"
-                                src="src"
-                                srcSet="a load of logo src sets"
-                                title="Image Title"
-                                ui={true}
-                              >
-                                <img
-                                  alt="Image Widget"
-                                  className="ui fluid image"
-                                  onLoad={[Function]}
-                                  sizes="a load of logo sizes"
-                                  src="src"
-                                  srcSet="a load of logo src sets"
-                                  title="Image Title"
-                                />
-                              </Image>
-                            </figure>
-                          </ResponsiveImage>
+                            <img
+                              alt="text"
+                              className="ui image"
+                              sizes="a load of logo sizes"
+                              src="src"
+                              srcSet="a load of logo src sets"
+                            />
+                          </Image>
                         </a>
                       </MenuItem>
                       <ShowOn
@@ -628,21 +601,13 @@ exports[`HomepageHero by default should render the right structure 1`] = `
                                           href="/"
                                           link={true}
                                         >
-                                          <ResponsiveImage
+                                          <Image
                                             alt="text"
-                                            alternativeText="Image Widget"
-                                            hasRoundedCorners={false}
-                                            imageHeight={null}
-                                            imageNotFoundLabelText="Image not found!"
-                                            imageTitle="Image Title"
-                                            imageUrl="src"
-                                            imageWidth={null}
-                                            isAvatar={false}
-                                            isCircular={false}
-                                            isFluid={false}
-                                            label={null}
+                                            as="img"
                                             sizes="a load of logo sizes"
+                                            src="src"
                                             srcSet="a load of logo src sets"
+                                            ui={true}
                                           />
                                         </MenuItem>
                                         <MenuItem

--- a/src/components/property-page-widgets/PropertyPageHero/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/PropertyPageHero/__snapshots__/component.spec.js.snap
@@ -245,49 +245,22 @@ exports[`PropertyPageHero by default should render the right structure 1`] = `
                           href="/"
                           onClick={[Function]}
                         >
-                          <ResponsiveImage
+                          <Image
                             alt="text"
-                            alternativeText="Image Widget"
-                            hasRoundedCorners={false}
-                            imageHeight={null}
-                            imageNotFoundLabelText="Image not found!"
-                            imageTitle="Image Title"
-                            imageUrl="src"
-                            imageWidth={null}
-                            isAvatar={false}
-                            isCircular={false}
-                            isFluid={false}
-                            label={null}
+                            as="img"
                             sizes="a load of logo sizes"
+                            src="src"
                             srcSet="a load of logo src sets"
+                            ui={true}
                           >
-                            <figure
-                              className="responsive-image"
-                            >
-                              <Image
-                                alt="Image Widget"
-                                as="img"
-                                avatar={false}
-                                fluid={true}
-                                onLoad={[Function]}
-                                sizes="a load of logo sizes"
-                                src="src"
-                                srcSet="a load of logo src sets"
-                                title="Image Title"
-                                ui={true}
-                              >
-                                <img
-                                  alt="Image Widget"
-                                  className="ui fluid image"
-                                  onLoad={[Function]}
-                                  sizes="a load of logo sizes"
-                                  src="src"
-                                  srcSet="a load of logo src sets"
-                                  title="Image Title"
-                                />
-                              </Image>
-                            </figure>
-                          </ResponsiveImage>
+                            <img
+                              alt="text"
+                              className="ui image"
+                              sizes="a load of logo sizes"
+                              src="src"
+                              srcSet="a load of logo src sets"
+                            />
+                          </Image>
                         </a>
                       </MenuItem>
                       <ShowOn
@@ -620,21 +593,13 @@ exports[`PropertyPageHero by default should render the right structure 1`] = `
                                           href="/"
                                           link={true}
                                         >
-                                          <ResponsiveImage
+                                          <Image
                                             alt="text"
-                                            alternativeText="Image Widget"
-                                            hasRoundedCorners={false}
-                                            imageHeight={null}
-                                            imageNotFoundLabelText="Image not found!"
-                                            imageTitle="Image Title"
-                                            imageUrl="src"
-                                            imageWidth={null}
-                                            isAvatar={false}
-                                            isCircular={false}
-                                            isFluid={false}
-                                            label={null}
+                                            as="img"
                                             sizes="a load of logo sizes"
+                                            src="src"
                                             srcSet="a load of logo src sets"
+                                            ui={true}
                                           />
                                         </MenuItem>
                                         <MenuItem


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1548)

### What **one** thing does this PR do?
Displays the logo in the header and all components consuming header.

### Any other notes
- ResponsiveImage's `<figure />` tag was affecting how the `<a />` was inheriting its size.

#### Header
**before**
![image](https://user-images.githubusercontent.com/10498995/49796128-2414ad00-fd3c-11e8-94f7-6e946c4af9f5.png)

**after**
![image](https://user-images.githubusercontent.com/10498995/49796140-2f67d880-fd3c-11e8-95cf-f3be17475a16.png)

#### Hero
**before**
![image](https://user-images.githubusercontent.com/10498995/49796117-1a8b4500-fd3c-11e8-9ac4-b51d7091abe9.png)

**after**
![image](https://user-images.githubusercontent.com/10498995/49796156-3abb0400-fd3c-11e8-96e3-ca28a3b2ee62.png)

#### PropertyPageHero
**before**
![image](https://user-images.githubusercontent.com/10498995/49796104-12330a00-fd3c-11e8-8ca3-8b020c23d9d6.png)

**after**
![image](https://user-images.githubusercontent.com/10498995/49796188-4c9ca700-fd3c-11e8-848f-0924eea141a8.png)

#### HomepageHero
**before**
![image](https://user-images.githubusercontent.com/10498995/49796093-07787500-fd3c-11e8-9565-592131f266b6.png)

**after**
![image](https://user-images.githubusercontent.com/10498995/49796171-427aa880-fd3c-11e8-9725-27c947e5ce42.png)
