### PR TITLE
TE-1658 Dropdown indentation accepts 0 to 5 integers inclusive

### DIFF
--- a/src/components/inputs/Dropdown/Readme.md
+++ b/src/components/inputs/Dropdown/Readme.md
@@ -112,10 +112,12 @@ const { optionsWithImages } = require('./mock-data/options');
 ```jsx
 const { indentedOptions } = require('./mock-data/options');
 // [
-//   { text: 'United States', value: 'us' }, 
-//   { text: 'Texas', value: 'tx', indent: 1 },
-//   { text: 'California', value: 'ca', indent: 1 },
-//   { text: 'Los Angeles', value: 'la', indent: 2 },
+//    { text: 'United States', value: 'us' indent: 0},
+//    { text: 'Texas', value: 'tx', indent: 1 },
+//    { text: 'Colorado', value: 'co', indent: 2 },
+//    { text: 'New York', value: 'ny', indent: 3 },
+//    { text: 'Minessota', value: 'mi', indent: 4 },
+//    { text: 'California', value: 'ca', indent: 5 },
 // ];
 
 <Dropdown label="Properties" options={indentedOptions} />;

--- a/src/components/inputs/Dropdown/component.js
+++ b/src/components/inputs/Dropdown/component.js
@@ -133,8 +133,8 @@ Component.propTypes = {
       imageSrcSet: PropTypes.string,
       /** The source url of the image. */
       imageUrl: PropTypes.string,
-      /** The indent level of an option. One of: 1, 2 */
-      indent: PropTypes.oneOf([1, 2]),
+      /** The indent level of an option. One of: 0, 1, 2, 3, 4, 5 */
+      indent: PropTypes.oneOf([0, 1, 2, 3, 4, 5]),
       /** The visible text for the option. */
       text: PropTypes.string.isRequired,
       /** The underlying value for the option. */

--- a/src/components/inputs/Dropdown/mock-data/options.js
+++ b/src/components/inputs/Dropdown/mock-data/options.js
@@ -29,9 +29,10 @@ export const optionsWithImages = [
 ];
 
 export const indentedOptions = [
-  { text: 'United Kingdom', value: 'gb' },
-  { text: 'United States', value: 'us' },
+  { text: 'United States', value: 'us', indent: 0 },
   { text: 'Texas', value: 'tx', indent: 1 },
-  { text: 'California', value: 'ca', indent: 1 },
-  { text: 'Los Angeles', value: 'la', indent: 2 },
+  { text: 'Colorado', value: 'co', indent: 2 },
+  { text: 'New York', value: 'ny', indent: 3 },
+  { text: 'Minessota', value: 'mi', indent: 4 },
+  { text: 'California', value: 'ca', indent: 5 },
 ];

--- a/src/styles/semantic/themes/livingstone/modules/dropdown.overrides
+++ b/src/styles/semantic/themes/livingstone/modules/dropdown.overrides
@@ -416,3 +416,15 @@
 .indent-2 span {
   margin-left: @indentationLevelTwo;
 }
+
+.indent-3 span {
+  margin-left: @indentationLevelThree;
+}
+
+.indent-4 span {
+  margin-left: @indentationLevelFour;
+}
+
+.indent-5 span {
+  margin-left: @indentationLevelFive;
+}

--- a/src/styles/semantic/themes/livingstone/modules/dropdown.variables
+++ b/src/styles/semantic/themes/livingstone/modules/dropdown.variables
@@ -220,3 +220,6 @@
 /* Indentation */
 @indentationLevelOne: @10px;
 @indentationLevelTwo: @20px;
+@indentationLevelThree: @30px;
+@indentationLevelFour: @40px;
+@indentationLevelFive: @50px;


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1658)

### What **one** thing does this PR do?
Upgrades `Dropdown` indentation to  accept integers between 0 and 5 inclusive
### Behaviour

![screenshot 2019-01-17 at 12 38 23](https://user-images.githubusercontent.com/33876435/51316558-58733b80-1a55-11e9-92aa-115e26281d94.png)

