### PR TITLE
TE-1660 Hero remove 1px border

### DIFF
--- a/src/styles/semantic/themes/livingstone/elements/segment.overrides
+++ b/src/styles/semantic/themes/livingstone/elements/segment.overrides
@@ -114,6 +114,7 @@
   display: flex;
   height: ~"calc(100vh - var(@{fullBleedBottomOffsetIdentifier}, 0))";
   padding: 0;
+  border-bottom: none;
 
   figure.responsive-image {
     position: absolute;


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1660)

### What **one** thing does this PR do?
Removes the one pixel border from the hero.

### Any other notes
When a segment is the last child it removes the border. In the case of FullBleed being used as a hero at the top of the document it's the first child so will have a border bottom.

The recordings have an empty `<div>` after the segment to demonstrate the border.

#### Before
![kapture 2019-01-16 at 15 44 48](https://user-images.githubusercontent.com/10498995/51256548-f90a2280-19a5-11e9-8a71-c0f3e8c4d768.gif)

#### After
![kapture 2019-01-16 at 15 45 48](https://user-images.githubusercontent.com/10498995/51256568-032c2100-19a6-11e9-972b-61a39b3a0ab4.gif)
