### PR TITLE
TE-1685 Desktop Menu Modal layout fix

### DIFF
--- a/src/components/collections/Header/__snapshots__/component.spec.js.snap
+++ b/src/components/collections/Header/__snapshots__/component.spec.js.snap
@@ -69,14 +69,12 @@ exports[`<Header /> by default should render the right structure 1`] = `
           <div
             className="ui borderless ui text container menu"
           >
-            <MenuItem
+            <Item
               href="/"
-              link={true}
             >
               <a
-                className="link item"
+                className="item"
                 href="/"
-                onClick={[Function]}
               >
                 <Heading
                   className={null}
@@ -98,7 +96,7 @@ exports[`<Header /> by default should render the right structure 1`] = `
                   </Header>
                 </Heading>
               </a>
-            </MenuItem>
+            </Item>
             <ShowOn
               computer={false}
               mobile={true}
@@ -164,13 +162,9 @@ exports[`<Header /> by default should render the right structure 1`] = `
                           closeOnDimmerClick={true}
                           closeOnDocumentClick={false}
                           content={
-                            <Menu
-                              text={true}
-                              vertical={true}
-                            >
-                              <MenuItem
+                            Array [
+                              <Item
                                 href="/"
-                                link={true}
                               >
                                 <Heading
                                   className={null}
@@ -180,75 +174,80 @@ exports[`<Header /> by default should render the right structure 1`] = `
                                 >
                                   someLogoText
                                 </Heading>
-                              </MenuItem>
-                              <MenuItem
-                                active={false}
-                                href="/"
-                                link={true}
+                              </Item>,
+                              <Menu
+                                text={true}
+                                vertical={true}
                               >
-                                Home
-                              </MenuItem>
-                              <Accordion
-                                as={[Function]}
-                                panels={
-                                  Array [
-                                    Object {
-                                      "content": Object {
-                                        "content": Array [
-                                          <MenuItem
-                                            active={false}
-                                            href="/la-casa-viva"
-                                            link={true}
-                                          >
-                                            La Casa Viva
-                                          </MenuItem>,
-                                          <MenuItem
-                                            active={false}
-                                            href="/la-casa-muerta"
-                                            link={true}
-                                          >
-                                            La Casa Muerta
-                                          </MenuItem>,
-                                          <MenuItem
-                                            active={false}
-                                            href="/the-white-lodge"
-                                            link={true}
-                                          >
-                                            The White Lodge
-                                          </MenuItem>,
-                                          <MenuItem
-                                            active={false}
-                                            href="/the-black-lodge"
-                                            link={true}
-                                          >
-                                            The Black Lodge
-                                          </MenuItem>,
-                                        ],
-                                        "key": "1All properties",
+                                <MenuItem
+                                  active={false}
+                                  href="/"
+                                  link={true}
+                                >
+                                  Home
+                                </MenuItem>
+                                <Accordion
+                                  as={[Function]}
+                                  panels={
+                                    Array [
+                                      Object {
+                                        "content": Object {
+                                          "content": Array [
+                                            <MenuItem
+                                              active={false}
+                                              href="/la-casa-viva"
+                                              link={true}
+                                            >
+                                              La Casa Viva
+                                            </MenuItem>,
+                                            <MenuItem
+                                              active={false}
+                                              href="/la-casa-muerta"
+                                              link={true}
+                                            >
+                                              La Casa Muerta
+                                            </MenuItem>,
+                                            <MenuItem
+                                              active={false}
+                                              href="/the-white-lodge"
+                                              link={true}
+                                            >
+                                              The White Lodge
+                                            </MenuItem>,
+                                            <MenuItem
+                                              active={false}
+                                              href="/the-black-lodge"
+                                              link={true}
+                                            >
+                                              The Black Lodge
+                                            </MenuItem>,
+                                          ],
+                                          "key": "1All properties",
+                                        },
+                                        "title": Object {
+                                          "content": "All properties",
+                                          "key": "All properties1",
+                                        },
                                       },
-                                      "title": Object {
-                                        "content": "All properties",
-                                        "key": "All properties1",
-                                      },
-                                    },
-                                  ]
-                                }
-                              />
-                              <MenuItem
-                                active={false}
-                                href="/"
-                                link={true}
-                              >
-                                Contact Us
-                              </MenuItem>
-                              <MenuItem
-                                active={false}
-                                href="/"
-                                link={true}
-                              >
-                                What to do
-                              </MenuItem>
-                            </Menu>
+                                    ]
+                                  }
+                                />
+                                <MenuItem
+                                  active={false}
+                                  href="/"
+                                  link={true}
+                                >
+                                  Contact Us
+                                </MenuItem>
+                                <MenuItem
+                                  active={false}
+                                  href="/"
+                                  link={true}
+                                >
+                                  What to do
+                                </MenuItem>
+                              </Menu>,
+                            ]
                           }
                           dimmer="inverted"
                           eventPool="Modal"
@@ -773,14 +772,12 @@ exports[`<Header /> if \`props.isBackgroundFilled\` is true should render the ri
           <div
             className="ui borderless ui text container menu"
           >
-            <MenuItem
+            <Item
               href="/"
-              link={true}
             >
               <a
-                className="link item"
+                className="item"
                 href="/"
-                onClick={[Function]}
               >
                 <Heading
                   className={null}
@@ -802,7 +799,7 @@ exports[`<Header /> if \`props.isBackgroundFilled\` is true should render the ri
                   </Header>
                 </Heading>
               </a>
-            </MenuItem>
+            </Item>
             <ShowOn
               computer={false}
               mobile={true}
@@ -868,13 +865,9 @@ exports[`<Header /> if \`props.isBackgroundFilled\` is true should render the ri
                           closeOnDimmerClick={true}
                           closeOnDocumentClick={false}
                           content={
-                            <Menu
-                              text={true}
-                              vertical={true}
-                            >
-                              <MenuItem
+                            Array [
+                              <Item
                                 href="/"
-                                link={true}
                               >
                                 <Heading
                                   className={null}
@@ -884,75 +877,80 @@ exports[`<Header /> if \`props.isBackgroundFilled\` is true should render the ri
                                 >
                                   someLogoText
                                 </Heading>
-                              </MenuItem>
-                              <MenuItem
-                                active={false}
-                                href="/"
-                                link={true}
+                              </Item>,
+                              <Menu
+                                text={true}
+                                vertical={true}
                               >
-                                Home
-                              </MenuItem>
-                              <Accordion
-                                as={[Function]}
-                                panels={
-                                  Array [
-                                    Object {
-                                      "content": Object {
-                                        "content": Array [
-                                          <MenuItem
-                                            active={false}
-                                            href="/la-casa-viva"
-                                            link={true}
-                                          >
-                                            La Casa Viva
-                                          </MenuItem>,
-                                          <MenuItem
-                                            active={false}
-                                            href="/la-casa-muerta"
-                                            link={true}
-                                          >
-                                            La Casa Muerta
-                                          </MenuItem>,
-                                          <MenuItem
-                                            active={false}
-                                            href="/the-white-lodge"
-                                            link={true}
-                                          >
-                                            The White Lodge
-                                          </MenuItem>,
-                                          <MenuItem
-                                            active={false}
-                                            href="/the-black-lodge"
-                                            link={true}
-                                          >
-                                            The Black Lodge
-                                          </MenuItem>,
-                                        ],
-                                        "key": "1All properties",
+                                <MenuItem
+                                  active={false}
+                                  href="/"
+                                  link={true}
+                                >
+                                  Home
+                                </MenuItem>
+                                <Accordion
+                                  as={[Function]}
+                                  panels={
+                                    Array [
+                                      Object {
+                                        "content": Object {
+                                          "content": Array [
+                                            <MenuItem
+                                              active={false}
+                                              href="/la-casa-viva"
+                                              link={true}
+                                            >
+                                              La Casa Viva
+                                            </MenuItem>,
+                                            <MenuItem
+                                              active={false}
+                                              href="/la-casa-muerta"
+                                              link={true}
+                                            >
+                                              La Casa Muerta
+                                            </MenuItem>,
+                                            <MenuItem
+                                              active={false}
+                                              href="/the-white-lodge"
+                                              link={true}
+                                            >
+                                              The White Lodge
+                                            </MenuItem>,
+                                            <MenuItem
+                                              active={false}
+                                              href="/the-black-lodge"
+                                              link={true}
+                                            >
+                                              The Black Lodge
+                                            </MenuItem>,
+                                          ],
+                                          "key": "1All properties",
+                                        },
+                                        "title": Object {
+                                          "content": "All properties",
+                                          "key": "All properties1",
+                                        },
                                       },
-                                      "title": Object {
-                                        "content": "All properties",
-                                        "key": "All properties1",
-                                      },
-                                    },
-                                  ]
-                                }
-                              />
-                              <MenuItem
-                                active={false}
-                                href="/"
-                                link={true}
-                              >
-                                Contact Us
-                              </MenuItem>
-                              <MenuItem
-                                active={false}
-                                href="/"
-                                link={true}
-                              >
-                                What to do
-                              </MenuItem>
-                            </Menu>
+                                    ]
+                                  }
+                                />
+                                <MenuItem
+                                  active={false}
+                                  href="/"
+                                  link={true}
+                                >
+                                  Contact Us
+                                </MenuItem>
+                                <MenuItem
+                                  active={false}
+                                  href="/"
+                                  link={true}
+                                >
+                                  What to do
+                                </MenuItem>
+                              </Menu>,
+                            ]
                           }
                           dimmer="inverted"
                           eventPool="Modal"
@@ -1477,14 +1475,12 @@ exports[`<Header /> if navigation items exceed the header max width should rende
           <div
             className="ui borderless ui text container menu"
           >
-            <MenuItem
+            <Item
               href="/"
-              link={true}
             >
               <a
-                className="link item"
+                className="item"
                 href="/"
-                onClick={[Function]}
               >
                 <Heading
                   className={null}
@@ -1506,7 +1502,7 @@ exports[`<Header /> if navigation items exceed the header max width should rende
                   </Header>
                 </Heading>
               </a>
-            </MenuItem>
+            </Item>
             <ShowOn
               computer={true}
               mobile={true}
@@ -1572,13 +1568,9 @@ exports[`<Header /> if navigation items exceed the header max width should rende
                           closeOnDimmerClick={true}
                           closeOnDocumentClick={false}
                           content={
-                            <Menu
-                              text={true}
-                              vertical={true}
-                            >
-                              <MenuItem
+                            Array [
+                              <Item
                                 href="/"
-                                link={true}
                               >
                                 <Heading
                                   className={null}
@@ -1588,75 +1580,80 @@ exports[`<Header /> if navigation items exceed the header max width should rende
                                 >
                                   someLogoText
                                 </Heading>
-                              </MenuItem>
-                              <MenuItem
-                                active={false}
-                                href="/"
-                                link={true}
+                              </Item>,
+                              <Menu
+                                text={true}
+                                vertical={true}
                               >
-                                Home
-                              </MenuItem>
-                              <Accordion
-                                as={[Function]}
-                                panels={
-                                  Array [
-                                    Object {
-                                      "content": Object {
-                                        "content": Array [
-                                          <MenuItem
-                                            active={false}
-                                            href="/la-casa-viva"
-                                            link={true}
-                                          >
-                                            La Casa Viva
-                                          </MenuItem>,
-                                          <MenuItem
-                                            active={false}
-                                            href="/la-casa-muerta"
-                                            link={true}
-                                          >
-                                            La Casa Muerta
-                                          </MenuItem>,
-                                          <MenuItem
-                                            active={false}
-                                            href="/the-white-lodge"
-                                            link={true}
-                                          >
-                                            The White Lodge
-                                          </MenuItem>,
-                                          <MenuItem
-                                            active={false}
-                                            href="/the-black-lodge"
-                                            link={true}
-                                          >
-                                            The Black Lodge
-                                          </MenuItem>,
-                                        ],
-                                        "key": "1All properties",
+                                <MenuItem
+                                  active={false}
+                                  href="/"
+                                  link={true}
+                                >
+                                  Home
+                                </MenuItem>
+                                <Accordion
+                                  as={[Function]}
+                                  panels={
+                                    Array [
+                                      Object {
+                                        "content": Object {
+                                          "content": Array [
+                                            <MenuItem
+                                              active={false}
+                                              href="/la-casa-viva"
+                                              link={true}
+                                            >
+                                              La Casa Viva
+                                            </MenuItem>,
+                                            <MenuItem
+                                              active={false}
+                                              href="/la-casa-muerta"
+                                              link={true}
+                                            >
+                                              La Casa Muerta
+                                            </MenuItem>,
+                                            <MenuItem
+                                              active={false}
+                                              href="/the-white-lodge"
+                                              link={true}
+                                            >
+                                              The White Lodge
+                                            </MenuItem>,
+                                            <MenuItem
+                                              active={false}
+                                              href="/the-black-lodge"
+                                              link={true}
+                                            >
+                                              The Black Lodge
+                                            </MenuItem>,
+                                          ],
+                                          "key": "1All properties",
+                                        },
+                                        "title": Object {
+                                          "content": "All properties",
+                                          "key": "All properties1",
+                                        },
                                       },
-                                      "title": Object {
-                                        "content": "All properties",
-                                        "key": "All properties1",
-                                      },
-                                    },
-                                  ]
-                                }
-                              />
-                              <MenuItem
-                                active={false}
-                                href="/"
-                                link={true}
-                              >
-                                Contact Us
-                              </MenuItem>
-                              <MenuItem
-                                active={false}
-                                href="/"
-                                link={true}
-                              >
-                                What to do when you go out on a Sunday and then somebody attacks you with big floppy fish
-                              </MenuItem>
-                            </Menu>
+                                    ]
+                                  }
+                                />
+                                <MenuItem
+                                  active={false}
+                                  href="/"
+                                  link={true}
+                                >
+                                  Contact Us
+                                </MenuItem>
+                                <MenuItem
+                                  active={false}
+                                  href="/"
+                                  link={true}
+                                >
+                                  What to do when you go out on a Sunday and then somebody attacks you with big floppy fish
+                                </MenuItem>
+                              </Menu>,
+                            ]
                           }
                           dimmer="inverted"
                           eventPool="Modal"

--- a/src/components/collections/Header/utils/__snapshots__/getHiddenMenuMarkup.spec.js.snap
+++ b/src/components/collections/Header/utils/__snapshots__/getHiddenMenuMarkup.spec.js.snap
@@ -66,13 +66,9 @@ exports[`getHiddenMenuMarkup by default should render the right structure 1`] = 
               closeOnDimmerClick={true}
               closeOnDocumentClick={false}
               content={
-                <Menu
-                  text={true}
-                  vertical={true}
-                >
-                  <MenuItem
+                Array [
+                  <Item
                     href="/"
-                    link={true}
                   >
                     <Image
                       alt="someLogoText"
@@ -82,75 +78,80 @@ exports[`getHiddenMenuMarkup by default should render the right structure 1`] = 
                       srcSet="someLogoSrcSet"
                       ui={true}
                     />
-                  </MenuItem>
-                  <MenuItem
-                    active={true}
-                    href="/"
-                    link={true}
+                  </Item>,
+                  <Menu
+                    text={true}
+                    vertical={true}
                   >
-                    Home
-                  </MenuItem>
-                  <Accordion
-                    as={[Function]}
-                    panels={
-                      Array [
-                        Object {
-                          "content": Object {
-                            "content": Array [
-                              <MenuItem
-                                active={true}
-                                href="/la-casa-viva"
-                                link={true}
-                              >
-                                La Casa Viva
-                              </MenuItem>,
-                              <MenuItem
-                                active={false}
-                                href="/la-casa-muerta"
-                                link={true}
-                              >
-                                La Casa Muerta
-                              </MenuItem>,
-                              <MenuItem
-                                active={false}
-                                href="/the-white-lodge"
-                                link={true}
-                              >
-                                The White Lodge
-                              </MenuItem>,
-                              <MenuItem
-                                active={false}
-                                href="/the-black-lodge"
-                                link={true}
-                              >
-                                The Black Lodge
-                              </MenuItem>,
-                            ],
-                            "key": "1All properties",
+                    <MenuItem
+                      active={true}
+                      href="/"
+                      link={true}
+                    >
+                      Home
+                    </MenuItem>
+                    <Accordion
+                      as={[Function]}
+                      panels={
+                        Array [
+                          Object {
+                            "content": Object {
+                              "content": Array [
+                                <MenuItem
+                                  active={true}
+                                  href="/la-casa-viva"
+                                  link={true}
+                                >
+                                  La Casa Viva
+                                </MenuItem>,
+                                <MenuItem
+                                  active={false}
+                                  href="/la-casa-muerta"
+                                  link={true}
+                                >
+                                  La Casa Muerta
+                                </MenuItem>,
+                                <MenuItem
+                                  active={false}
+                                  href="/the-white-lodge"
+                                  link={true}
+                                >
+                                  The White Lodge
+                                </MenuItem>,
+                                <MenuItem
+                                  active={false}
+                                  href="/the-black-lodge"
+                                  link={true}
+                                >
+                                  The Black Lodge
+                                </MenuItem>,
+                              ],
+                              "key": "1All properties",
+                            },
+                            "title": Object {
+                              "content": "All properties",
+                              "key": "All properties1",
+                            },
                           },
-                          "title": Object {
-                            "content": "All properties",
-                            "key": "All properties1",
-                          },
-                        },
-                      ]
-                    }
-                  />
-                  <MenuItem
-                    active={false}
-                    href="/"
-                    link={true}
-                  >
-                    Contact Us
-                  </MenuItem>
-                  <MenuItem
-                    active={false}
-                    href="/"
-                    link={true}
-                  >
-                    What to do
-                  </MenuItem>
-                </Menu>
+                        ]
+                      }
+                    />
+                    <MenuItem
+                      active={false}
+                      href="/"
+                      link={true}
+                    >
+                      Contact Us
+                    </MenuItem>
+                    <MenuItem
+                      active={false}
+                      href="/"
+                      link={true}
+                    >
+                      What to do
+                    </MenuItem>
+                  </Menu>,
+                ]
               }
               dimmer="inverted"
               eventPool="Modal"
@@ -590,13 +591,9 @@ exports[`getHiddenMenuMarkup if \`props.searchBarGuestsOptions\` and \`props.sea
               closeOnDimmerClick={true}
               closeOnDocumentClick={false}
               content={
-                <Menu
-                  text={true}
-                  vertical={true}
-                >
-                  <MenuItem
+                Array [
+                  <Item
                     href="/"
-                    link={true}
                   >
                     <Image
                       alt="someLogoText"
@@ -606,75 +603,80 @@ exports[`getHiddenMenuMarkup if \`props.searchBarGuestsOptions\` and \`props.sea
                       srcSet="someLogoSrcSet"
                       ui={true}
                     />
-                  </MenuItem>
-                  <MenuItem
-                    active={true}
-                    href="/"
-                    link={true}
+                  </Item>,
+                  <Menu
+                    text={true}
+                    vertical={true}
                   >
-                    Home
-                  </MenuItem>
-                  <Accordion
-                    as={[Function]}
-                    panels={
-                      Array [
-                        Object {
-                          "content": Object {
-                            "content": Array [
-                              <MenuItem
-                                active={true}
-                                href="/la-casa-viva"
-                                link={true}
-                              >
-                                La Casa Viva
-                              </MenuItem>,
-                              <MenuItem
-                                active={false}
-                                href="/la-casa-muerta"
-                                link={true}
-                              >
-                                La Casa Muerta
-                              </MenuItem>,
-                              <MenuItem
-                                active={false}
-                                href="/the-white-lodge"
-                                link={true}
-                              >
-                                The White Lodge
-                              </MenuItem>,
-                              <MenuItem
-                                active={false}
-                                href="/the-black-lodge"
-                                link={true}
-                              >
-                                The Black Lodge
-                              </MenuItem>,
-                            ],
-                            "key": "1All properties",
+                    <MenuItem
+                      active={true}
+                      href="/"
+                      link={true}
+                    >
+                      Home
+                    </MenuItem>
+                    <Accordion
+                      as={[Function]}
+                      panels={
+                        Array [
+                          Object {
+                            "content": Object {
+                              "content": Array [
+                                <MenuItem
+                                  active={true}
+                                  href="/la-casa-viva"
+                                  link={true}
+                                >
+                                  La Casa Viva
+                                </MenuItem>,
+                                <MenuItem
+                                  active={false}
+                                  href="/la-casa-muerta"
+                                  link={true}
+                                >
+                                  La Casa Muerta
+                                </MenuItem>,
+                                <MenuItem
+                                  active={false}
+                                  href="/the-white-lodge"
+                                  link={true}
+                                >
+                                  The White Lodge
+                                </MenuItem>,
+                                <MenuItem
+                                  active={false}
+                                  href="/the-black-lodge"
+                                  link={true}
+                                >
+                                  The Black Lodge
+                                </MenuItem>,
+                              ],
+                              "key": "1All properties",
+                            },
+                            "title": Object {
+                              "content": "All properties",
+                              "key": "All properties1",
+                            },
                           },
-                          "title": Object {
-                            "content": "All properties",
-                            "key": "All properties1",
-                          },
-                        },
-                      ]
-                    }
-                  />
-                  <MenuItem
-                    active={false}
-                    href="/"
-                    link={true}
-                  >
-                    Contact Us
-                  </MenuItem>
-                  <MenuItem
-                    active={false}
-                    href="/"
-                    link={true}
-                  >
-                    What to do
-                  </MenuItem>
-                </Menu>
+                        ]
+                      }
+                    />
+                    <MenuItem
+                      active={false}
+                      href="/"
+                      link={true}
+                    >
+                      Contact Us
+                    </MenuItem>
+                    <MenuItem
+                      active={false}
+                      href="/"
+                      link={true}
+                    >
+                      What to do
+                    </MenuItem>
+                  </Menu>,
+                ]
               }
               dimmer="inverted"
               eventPool="Modal"

--- a/src/components/collections/Header/utils/__snapshots__/getLogoMarkup.spec.js.snap
+++ b/src/components/collections/Header/utils/__snapshots__/getLogoMarkup.spec.js.snap
@@ -1,14 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`getLogoMarkup by default should render the right structure 1`] = `
-<MenuItem
+<Item
   href="/"
-  link={true}
 >
   <a
-    className="link item"
+    className="item"
     href="/"
-    onClick={[Function]}
   >
     <Heading
       className={null}
@@ -30,18 +28,16 @@ exports[`getLogoMarkup by default should render the right structure 1`] = `
       </Header>
     </Heading>
   </a>
-</MenuItem>
+</Item>
 `;
 
 exports[`getLogoMarkup if \`logoSrc\`, \`logoSizes\` and \`logoSrcSet\` are passed should render the right structure 1`] = `
-<MenuItem
+<Item
   href="/"
-  link={true}
 >
   <a
-    className="link item"
+    className="item"
     href="/"
-    onClick={[Function]}
   >
     <Image
       alt="someLogoText"
@@ -60,5 +56,5 @@ exports[`getLogoMarkup if \`logoSrc\`, \`logoSizes\` and \`logoSrcSet\` are pass
       />
     </Image>
   </a>
-</MenuItem>
+</Item>
 `;

--- a/src/components/collections/Header/utils/getHiddenMenuMarkup.js
+++ b/src/components/collections/Header/utils/getHiddenMenuMarkup.js
@@ -80,8 +80,8 @@ export const getHiddenMenuMarkup = (
     )}
     <Menu.Item>
       <Modal isFullscreen trigger={<Icon name={ICON_NAMES.BARS} />}>
+        {getLogoMarkup(logoText, logoSrc, logoSizes, logoSrcSet)}
         <Menu text vertical>
-          {getLogoMarkup(logoText, logoSrc, logoSizes, logoSrcSet)}
           {navigationItems.map(({ subItems, text, href }, index) =>
             size(subItems) ? (
               <Accordion

--- a/src/components/collections/Header/utils/getLogoMarkup.js
+++ b/src/components/collections/Header/utils/getLogoMarkup.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Menu, Image } from 'semantic-ui-react';
+import { Item, Image } from 'semantic-ui-react';
 
 import { Heading } from 'typography/Heading';
 
@@ -11,7 +11,7 @@ import { Heading } from 'typography/Heading';
  * @return {Object}
  */
 export const getLogoMarkup = (logoText, logoSrc, logoSizes, logoSrcSet) => (
-  <Menu.Item href="/" link>
+  <Item href="/">
     {logoSrc ? (
       <Image
         alt={logoText}
@@ -22,5 +22,5 @@ export const getLogoMarkup = (logoText, logoSrc, logoSizes, logoSrcSet) => (
     ) : (
       <Heading size="small">{logoText}</Heading>
     )}
-  </Menu.Item>
+  </Item>
 );

--- a/src/components/collections/Hero/__snapshots__/component.spec.js.snap
+++ b/src/components/collections/Hero/__snapshots__/component.spec.js.snap
@@ -176,14 +176,12 @@ exports[`<Hero /> by default should render the right structure 1`] = `
                   <div
                     className="ui borderless ui text container menu"
                   >
-                    <MenuItem
+                    <Item
                       href="/"
-                      link={true}
                     >
                       <a
-                        className="link item"
+                        className="item"
                         href="/"
-                        onClick={[Function]}
                       >
                         <Image
                           alt="Livingstone Cottage"
@@ -202,7 +200,7 @@ exports[`<Hero /> by default should render the right structure 1`] = `
                           />
                         </Image>
                       </a>
-                    </MenuItem>
+                    </Item>
                     <ShowOn
                       computer={false}
                       mobile={true}
@@ -567,13 +565,9 @@ exports[`<Hero /> by default should render the right structure 1`] = `
                                   closeOnDimmerClick={true}
                                   closeOnDocumentClick={false}
                                   content={
-                                    <Menu
-                                      text={true}
-                                      vertical={true}
-                                    >
-                                      <MenuItem
+                                    Array [
+                                      <Item
                                         href="/"
-                                        link={true}
                                       >
                                         <Image
                                           alt="Livingstone Cottage"
@@ -583,15 +577,20 @@ exports[`<Hero /> by default should render the right structure 1`] = `
                                           srcSet="a load of logo src sets"
                                           ui={true}
                                         />
-                                      </MenuItem>
-                                      <MenuItem
-                                        active={false}
-                                        href="/"
-                                        link={true}
+                                      </Item>,
+                                      <Menu
+                                        text={true}
+                                        vertical={true}
                                       >
-                                        Home
-                                      </MenuItem>
-                                    </Menu>
+                                        <MenuItem
+                                          active={false}
+                                          href="/"
+                                          link={true}
+                                        >
+                                          Home
+                                        </MenuItem>
+                                      </Menu>,
+                                    ]
                                   }
                                   dimmer="inverted"
                                   eventPool="Modal"

--- a/src/components/general-widgets/HomepageHero/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/HomepageHero/__snapshots__/component.spec.js.snap
@@ -240,14 +240,12 @@ exports[`HomepageHero should render the right structure 1`] = `
                     <div
                       className="ui borderless ui text container menu"
                     >
-                      <MenuItem
+                      <Item
                         href="/"
-                        link={true}
                       >
                         <a
-                          className="link item"
+                          className="item"
                           href="/"
-                          onClick={[Function]}
                         >
                           <Image
                             alt="text"
@@ -266,7 +264,7 @@ exports[`HomepageHero should render the right structure 1`] = `
                             />
                           </Image>
                         </a>
-                      </MenuItem>
+                      </Item>
                       <ShowOn
                         computer={false}
                         mobile={true}
@@ -609,13 +607,9 @@ exports[`HomepageHero should render the right structure 1`] = `
                                     closeOnDimmerClick={true}
                                     closeOnDocumentClick={false}
                                     content={
-                                      <Menu
-                                        text={true}
-                                        vertical={true}
-                                      >
-                                        <MenuItem
+                                      Array [
+                                        <Item
                                           href="/"
-                                          link={true}
                                         >
                                           <Image
                                             alt="text"
@@ -625,15 +619,20 @@ exports[`HomepageHero should render the right structure 1`] = `
                                             srcSet="a load of logo src sets"
                                             ui={true}
                                           />
-                                        </MenuItem>
-                                        <MenuItem
-                                          active={false}
-                                          href="/"
-                                          link={true}
+                                        </Item>,
+                                        <Menu
+                                          text={true}
+                                          vertical={true}
                                         >
-                                          Home
-                                        </MenuItem>
-                                      </Menu>
+                                          <MenuItem
+                                            active={false}
+                                            href="/"
+                                            link={true}
+                                          >
+                                            Home
+                                          </MenuItem>
+                                        </Menu>,
+                                      ]
                                     }
                                     dimmer="inverted"
                                     eventPool="Modal"

--- a/src/components/property-page-widgets/PropertyPageHero/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/PropertyPageHero/__snapshots__/component.spec.js.snap
@@ -232,14 +232,12 @@ exports[`PropertyPageHero by default if there are fewer than two images should r
                     <div
                       className="ui borderless ui text container menu"
                     >
-                      <MenuItem
+                      <Item
                         href="/"
-                        link={true}
                       >
                         <a
-                          className="link item"
+                          className="item"
                           href="/"
-                          onClick={[Function]}
                         >
                           <Image
                             alt="text"
@@ -258,7 +256,7 @@ exports[`PropertyPageHero by default if there are fewer than two images should r
                             />
                           </Image>
                         </a>
-                      </MenuItem>
+                      </Item>
                       <ShowOn
                         computer={false}
                         mobile={true}
@@ -595,13 +593,9 @@ exports[`PropertyPageHero by default if there are fewer than two images should r
                                     closeOnDimmerClick={true}
                                     closeOnDocumentClick={false}
                                     content={
-                                      <Menu
-                                        text={true}
-                                        vertical={true}
-                                      >
-                                        <MenuItem
+                                      Array [
+                                        <Item
                                           href="/"
-                                          link={true}
                                         >
                                           <Image
                                             alt="text"
@@ -611,15 +605,20 @@ exports[`PropertyPageHero by default if there are fewer than two images should r
                                             srcSet="a load of logo src sets"
                                             ui={true}
                                           />
-                                        </MenuItem>
-                                        <MenuItem
-                                          active={false}
-                                          href="/"
-                                          link={true}
+                                        </Item>,
+                                        <Menu
+                                          text={true}
+                                          vertical={true}
                                         >
-                                          Home
-                                        </MenuItem>
-                                      </Menu>
+                                          <MenuItem
+                                            active={false}
+                                            href="/"
+                                            link={true}
+                                          >
+                                            Home
+                                          </MenuItem>
+                                        </Menu>,
+                                      ]
                                     }
                                     dimmer="inverted"
                                     eventPool="Modal"
@@ -1048,14 +1047,12 @@ exports[`PropertyPageHero by default should render the right structure 1`] = `
                     <div
                       className="ui borderless ui text container menu"
                     >
-                      <MenuItem
+                      <Item
                         href="/"
-                        link={true}
                       >
                         <a
-                          className="link item"
+                          className="item"
                           href="/"
-                          onClick={[Function]}
                         >
                           <Image
                             alt="text"
@@ -1074,7 +1071,7 @@ exports[`PropertyPageHero by default should render the right structure 1`] = `
                             />
                           </Image>
                         </a>
-                      </MenuItem>
+                      </Item>
                       <ShowOn
                         computer={false}
                         mobile={true}
@@ -1411,13 +1408,9 @@ exports[`PropertyPageHero by default should render the right structure 1`] = `
                                     closeOnDimmerClick={true}
                                     closeOnDocumentClick={false}
                                     content={
-                                      <Menu
-                                        text={true}
-                                        vertical={true}
-                                      >
-                                        <MenuItem
+                                      Array [
+                                        <Item
                                           href="/"
-                                          link={true}
                                         >
                                           <Image
                                             alt="text"
@@ -1427,15 +1420,20 @@ exports[`PropertyPageHero by default should render the right structure 1`] = `
                                             srcSet="a load of logo src sets"
                                             ui={true}
                                           />
-                                        </MenuItem>
-                                        <MenuItem
-                                          active={false}
-                                          href="/"
-                                          link={true}
+                                        </Item>,
+                                        <Menu
+                                          text={true}
+                                          vertical={true}
                                         >
-                                          Home
-                                        </MenuItem>
-                                      </Menu>
+                                          <MenuItem
+                                            active={false}
+                                            href="/"
+                                            link={true}
+                                          >
+                                            Home
+                                          </MenuItem>
+                                        </Menu>,
+                                      ]
                                     }
                                     dimmer="inverted"
                                     eventPool="Modal"

--- a/src/styles/semantic/themes/livingstone/collections/menu.overrides
+++ b/src/styles/semantic/themes/livingstone/collections/menu.overrides
@@ -91,19 +91,41 @@
 ---------------*/
 
   /* Vertical */
+
   .ui.modal &.vertical {
     width: @verticalMenuInModalWidth;
+    max-width: @verticalMenuInModalMaxWidth;
+    min-height: @verticalMenuInModalMinHeight;
+    margin: auto;
+    height: auto;
+    display: flex;
+    justify-content: center;
+    margin-top: @verticalMenuInModalMarginTop;
+
+    @media only screen and (max-width: @largeMonitorBreakpoint) {
+      margin-top: @verticalMenuInModalMarginTopMobile;
+      justify-content: flex-start;
+    }
+
+    &:not(.accordion) > .item {
+      border-bottom: @verticalMenuInModalItemBorderBottom;
+      line-height: @verticalMenuInModalItemLineHeight;
+      padding-left: @verticalMenuInModalItemPaddingLeft;
+      font-weight: bold;
+    }
 
     > .item {
+      align-self: flex-start;
+      width: 100%;
+      margin: 0;
+      padding-top: @verticalMenuInModalItemPaddingTop;
+      padding-bottom: @verticalMenuInModalItemPaddingBottom;
 
       &:first-child {
         padding-top: 0;
       }
 
       &:not(:first-child) {
-        border-bottom: @verticalMenuInModalItemBorderBottom;
-        line-height: @verticalMenuInModalItemLineHeight;
-        padding-left: @verticalMenuInModalItemPaddingLeft;
 
         > .title {
           padding: 0;
@@ -119,6 +141,9 @@
 
           > .item {
             padding-left: @verticalMenuInModalSubItemPaddingLeft;
+            margin: 0;
+            padding-top: @verticalMenuInModalSubItemPaddingTop;
+            padding-bottom: @verticalMenuInModalSubItemPaddingBottom;
           }
         }
 

--- a/src/styles/semantic/themes/livingstone/collections/menu.variables
+++ b/src/styles/semantic/themes/livingstone/collections/menu.variables
@@ -115,14 +115,25 @@
 /* Vertical */
 @verticalMenuInModalWidthOffset: 2 * @textVerticalMenuHorizontalMargin;
 @verticalMenuInModalWidth: ~"calc(100% - @{verticalMenuInModalWidthOffset})";
+@verticalMenuInModalMaxWidth: 500px;
+
+@verticalMenuInModalMinHeight: ~"calc(100% - 117px)";
 
 @verticalMenuInModalItemLineHeight: @30px;
 @verticalMenuInModalItemPaddingLeft: @10px;
+@verticalMenuInModalItemPaddingTop: 20px;
+@verticalMenuInModalItemPaddingBottom: 20px;
 @verticalMenuInModalItemBorderBottom: @1px solid @greyFour;
+
+@verticalMenuInModalSubItemPaddingTop: 10px;
+@verticalMenuInModalSubItemPaddingBottom: 10px;
 
 @verticalMenuInModalAccordionIconMargin: @8px @verticalMenuInModalItemPaddingLeft 0;
 
 @verticalMenuInModalSubItemPaddingLeft: @10px;
+
+@verticalMenuInModalMarginTop: 50px;
+@verticalMenuInModalMarginTopMobile: 20px;
 
 /* Secondary */
 

--- a/src/styles/semantic/themes/livingstone/modules/modal.overrides
+++ b/src/styles/semantic/themes/livingstone/modules/modal.overrides
@@ -45,17 +45,26 @@
 .ui.fullscreen.modal {
   bottom: 0;
   height: @fullScreenHeight;
-  overflow-y: scroll;
   position: absolute;
   top: 0;
+  width: 100%;
 
   &.scrolling.modal {
     margin: 0 !important;
   }
 
-  .content {
+  > .content > .link.item {
+    display: inline-block;
+  }
+
+  > .content {
     height: 100%;
     overflow: auto;
+    padding: @contentPadding;
+
+    @media only screen and (max-width: @largeMonitorBreakpoint) {
+      padding: @contentPaddingMobile !important;
+    }
   }
 
   .ui.container {
@@ -75,17 +84,12 @@
   }
 
   > i.icon {
-    @media only screen and (min-width: @tabletBreakpoint) {
-      top: @withHorizontalCloseIconTop;
-    }
+    right: @withHorizontalCloseIconRight;
+    top: @withHorizontalCloseIconTop;
 
-    @media only screen and (min-width: (@horizontalGutterMaxWidth + 1)) {
-      left: @withHorizontalCloseIconLeft;
-      right: auto;
-    }
-
-    @media only screen and (min-width: @tabletBreakpoint) and (max-width: @horizontalGutterMaxWidth) {
-      right: @withHorizontalCloseIconRight;
+    @media only screen and (max-width: @largeMonitorBreakpoint) {
+      right: @withHorizontalCloseIconRightMobile;
+      top: @withHorizontalCloseIconTopMobile;
     }
 
     > svg {

--- a/src/styles/semantic/themes/livingstone/modules/modal.variables
+++ b/src/styles/semantic/themes/livingstone/modules/modal.variables
@@ -17,7 +17,8 @@
 /* Header */
 
 /* Content */
-@contentPadding: @32px @36px;
+@contentPadding: 30px 15%;
+@contentPaddingMobile: 15px 5%;
 
 /* Image / Description */
 
@@ -60,7 +61,9 @@
 /* With the horizontal gutters */
 @reducedHeadingWidth: ~"calc(100% - @{30px})";
 @withHorizontalCloseIconTop: @25px;
-@withHorizontalCloseIconRight: @25px;
+@withHorizontalCloseIconTopMobile: @5px;
+@withHorizontalCloseIconRight: 15%;
+@withHorizontalCloseIconRightMobile: 3%;
 
 @halfContainerWidthWithPadding: (@horizontalGutterMaxWidth / 2) - (@horizontalGutterLeftRightPadding * 2);
 @withHorizontalCloseIconLeft: ~"calc(50% + @{halfContainerWidthWithPadding})";


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1685)

### What **one** thing does this PR do?
First, modifies the structure of `getHiddenMenuMarkup` and `getLogoMarkup`; then, applies styling to meet the Youtrack card behaviour.

### Scrolling
![scrolling](https://user-images.githubusercontent.com/33876435/51601837-b5636b80-1f05-11e9-82c9-c35aaa984bcc.gif)

### Size breakpoint
![mobile-desktop-change](https://user-images.githubusercontent.com/33876435/51601906-df1c9280-1f05-11e9-819a-690b702b9f20.gif)

### Height Change

![height_change](https://user-images.githubusercontent.com/33876435/51602077-5e11cb00-1f06-11e9-9cea-301b93bed235.gif)

### Mobile View
![screenshot 2019-01-23 at 12 00 47](https://user-images.githubusercontent.com/33876435/51602155-92858700-1f06-11e9-9440-8c891925a01d.png)

### Desktop View
![screenshot 2019-01-23 at 12 01 53](https://user-images.githubusercontent.com/33876435/51602229-c19bf880-1f06-11e9-860d-5b335d7b1967.png)


