### PR TITLE
TE-1601 `Pictures`: expose `props.galleryImages` and `props.thumbnailImages`

### DIFF
--- a/src/components/layout/HorizontalGutters/component.js
+++ b/src/components/layout/HorizontalGutters/component.js
@@ -6,8 +6,6 @@ import { Container } from 'semantic-ui-react';
  * horizontal gutters on the left and right.
  */
 // eslint-disable-next-line jsdoc/require-jsdoc
-export const Component = ({ textAlign, ...props }) => (
-  <Container {...props} textAlign={textAlign} />
-);
+export const Component = props => <Container {...props} />;
 
 Component.displayName = 'HorizontalGutters';

--- a/src/components/property-page-widgets/Pictures/Readme.md
+++ b/src/components/property-page-widgets/Pictures/Readme.md
@@ -1,7 +1,10 @@
 ```jsx
-const { pictures } = require('./mock-data/pictures');
+const { images } = require('./mock-data/images');
 
-<Pictures pictures={pictures} />
+<Pictures
+  galleryImages={images}
+  thumbnailImages={images}
+/>
 ```
 
 ### Content
@@ -9,12 +12,13 @@ const { pictures } = require('./mock-data/pictures');
 #### Heading in gallery modal
 
 ```jsx
-const { pictures } = require('./mock-data/pictures');
+const { images } = require('./mock-data/images');
 
 <Pictures
-  pictures={pictures}
+  galleryImages={images}
   propertyName="The Cat House"
   ratingNumber={4.3}
+  thumbnailImages={images}
 />
 ```
 
@@ -22,11 +26,12 @@ const { pictures } = require('./mock-data/pictures');
 #### Strings
 
 ```jsx
-const { pictures } = require('./mock-data/pictures');
+const { images } = require('./mock-data/images');
 
 <Pictures
-  pictures={pictures}
+  galleryImages={images}
   headingText="Photos of the property"
   linkText="Click here for more"
+  thumbnailImages={images}
 />
 ```

--- a/src/components/property-page-widgets/Pictures/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Pictures/__snapshots__/component.spec.js.snap
@@ -2,9 +2,7 @@
 
 exports[`<Pictures /> should render the correct structure 1`] = `
 <Pictures
-  headingText="Property pictures"
-  linkText="Explore all pictures"
-  pictures={
+  galleryImages={
     Array [
       Object {
         "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max",
@@ -33,8 +31,39 @@ exports[`<Pictures /> should render the correct structure 1`] = `
       },
     ]
   }
+  headingText="Property pictures"
+  linkText="Explore all pictures"
   propertyName={null}
   ratingNumber={null}
+  thumbnailImages={
+    Array [
+      Object {
+        "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max",
+        "imageUrlAlternativeText": "Entrance",
+        "label": "Entrance",
+      },
+      Object {
+        "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max",
+        "imageUrlAlternativeText": "Kitchen",
+        "label": "Kitchen",
+      },
+      Object {
+        "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max",
+        "imageUrlAlternativeText": "Living room",
+        "label": "Living room",
+      },
+      Object {
+        "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max",
+        "imageUrlAlternativeText": "Studio",
+        "label": "Studio",
+      },
+      Object {
+        "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max",
+        "imageUrlAlternativeText": "Garden room",
+        "label": "Garden room",
+      },
+    ]
+  }
 >
   <Grid
     areColumnsCentered={false}

--- a/src/components/property-page-widgets/Pictures/component.js
+++ b/src/components/property-page-widgets/Pictures/component.js
@@ -20,18 +20,19 @@ import { Link } from 'elements/Link';
  */
 // eslint-disable-next-line jsdoc/require-jsdoc
 export const Component = ({
+  galleryImages,
   headingText,
   linkText,
-  pictures,
   propertyName,
   ratingNumber,
+  thumbnailImages,
 }) => (
   <Grid columns={3}>
     <GridColumn width={12}>
       <Heading>{headingText}</Heading>
     </GridColumn>
     <GridRow>
-      {getFirstSixItems(pictures).map(
+      {getFirstSixItems(thumbnailImages).map(
         ({ imageUrl, imageSizes, imageSrcSet, label }, index) => (
           <GridColumn key={buildKeyFromStrings(imageUrl, index)}>
             <ShowOn computer parent="div" tablet widescreen>
@@ -62,7 +63,7 @@ export const Component = ({
     <GridColumn width={12}>
       <Gallery
         heading={getGalleryHeadingMarkup(propertyName, ratingNumber)}
-        images={pictures}
+        images={galleryImages}
         trigger={<Link>{linkText}</Link>}
       />
     </GridColumn>
@@ -79,14 +80,16 @@ Component.defaultProps = {
 };
 
 Component.propTypes = {
+  /** The images to display in the gallery modal. See [the `ResponsiveImage` component for valid props](#/Media/ResponsiveImage).  */
+  galleryImages: PropTypes.arrayOf(PropTypes.object).isRequired,
   /** The text to display as a heading at the top of the widget. */
   headingText: PropTypes.string,
   /** The text to display on the link at the bottom of the widget. */
   linkText: PropTypes.string,
-  /** The pictures to display. See [the `ResponsiveImage` component for valid props](#/Media/ResponsiveImage).  */
-  pictures: PropTypes.arrayOf(PropTypes.object).isRequired,
   /** The name of the property to display in the gallery modal. */
   propertyName: PropTypes.string,
   /** The numeral rating for the property, out of 5 */
   ratingNumber: PropTypes.number,
+  /** The images to display as thumbnails. See [the `ResponsiveImage` component for valid props](#/Media/ResponsiveImage).  */
+  thumbnailImages: PropTypes.arrayOf(PropTypes.object).isRequired,
 };

--- a/src/components/property-page-widgets/Pictures/component.spec.js
+++ b/src/components/property-page-widgets/Pictures/component.spec.js
@@ -2,10 +2,11 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
 
-import { pictures } from './mock-data/pictures';
+import { images } from './mock-data/images';
 import { Component as Pictures } from './component';
 
-const getPictures = () => mount(<Pictures pictures={pictures} />);
+const getPictures = () =>
+  mount(<Pictures galleryImages={images} thumbnailImages={images} />);
 
 describe('<Pictures />', () => {
   it('should render the correct structure', () => {

--- a/src/components/property-page-widgets/Pictures/mock-data/images.js
+++ b/src/components/property-page-widgets/Pictures/mock-data/images.js
@@ -1,7 +1,7 @@
 const imageUrl =
   'https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max';
 
-export const pictures = [
+export const images = [
   { imageUrl, imageUrlAlternativeText: 'Entrance', label: 'Entrance' },
   { imageUrl, imageUrlAlternativeText: 'Kitchen', label: 'Kitchen' },
   {


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1601)

### What **one** thing does this PR do?
Exposes `props.galleryImages` and `props.thumbnailImages` on the `Pictures` component to allow consuming components to pass different size images for each display case.