### PR TITLE
TE-1686 HostProfile Description is not required

### DIFF
--- a/src/components/property-page-widgets/HostProfile/component.js
+++ b/src/components/property-page-widgets/HostProfile/component.js
@@ -13,9 +13,9 @@ import { Heading } from 'typography/Heading';
 import { Grid } from 'layout/Grid';
 import { GridRow } from 'layout/GridRow';
 import { GridColumn } from 'layout/GridColumn';
-import { Paragraph } from 'typography/Paragraph';
 import { getHrefTelString } from 'utils/get-href-tel-string';
 
+import { getDescription } from './utils/getDescription';
 import { getStringWithColonSuffix } from './utils/getStringWithColonSuffix';
 
 /**
@@ -52,9 +52,7 @@ export const Component = ({
       </GridColumn>
     </GridRow>
     <GridRow verticalAlign="top">
-      <GridColumn computer={7} mobile={12} tablet={12}>
-        <Paragraph size="medium">{description}</Paragraph>
-      </GridColumn>
+      {getDescription(description)}
       <GridColumn computer={5} mobile={12} tablet={12}>
         <Heading size="small">{contactInformationHeadingText}</Heading>
         <List relaxed size="medium">
@@ -96,6 +94,7 @@ Component.defaultProps = {
   languagesLabel: LANGUAGES,
   phone: null,
   phoneLabel: PHONE,
+  description: null,
 };
 
 Component.propTypes = {
@@ -104,7 +103,7 @@ Component.propTypes = {
   /** The text for the contact information heading. */
   contactInformationHeadingText: PropTypes.string,
   /** The description of the property host. */
-  description: PropTypes.string.isRequired,
+  description: PropTypes.string,
   /** The email of the property host. */
   email: PropTypes.string,
   /** The label for the contact email address. */

--- a/src/components/property-page-widgets/HostProfile/utils/__snapshots__/getDescription.spec.js.snap
+++ b/src/components/property-page-widgets/HostProfile/utils/__snapshots__/getDescription.spec.js.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`\`getDescription\` should have the right structure 1`] = `
+<GridColumn
+  computer={7}
+  mobile={12}
+  tablet={12}
+  verticalAlignContent="top"
+  width={null}
+>
+  <Paragraph
+    size="medium"
+    weight={null}
+  >
+    lorem upsum dulur sumut
+  </Paragraph>
+</GridColumn>
+`;

--- a/src/components/property-page-widgets/HostProfile/utils/getDescription.js
+++ b/src/components/property-page-widgets/HostProfile/utils/getDescription.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { size } from 'lodash';
+
+import { GridColumn } from 'layout/GridColumn';
+import { Paragraph } from 'typography/Paragraph';
+
+/**
+ * @typedef {Object} null
+ * @param {string} description
+ * @return {Object|null}
+ */
+export const getDescription = description =>
+  size(description) > 0 ? (
+    <GridColumn computer={7} mobile={12} tablet={12}>
+      <Paragraph size="medium">{description}</Paragraph>
+    </GridColumn>
+  ) : null;

--- a/src/components/property-page-widgets/HostProfile/utils/getDescription.spec.js
+++ b/src/components/property-page-widgets/HostProfile/utils/getDescription.spec.js
@@ -1,0 +1,16 @@
+import { getDescription } from './getDescription';
+
+describe('`getDescription`', () => {
+  it('should have the right structure', () => {
+    const description = 'lorem upsum dulur sumut';
+    const actual = getDescription(description);
+
+    expect(actual).toMatchSnapshot();
+  });
+  it('should return null if the description length is 0 or undefined', () => {
+    const description = undefined;
+    const actual = getDescription(description);
+
+    expect(actual).toBe(null);
+  });
+});


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1686)

### What **one** thing does this PR do?
Makes the `description` prop not required in `HostProfile`; then, implements `getDescription` util to handle `undefined`

### Behaviour
![hostprofile](https://user-images.githubusercontent.com/33876435/51382116-3988ae00-1b16-11e9-8db5-15a9d524e05e.gif)


