### PR TITLE
TE-1590 Fix PropertyPageSearchbar

### DIFF
--- a/src/styles/semantic/themes/livingstone/globals/site.overrides
+++ b/src/styles/semantic/themes/livingstone/globals/site.overrides
@@ -529,17 +529,6 @@ blockquote.ui.quote .row {
     }
   }
 
-  @media only screen and (max-height: @computerBreakpoint) {
-
-    .show-on-mobile {
-      display: block !important;
-    }
-
-    .show-on-desktop {
-      display: none !important;
-    }
-  }
-
   @media @tabletScreen {
 
     .ui.segments > .ui.segment {


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1590)

### What **one** thing does this PR do?
Removes an obsolete media query that was introduced to work with the `ShowOnDesktop`, `ShowOnMobile` responsive wrappers. This was causing the removal of the datepicker; which left an empty space for the `Button` to fall all the way to the left. 

* Another PR will be opened in templates-ssr in order change the button justification. 

### Before

<img width="716" alt="screenshot 2018-12-19 at 10 07 02" src="https://user-images.githubusercontent.com/33876435/50211607-5ac07800-0379-11e9-98e0-b425f8b39604.png">
<img width="1402" alt="screenshot 2018-12-19 at 10 09 45" src="https://user-images.githubusercontent.com/33876435/50211608-5b590e80-0379-11e9-8948-e93a77bcacbd.png">

### After

<img width="533" alt="screenshot 2018-12-19 at 10 07 45" src="https://user-images.githubusercontent.com/33876435/50211642-6875fd80-0379-11e9-92b1-882925e62171.png">
<img width="1416" alt="screenshot 2018-12-19 at 10 10 06" src="https://user-images.githubusercontent.com/33876435/50211643-6875fd80-0379-11e9-91b4-823bb9a46730.png">
