### PR TITLE
TE-1528 Fix text width for footer dropdowns

### DIFF
--- a/src/styles/semantic/themes/livingstone/modules/dropdown.overrides
+++ b/src/styles/semantic/themes/livingstone/modules/dropdown.overrides
@@ -7,6 +7,7 @@
 --------------------*/
 
 .ui.dropdown {
+  display: inline-flex;
 
   /*-------------------
        Content
@@ -112,6 +113,7 @@
 
   .ui.selection.dropdown {
     color: @defaultTextColor;
+    display: inline-flex;
     max-width: @selectionMaxWidth;
     width: @selectionWidth;
 


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1528)

### What **one** thing does this PR do?
Adapts all versions of the dropdown component to behave appropriately with `width: 100%` property. 

### Before

![screenshot 2018-12-12 at 17 21 15](https://user-images.githubusercontent.com/33876435/49883317-b8f9d200-fe32-11e8-82be-d288be8654a9.png)

### After

![screenshot 2018-12-12 at 17 16 42](https://user-images.githubusercontent.com/33876435/49883339-c8791b00-fe32-11e8-8c59-417a40dda183.png)

