### PR TITLE
TE-1651 Fix the input labels going into ellipsis

### DIFF
--- a/src/styles/semantic/themes/livingstone/modules/dropdown.overrides
+++ b/src/styles/semantic/themes/livingstone/modules/dropdown.overrides
@@ -194,6 +194,8 @@
 
     label {
       width: 100%;
+      text-overflow: clip;
+      overflow: visible;
     }
   }
 


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1651)

### What **one** thing does this PR do?
Prevents the `Dropdown` label from going into ellipsis when it's active.

### Behaviour
![searchbar](https://user-images.githubusercontent.com/33876435/51324010-e822e500-1a69-11e9-934c-80632198cc33.gif)

