### PR TITLE
TE-1691 Header: revert to submenu trigger having no link

### DIFF
--- a/src/components/collections/Header/__snapshots__/component.spec.js.snap
+++ b/src/components/collections/Header/__snapshots__/component.spec.js.snap
@@ -10,10 +10,10 @@ exports[`<Header /> by default should render the right structure 1`] = `
   navigationItems={
     Array [
       Object {
+        "href": "/",
         "text": "Home",
       },
       Object {
-        "href": "/all-properties",
         "subItems": Array [
           Object {
             "href": "/la-casa-viva",
@@ -183,6 +183,7 @@ exports[`<Header /> by default should render the right structure 1`] = `
                               </MenuItem>
                               <MenuItem
                                 active={false}
+                                href="/"
                                 link={true}
                               >
                                 Home
@@ -226,13 +227,7 @@ exports[`<Header /> by default should render the right structure 1`] = `
                                         "key": "1All properties",
                                       },
                                       "title": Object {
-                                        "content": <MenuItem
-                                          active={false}
-                                          href="/all-properties"
-                                          link={true}
-                                        >
-                                          All properties
-                                        </MenuItem>,
+                                        "content": "All properties",
                                         "key": "All properties1",
                                       },
                                     },
@@ -375,15 +370,17 @@ exports[`<Header /> by default should render the right structure 1`] = `
                 >
                   <MenuItem
                     active={false}
+                    href="/"
                     key="Home0"
                     link={true}
                   >
-                    <div
+                    <a
                       className="link item"
+                      href="/"
                       onClick={[Function]}
                     >
                       Home
-                    </div>
+                    </a>
                   </MenuItem>
                   <Submenu
                     isMenuItem={true}
@@ -476,15 +473,7 @@ exports[`<Header /> by default should render the right structure 1`] = `
                       selectOnBlur={true}
                       selectOnNavigation={true}
                       simple={true}
-                      trigger={
-                        <MenuItem
-                          active={false}
-                          href="/all-properties"
-                          link={true}
-                        >
-                          All properties
-                        </MenuItem>
-                      }
+                      trigger="All properties"
                       upward={false}
                       value={null}
                       wrapSelection={true}
@@ -501,20 +490,7 @@ exports[`<Header /> by default should render the right structure 1`] = `
                         role="listbox"
                         tabIndex={0}
                       >
-                        <MenuItem
-                          active={false}
-                          href="/all-properties"
-                          key="All properties1"
-                          link={true}
-                        >
-                          <a
-                            className="link item"
-                            href="/all-properties"
-                            onClick={[Function]}
-                          >
-                            All properties
-                          </a>
-                        </MenuItem>
+                        All properties
                         <Icon
                           color={null}
                           hasBorder={false}
@@ -738,10 +714,10 @@ exports[`<Header /> if \`props.isBackgroundFilled\` is true should render the ri
   navigationItems={
     Array [
       Object {
+        "href": "/",
         "text": "Home",
       },
       Object {
-        "href": "/all-properties",
         "subItems": Array [
           Object {
             "href": "/la-casa-viva",
@@ -911,6 +887,7 @@ exports[`<Header /> if \`props.isBackgroundFilled\` is true should render the ri
                               </MenuItem>
                               <MenuItem
                                 active={false}
+                                href="/"
                                 link={true}
                               >
                                 Home
@@ -954,13 +931,7 @@ exports[`<Header /> if \`props.isBackgroundFilled\` is true should render the ri
                                         "key": "1All properties",
                                       },
                                       "title": Object {
-                                        "content": <MenuItem
-                                          active={false}
-                                          href="/all-properties"
-                                          link={true}
-                                        >
-                                          All properties
-                                        </MenuItem>,
+                                        "content": "All properties",
                                         "key": "All properties1",
                                       },
                                     },
@@ -1103,15 +1074,17 @@ exports[`<Header /> if \`props.isBackgroundFilled\` is true should render the ri
                 >
                   <MenuItem
                     active={false}
+                    href="/"
                     key="Home0"
                     link={true}
                   >
-                    <div
+                    <a
                       className="link item"
+                      href="/"
                       onClick={[Function]}
                     >
                       Home
-                    </div>
+                    </a>
                   </MenuItem>
                   <Submenu
                     isMenuItem={true}
@@ -1204,15 +1177,7 @@ exports[`<Header /> if \`props.isBackgroundFilled\` is true should render the ri
                       selectOnBlur={true}
                       selectOnNavigation={true}
                       simple={true}
-                      trigger={
-                        <MenuItem
-                          active={false}
-                          href="/all-properties"
-                          link={true}
-                        >
-                          All properties
-                        </MenuItem>
-                      }
+                      trigger="All properties"
                       upward={false}
                       value={null}
                       wrapSelection={true}
@@ -1229,20 +1194,7 @@ exports[`<Header /> if \`props.isBackgroundFilled\` is true should render the ri
                         role="listbox"
                         tabIndex={0}
                       >
-                        <MenuItem
-                          active={false}
-                          href="/all-properties"
-                          key="All properties1"
-                          link={true}
-                        >
-                          <a
-                            className="link item"
-                            href="/all-properties"
-                            onClick={[Function]}
-                          >
-                            All properties
-                          </a>
-                        </MenuItem>
+                        All properties
                         <Icon
                           color={null}
                           hasBorder={false}
@@ -1683,12 +1635,7 @@ exports[`<Header /> if navigation items exceed the header max width should rende
                                         "key": "1All properties",
                                       },
                                       "title": Object {
-                                        "content": <MenuItem
-                                          active={false}
-                                          link={true}
-                                        >
-                                          All properties
-                                        </MenuItem>,
+                                        "content": "All properties",
                                         "key": "All properties1",
                                       },
                                     },

--- a/src/components/collections/Header/mock-data/navigationItems.js
+++ b/src/components/collections/Header/mock-data/navigationItems.js
@@ -1,10 +1,7 @@
 export const navigationItems = [
-  {
-    text: 'Home',
-  },
+  { text: 'Home', href: '/' },
   {
     text: 'All properties',
-    href: '/all-properties',
     subItems: [
       {
         href: '/la-casa-viva',

--- a/src/components/collections/Header/utils/__snapshots__/getHiddenMenuMarkup.spec.js.snap
+++ b/src/components/collections/Header/utils/__snapshots__/getHiddenMenuMarkup.spec.js.snap
@@ -85,6 +85,7 @@ exports[`getHiddenMenuMarkup by default should render the right structure 1`] = 
                   </MenuItem>
                   <MenuItem
                     active={true}
+                    href="/"
                     link={true}
                   >
                     Home
@@ -128,13 +129,7 @@ exports[`getHiddenMenuMarkup by default should render the right structure 1`] = 
                             "key": "1All properties",
                           },
                           "title": Object {
-                            "content": <MenuItem
-                              active={false}
-                              href="/all-properties"
-                              link={true}
-                            >
-                              All properties
-                            </MenuItem>,
+                            "content": "All properties",
                             "key": "All properties1",
                           },
                         },
@@ -614,6 +609,7 @@ exports[`getHiddenMenuMarkup if \`props.searchBarGuestsOptions\` and \`props.sea
                   </MenuItem>
                   <MenuItem
                     active={true}
+                    href="/"
                     link={true}
                   >
                     Home
@@ -657,13 +653,7 @@ exports[`getHiddenMenuMarkup if \`props.searchBarGuestsOptions\` and \`props.sea
                             "key": "1All properties",
                           },
                           "title": Object {
-                            "content": <MenuItem
-                              active={false}
-                              href="/all-properties"
-                              link={true}
-                            >
-                              All properties
-                            </MenuItem>,
+                            "content": "All properties",
                             "key": "All properties1",
                           },
                         },

--- a/src/components/collections/Header/utils/__snapshots__/getStandardMenuMarkup.spec.js.snap
+++ b/src/components/collections/Header/utils/__snapshots__/getStandardMenuMarkup.spec.js.snap
@@ -23,15 +23,17 @@ exports[`getStandardMenuMarkup by default should render the right structure 1`] 
       >
         <MenuItem
           active={false}
+          href="/"
           key="Home0"
           link={true}
         >
-          <div
+          <a
             className="link item"
+            href="/"
             onClick={[Function]}
           >
             Home
-          </div>
+          </a>
         </MenuItem>
         <Submenu
           isMenuItem={true}
@@ -124,15 +126,7 @@ exports[`getStandardMenuMarkup by default should render the right structure 1`] 
             selectOnBlur={true}
             selectOnNavigation={true}
             simple={true}
-            trigger={
-              <MenuItem
-                active={true}
-                href="/all-properties"
-                link={true}
-              >
-                All properties
-              </MenuItem>
-            }
+            trigger="All properties"
             upward={false}
             value={null}
             wrapSelection={true}
@@ -149,20 +143,7 @@ exports[`getStandardMenuMarkup by default should render the right structure 1`] 
               role="listbox"
               tabIndex={0}
             >
-              <MenuItem
-                active={true}
-                href="/all-properties"
-                key="All properties1"
-                link={true}
-              >
-                <a
-                  className="active link item"
-                  href="/all-properties"
-                  onClick={[Function]}
-                >
-                  All properties
-                </a>
-              </MenuItem>
+              All properties
               <Icon
                 color={null}
                 hasBorder={false}
@@ -394,15 +375,17 @@ exports[`getStandardMenuMarkup if \`props.primaryCTA\` is passed should render t
       >
         <MenuItem
           active={false}
+          href="/"
           key="Home0"
           link={true}
         >
-          <div
+          <a
             className="link item"
+            href="/"
             onClick={[Function]}
           >
             Home
-          </div>
+          </a>
         </MenuItem>
         <Submenu
           isMenuItem={true}
@@ -495,15 +478,7 @@ exports[`getStandardMenuMarkup if \`props.primaryCTA\` is passed should render t
             selectOnBlur={true}
             selectOnNavigation={true}
             simple={true}
-            trigger={
-              <MenuItem
-                active={true}
-                href="/all-properties"
-                link={true}
-              >
-                All properties
-              </MenuItem>
-            }
+            trigger="All properties"
             upward={false}
             value={null}
             wrapSelection={true}
@@ -520,20 +495,7 @@ exports[`getStandardMenuMarkup if \`props.primaryCTA\` is passed should render t
               role="listbox"
               tabIndex={0}
             >
-              <MenuItem
-                active={true}
-                href="/all-properties"
-                key="All properties1"
-                link={true}
-              >
-                <a
-                  className="active link item"
-                  href="/all-properties"
-                  onClick={[Function]}
-                >
-                  All properties
-                </a>
-              </MenuItem>
+              All properties
               <Icon
                 color={null}
                 hasBorder={false}

--- a/src/components/collections/Header/utils/getHiddenMenuMarkup.js
+++ b/src/components/collections/Header/utils/getHiddenMenuMarkup.js
@@ -90,16 +90,7 @@ export const getHiddenMenuMarkup = (
                 panels={[
                   {
                     title: {
-                      content: (
-                        <Menu.Item
-                          active={index === activeNavigationItemIndex}
-                          href={href}
-                          key={buildKeyFromStrings(text, index)}
-                          link
-                        >
-                          {text}
-                        </Menu.Item>
-                      ),
+                      content: text,
                       key: buildKeyFromStrings(text, index),
                     },
                     content: {

--- a/src/components/collections/Header/utils/getStandardMenuMarkup.js
+++ b/src/components/collections/Header/utils/getStandardMenuMarkup.js
@@ -46,14 +46,7 @@ export const getStandardMenuMarkup = ({
             !!primaryCTA
           )}
         >
-          <Menu.Item
-            active={index === activeNavigationItemIndex}
-            href={href}
-            key={buildKeyFromStrings(text, index)}
-            link
-          >
-            {text}
-          </Menu.Item>
+          {text}
         </Submenu>
       ) : (
         getLinkMarkup(text, href, index, activeNavigationItemIndex)

--- a/src/styles/semantic/themes/livingstone/collections/menu.overrides
+++ b/src/styles/semantic/themes/livingstone/collections/menu.overrides
@@ -127,16 +127,6 @@
           border-bottom-color: var(@themeActionColorIdentifier, @themeActionColorDefault);
         }
       }
-
-      &.accordion {
-
-        .title {
-
-          .link.item {
-            display: inline;
-          }
-        }
-      }
     }
   }
 
@@ -317,10 +307,6 @@ header {
         @media @mobileScreen {
           border: none;
         }
-      }
-
-      > .item.dropdown {
-        padding: 0;
       }
 
       > .active.item,

--- a/src/styles/semantic/themes/livingstone/collections/menu.variables
+++ b/src/styles/semantic/themes/livingstone/collections/menu.variables
@@ -77,7 +77,7 @@
 @dropdownHoveredItemBackground: @primaryColor;
 
 /* Dropdown Variations */
-@pointingDropdownMenuDistance: -(20%);
+@pointingDropdownMenuDistance: -(10%);
 
 /*--------------
      States


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1691)

### What **one** thing does this PR do?
Reverts the changes made in https://github.com/lodgify/lodgify-ui/pull/481 so that submenus in header have no link.
