### PR TITLE
TE-1725 Expose a CookieAlert component

### DIFF
--- a/src/components/collections/Header/__snapshots__/component.spec.js.snap
+++ b/src/components/collections/Header/__snapshots__/component.spec.js.snap
@@ -122,7 +122,32 @@ exports[`<Header /> by default should render the right structure 1`] = `
                       onClick={[Function]}
                     >
                       <Modal
+<<<<<<< Updated upstream
+                        dimmer="inverted"
+                        hasMargin={false}
+                        isAlignedBottom={false}
+=======
+                        closeIcon={
+                          <Icon
+                            color={null}
+                            hasBorder={false}
+                            isButton={false}
+                            isCircular={false}
+                            isColorInverted={false}
+                            isDisabled={false}
+                            isLabelLeft={false}
+                            labelText={null}
+                            labelWeight={null}
+                            name="close"
+                            path={null}
+                            size={null}
+                          />
+                        }
+                        hasRoundedCorners={false}
+>>>>>>> Stashed changes
                         isFullscreen={true}
+                        isJustifiedRight={false}
+                        isModalRounded={false}
                         onClose={[Function]}
                         size="tiny"
                         trigger={
@@ -143,6 +168,7 @@ exports[`<Header /> by default should render the right structure 1`] = `
                         }
                       >
                         <Modal
+                          className=""
                           closeIcon={
                             <Icon
                               color={null}
@@ -825,7 +851,32 @@ exports[`<Header /> if \`props.isBackgroundFilled\` is true should render the ri
                       onClick={[Function]}
                     >
                       <Modal
+<<<<<<< Updated upstream
+                        dimmer="inverted"
+                        hasMargin={false}
+                        isAlignedBottom={false}
+=======
+                        closeIcon={
+                          <Icon
+                            color={null}
+                            hasBorder={false}
+                            isButton={false}
+                            isCircular={false}
+                            isColorInverted={false}
+                            isDisabled={false}
+                            isLabelLeft={false}
+                            labelText={null}
+                            labelWeight={null}
+                            name="close"
+                            path={null}
+                            size={null}
+                          />
+                        }
+                        hasRoundedCorners={false}
+>>>>>>> Stashed changes
                         isFullscreen={true}
+                        isJustifiedRight={false}
+                        isModalRounded={false}
                         onClose={[Function]}
                         size="tiny"
                         trigger={
@@ -846,6 +897,7 @@ exports[`<Header /> if \`props.isBackgroundFilled\` is true should render the ri
                         }
                       >
                         <Modal
+                          className=""
                           closeIcon={
                             <Icon
                               color={null}
@@ -1528,7 +1580,32 @@ exports[`<Header /> if navigation items exceed the header max width should rende
                       onClick={[Function]}
                     >
                       <Modal
+<<<<<<< Updated upstream
+                        dimmer="inverted"
+                        hasMargin={false}
+                        isAlignedBottom={false}
+=======
+                        closeIcon={
+                          <Icon
+                            color={null}
+                            hasBorder={false}
+                            isButton={false}
+                            isCircular={false}
+                            isColorInverted={false}
+                            isDisabled={false}
+                            isLabelLeft={false}
+                            labelText={null}
+                            labelWeight={null}
+                            name="close"
+                            path={null}
+                            size={null}
+                          />
+                        }
+                        hasRoundedCorners={false}
+>>>>>>> Stashed changes
                         isFullscreen={true}
+                        isJustifiedRight={false}
+                        isModalRounded={false}
                         onClose={[Function]}
                         size="tiny"
                         trigger={
@@ -1549,6 +1626,7 @@ exports[`<Header /> if navigation items exceed the header max width should rende
                         }
                       >
                         <Modal
+                          className=""
                           closeIcon={
                             <Icon
                               color={null}

--- a/src/components/collections/Header/utils/__snapshots__/getHiddenMenuMarkup.spec.js.snap
+++ b/src/components/collections/Header/utils/__snapshots__/getHiddenMenuMarkup.spec.js.snap
@@ -26,7 +26,32 @@ exports[`getHiddenMenuMarkup by default should render the right structure 1`] = 
           onClick={[Function]}
         >
           <Modal
+<<<<<<< Updated upstream
+            dimmer="inverted"
+            hasMargin={false}
+            isAlignedBottom={false}
+=======
+            closeIcon={
+              <Icon
+                color={null}
+                hasBorder={false}
+                isButton={false}
+                isCircular={false}
+                isColorInverted={false}
+                isDisabled={false}
+                isLabelLeft={false}
+                labelText={null}
+                labelWeight={null}
+                name="close"
+                path={null}
+                size={null}
+              />
+            }
+            hasRoundedCorners={false}
+>>>>>>> Stashed changes
             isFullscreen={true}
+            isJustifiedRight={false}
+            isModalRounded={false}
             onClose={[Function]}
             size="tiny"
             trigger={
@@ -47,6 +72,7 @@ exports[`getHiddenMenuMarkup by default should render the right structure 1`] = 
             }
           >
             <Modal
+              className=""
               closeIcon={
                 <Icon
                   color={null}
@@ -327,7 +353,32 @@ exports[`getHiddenMenuMarkup if \`props.searchBarGuestsOptions\` and \`props.sea
             willDropdownsOpenAbove={false}
           >
             <Modal
+<<<<<<< Updated upstream
+              dimmer="inverted"
+              hasMargin={false}
+              isAlignedBottom={false}
+=======
+              closeIcon={
+                <Icon
+                  color={null}
+                  hasBorder={false}
+                  isButton={false}
+                  isCircular={false}
+                  isColorInverted={false}
+                  isDisabled={false}
+                  isLabelLeft={false}
+                  labelText={null}
+                  labelWeight={null}
+                  name="close"
+                  path={null}
+                  size={null}
+                />
+              }
+              hasRoundedCorners={false}
+>>>>>>> Stashed changes
               isFullscreen={true}
+              isJustifiedRight={false}
+              isModalRounded={false}
               onClose={[Function]}
               size="tiny"
               trigger={
@@ -348,6 +399,7 @@ exports[`getHiddenMenuMarkup if \`props.searchBarGuestsOptions\` and \`props.sea
               }
             >
               <Modal
+                className=""
                 closeIcon={
                   <Icon
                     color={null}
@@ -551,7 +603,32 @@ exports[`getHiddenMenuMarkup if \`props.searchBarGuestsOptions\` and \`props.sea
           onClick={[Function]}
         >
           <Modal
+<<<<<<< Updated upstream
+            dimmer="inverted"
+            hasMargin={false}
+            isAlignedBottom={false}
+=======
+            closeIcon={
+              <Icon
+                color={null}
+                hasBorder={false}
+                isButton={false}
+                isCircular={false}
+                isColorInverted={false}
+                isDisabled={false}
+                isLabelLeft={false}
+                labelText={null}
+                labelWeight={null}
+                name="close"
+                path={null}
+                size={null}
+              />
+            }
+            hasRoundedCorners={false}
+>>>>>>> Stashed changes
             isFullscreen={true}
+            isJustifiedRight={false}
+            isModalRounded={false}
             onClose={[Function]}
             size="tiny"
             trigger={
@@ -572,6 +649,7 @@ exports[`getHiddenMenuMarkup if \`props.searchBarGuestsOptions\` and \`props.sea
             }
           >
             <Modal
+              className=""
               closeIcon={
                 <Icon
                   color={null}

--- a/src/components/collections/Hero/__snapshots__/component.spec.js.snap
+++ b/src/components/collections/Hero/__snapshots__/component.spec.js.snap
@@ -288,7 +288,32 @@ exports[`<Hero /> by default should render the right structure 1`] = `
                                 willDropdownsOpenAbove={false}
                               >
                                 <Modal
+<<<<<<< Updated upstream
+                                  dimmer="inverted"
+                                  hasMargin={false}
+                                  isAlignedBottom={false}
+=======
+                                  closeIcon={
+                                    <Icon
+                                      color={null}
+                                      hasBorder={false}
+                                      isButton={false}
+                                      isCircular={false}
+                                      isColorInverted={false}
+                                      isDisabled={false}
+                                      isLabelLeft={false}
+                                      labelText={null}
+                                      labelWeight={null}
+                                      name="close"
+                                      path={null}
+                                      size={null}
+                                    />
+                                  }
+                                  hasRoundedCorners={false}
+>>>>>>> Stashed changes
                                   isFullscreen={true}
+                                  isJustifiedRight={false}
+                                  isModalRounded={false}
                                   onClose={[Function]}
                                   size="tiny"
                                   trigger={
@@ -309,6 +334,7 @@ exports[`<Hero /> by default should render the right structure 1`] = `
                                   }
                                 >
                                   <Modal
+                                    className=""
                                     closeIcon={
                                       <Icon
                                         color={null}
@@ -525,7 +551,32 @@ exports[`<Hero /> by default should render the right structure 1`] = `
                               onClick={[Function]}
                             >
                               <Modal
+<<<<<<< Updated upstream
+                                dimmer="inverted"
+                                hasMargin={false}
+                                isAlignedBottom={false}
+=======
+                                closeIcon={
+                                  <Icon
+                                    color={null}
+                                    hasBorder={false}
+                                    isButton={false}
+                                    isCircular={false}
+                                    isColorInverted={false}
+                                    isDisabled={false}
+                                    isLabelLeft={false}
+                                    labelText={null}
+                                    labelWeight={null}
+                                    name="close"
+                                    path={null}
+                                    size={null}
+                                  />
+                                }
+                                hasRoundedCorners={false}
+>>>>>>> Stashed changes
                                 isFullscreen={true}
+                                isJustifiedRight={false}
+                                isModalRounded={false}
                                 onClose={[Function]}
                                 size="tiny"
                                 trigger={
@@ -546,6 +597,7 @@ exports[`<Hero /> by default should render the right structure 1`] = `
                                 }
                               >
                                 <Modal
+                                  className=""
                                   closeIcon={
                                     <Icon
                                       color={null}

--- a/src/components/elements/Modal/component.js
+++ b/src/components/elements/Modal/component.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Modal } from 'semantic-ui-react';
+import getClassNames from 'classnames';
 
 import { Icon, ICON_NAMES } from 'elements/Icon';
 
@@ -11,16 +12,38 @@ import { Icon, ICON_NAMES } from 'elements/Icon';
 // eslint-disable-next-line jsdoc/require-jsdoc
 export const Component = ({
   children,
+  dimmer,
+  hasMargin,
+  isAlignedBottom,
   isFullscreen,
+<<<<<<< Updated upstream
+  isJustifiedRight,
+  isModalRounded,
+=======
+  closeIcon,
+  hasRoundedCorners,
+>>>>>>> Stashed changes
   isOpen,
   onClose,
   size,
   trigger,
 }) => (
   <Modal
+    className={getClassNames({
+<<<<<<< Updated upstream
+      'is-modal-rounded': isModalRounded,
+      'is-justified-right': isJustifiedRight,
+      'is-aligned-bottom': isAlignedBottom,
+      'has-margin': hasMargin,
+    })}
     closeIcon={<Icon name={ICON_NAMES.CLOSE} />}
+=======
+      'has-rounded-corners': hasRoundedCorners,
+    })}
+    closeIcon={closeIcon}
+>>>>>>> Stashed changes
     content={children}
-    dimmer="inverted"
+    dimmer={dimmer}
     onClose={onClose}
     open={isOpen}
     size={isFullscreen ? 'fullscreen' : size}
@@ -31,22 +54,49 @@ export const Component = ({
 Component.displayName = 'Modal';
 
 Component.defaultProps = {
+  dimmer: 'inverted',
+  hasMargin: false,
+  isAlignedBottom: false,
   isFullscreen: false,
+<<<<<<< Updated upstream
+  isJustifiedRight: false,
+  isModalRounded: false,
+=======
+  hasRoundedCorners: false,
+>>>>>>> Stashed changes
   isOpen: undefined,
   onClose: Function.prototype,
   size: 'tiny',
+  closeIcon: <Icon name={ICON_NAMES.CLOSE} />,
 };
 
 Component.propTypes = {
   /** The content of the modal when displayed. */
   children: PropTypes.node.isRequired,
+<<<<<<< Updated upstream
+  /** The background which fills the empty space left by the modal container. */
+  dimmer: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+  /** Does the modal have a margin. */
+  hasMargin: PropTypes.bool,
+  /** Is the modal aligned bottom. */
+  isAlignedBottom: PropTypes.bool,
+=======
+  /** The icon to close the modal */
+  closeIcon: PropTypes.node,
+  /** Does the modal have round corners */
+  hasRoundedCorners: PropTypes.bool,
+>>>>>>> Stashed changes
   /** Is the modal filling the whole screen when displayed. */
   isFullscreen: PropTypes.bool,
+  /** Is the modal justified right.*/
+  isJustifiedRight: PropTypes.bool,
+  /** Are the edges of the modal round */
+  isModalRounded: PropTypes.bool,
   /** Is the modal open. Used when consuming `Modal` as a controlled component. */
   isOpen: PropTypes.bool,
   /** A function called when a close event happens. Used when consuming `Modal` as a controlled component. */
   onClose: PropTypes.func,
-  /** The size of the modal */
+  /** The size of the modal. */
   size: PropTypes.oneOf(['mini', 'tiny', 'small', 'large']),
   /** The element to be clicked to display the modal. */
   trigger: PropTypes.node.isRequired,

--- a/src/components/general-widgets/CookieAlert/Readme.md
+++ b/src/components/general-widgets/CookieAlert/Readme.md
@@ -1,0 +1,42 @@
+```jsx
+ class Controller extends React.Component {
+  constructor(props) {
+    super(props);
+<<<<<<< Updated upstream
+    this.state = {isOpen: false}
+    this.handleChange = this.handleChange.bind(this);
+  }
+
+  handleChange() {
+    this.setState({isOpen: this.state.isOpen === false ? true : false});
+=======
+    this.state = {isOpen: true, isFormOpen: true}
+>>>>>>> Stashed changes
+  }
+
+render() {
+    return (      
+      <CookieAlert
+        text='Led through the mist, by the milk-light of moon, all that was lost is revealed. Our long bygone burdens, mere echoes of the spring, but where have where we come and where shall we end? If dreams cant come true, then why not pretend... How the gentle wind, beckons through the leaves, as Autumn, colors, fall. Then sing in a swirl, of golden memories, the loveliest, lies, of all.'
+        buttonText="Acceptance"
+        isOpen={this.state.isOpen}
+<<<<<<< Updated upstream
+        onClick={() => {alert('Potatoes and Molasses')}}
+        trigger={
+          <Button isRounded onClick={this.handleChange}>Trigger Cookie</Button>
+        }
+        onClose={this.handleChange}
+=======
+        isFormOpen={this.state.isFormOpen}
+        onClick={() => this.setState({ isOpen: false })}
+        onSubmit={() => this.setState({isFormOpen: false})}
+        trigger={
+          <Button isRounded onClick={() => this.setState({ isOpen: true })}>Trigger Cookie</Button>
+        }
+>>>>>>> Stashed changes
+      />);
+  }
+}
+
+<Controller />
+```

--- a/src/components/general-widgets/CookieAlert/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/CookieAlert/__snapshots__/component.spec.js.snap
@@ -1,0 +1,299 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+<<<<<<< Updated upstream
+exports[`The \`CookieAlert\` component should return the right structure 1`] = `
+<Modal
+  dimmer={true}
+  hasMargin={true}
+  isAlignedBottom={true}
+  isBackgroundTransparent={true}
+  isFullscreen={false}
+  isJustifiedRight={true}
+  isModalRounded={true}
+  isOpen={false}
+  onClose={[MockFunction]}
+  size="tiny"
+  trigger={<div />}
+>
+  <HorizontalGutters>
+    <FlexContainer
+      alignContent={null}
+      alignItems="center"
+      flexDirection="column"
+      flexWrap={null}
+      justifyContent="center"
+    >
+      <Divider
+        className=""
+        hasLine={false}
+        size="medium"
+      />
+      <Paragraph
+        size="medium"
+        weight={null}
+      >
+        some text
+      </Paragraph>
+      <Link
+        href="/"
+        isPositionedRight={false}
+        onClick={[Function]}
+        willOpenInNewTab={false}
+      >
+        A link
+      </Link>
+      <Divider
+        className=""
+        hasLine={false}
+        size="medium"
+      />
+      <Button
+        hasShadow={false}
+        icon={null}
+        isCompact={false}
+        isDisabled={false}
+        isLoading={false}
+        isPositionedRight={false}
+        isRounded={true}
+        isSecondary={false}
+        onClick={[MockFunction]}
+        size={null}
+      >
+        There is some text
+      </Button>
+      <Divider
+        className=""
+        hasLine={false}
+        size="medium"
+      />
+    </FlexContainer>
+  </HorizontalGutters>
+</Modal>
+=======
+exports[`The \`CookieAlert\` component if isUserOnMobile is false should return the right structure 1`] = `
+<CookieAlert
+  buttonText="There is some text"
+  isFormOpen={true}
+  isOpen={false}
+  isUserOnMobile={false}
+  linkText="A link"
+  linkUrl="/"
+  onClick={[MockFunction]}
+  onSubmit={[MockFunction]}
+  text="some text"
+  trigger={<div />}
+>
+  <div
+    className="cookies-form"
+  >
+    <Form
+      actionLink={null}
+      autoComplete={null}
+      errorMessage=""
+      headingText={null}
+      onSubmit={[MockFunction]}
+      submitButtonText="There is some text"
+      successMessage=""
+      validation={Object {}}
+    >
+      <Card
+        className="has-form"
+        fluid={true}
+      >
+        <div
+          className="ui fluid card has-form"
+          onClick={[Function]}
+        >
+          <CardContent>
+            <div
+              className="content"
+            >
+              <Form
+                as="form"
+                autoComplete={null}
+                error={false}
+                onSubmit={[Function]}
+                success={false}
+              >
+                <form
+                  autoComplete={null}
+                  className="ui form"
+                  onSubmit={[Function]}
+                >
+                  <FormField
+                    key=".0"
+                  >
+                    <div
+                      className="field"
+                    >
+                      <Paragraph
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        size="medium"
+                        weight={null}
+                      >
+                        <p
+                          className=""
+                        >
+                          some text
+                        </p>
+                      </Paragraph>
+                    </div>
+                  </FormField>
+                  <Button
+                    hasShadow={false}
+                    icon={null}
+                    isCompact={false}
+                    isDisabled={false}
+                    isLoading={false}
+                    isPositionedRight={true}
+                    isRounded={false}
+                    isSecondary={false}
+                    onClick={[Function]}
+                    size={null}
+                  >
+                    <Button
+                      as="button"
+                      circular={false}
+                      className=""
+                      compact={false}
+                      disabled={false}
+                      floated="right"
+                      loading={false}
+                      onClick={[Function]}
+                      secondary={false}
+                      size={null}
+                    >
+                      <button
+                        className="ui right floated button"
+                        onClick={[Function]}
+                        role="button"
+                      >
+                        There is some text
+                      </button>
+                    </Button>
+                  </Button>
+                </form>
+              </Form>
+            </div>
+          </CardContent>
+        </div>
+      </Card>
+    </Form>
+  </div>
+</CookieAlert>
+`;
+
+exports[`The \`CookieAlert\` component if isUserOnMobile is true should return the right structure 1`] = `
+<CookieAlert
+  buttonText="There is some text"
+  isFormOpen={true}
+  isOpen={false}
+  isUserOnMobile={true}
+  linkText="A link"
+  linkUrl="/"
+  onClick={[MockFunction]}
+  onSubmit={[MockFunction]}
+  text="some text"
+  trigger={<div />}
+>
+  <Modal
+    closeIcon={null}
+    hasRoundedCorners={true}
+    isFullscreen={false}
+    isOpen={false}
+    onClose={[Function]}
+    size="tiny"
+    trigger={<div />}
+  >
+    <Modal
+      className="has-rounded-corners"
+      closeIcon={null}
+      closeOnDimmerClick={true}
+      closeOnDocumentClick={false}
+      content={
+        <HorizontalGutters>
+          <FlexContainer
+            alignContent={null}
+            alignItems="center"
+            flexDirection="column"
+            flexWrap={null}
+            justifyContent="center"
+          >
+            <Divider
+              className=""
+              hasLine={false}
+              size="medium"
+            />
+            <Paragraph
+              size="medium"
+              weight={null}
+            >
+              some text
+            </Paragraph>
+            <Divider
+              className=""
+              hasLine={false}
+              size="medium"
+            />
+            <Button
+              hasShadow={false}
+              icon={null}
+              isCompact={false}
+              isDisabled={false}
+              isLoading={false}
+              isPositionedRight={false}
+              isRounded={true}
+              isSecondary={false}
+              onClick={[MockFunction]}
+              size={null}
+            >
+              There is some text
+            </Button>
+            <Divider
+              className=""
+              hasLine={false}
+              size="medium"
+            />
+          </FlexContainer>
+        </HorizontalGutters>
+      }
+      dimmer="inverted"
+      eventPool="Modal"
+      onClose={[Function]}
+      open={false}
+      size="tiny"
+      trigger={<div />}
+    >
+      <Portal
+        className="ui inverted page modals dimmer transition visible active"
+        closeOnDocumentClick={false}
+        closeOnEscape={true}
+        closeOnRootNodeClick={true}
+        eventPool="Modal"
+        mountNode={<body />}
+        onClose={[Function]}
+        onMount={[Function]}
+        onOpen={[Function]}
+        onUnmount={[Function]}
+        open={false}
+        openOnTriggerClick={true}
+        trigger={<div />}
+      >
+        <Ref
+          innerRef={[Function]}
+        >
+          <div
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+          />
+        </Ref>
+      </Portal>
+    </Modal>
+  </Modal>
+</CookieAlert>
+>>>>>>> Stashed changes
+`;

--- a/src/components/general-widgets/CookieAlert/component.js
+++ b/src/components/general-widgets/CookieAlert/component.js
@@ -1,0 +1,150 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { Modal } from 'elements/Modal';
+import { FlexContainer } from 'layout/FlexContainer';
+import { Button } from 'elements/Button';
+import { Divider } from 'elements/Divider';
+import { HorizontalGutters } from 'layout/HorizontalGutters';
+import { Paragraph } from 'typography/Paragraph';
+<<<<<<< Updated upstream
+import { Link } from 'elements/Link';
+
+export const Component = ({
+  buttonText,
+  isOpen,
+  linkText,
+  linkUrl,
+  onClick,
+  onClose,
+  text,
+  trigger,
+}) => (
+  <Modal
+    dimmer
+    hasMargin
+    isAlignedBottom
+    isBackgroundTransparent
+    isJustifiedRight
+    isModalRounded
+    isOpen={isOpen}
+    onClose={onClose}
+    trigger={trigger}
+  >
+    <HorizontalGutters>
+      <FlexContainer
+        alignItems="center"
+        flexDirection="column"
+        justifyContent="center"
+      >
+        <Divider />
+        <Paragraph>{text}</Paragraph>
+        <Link href={linkUrl}>{linkText}</Link>
+        <Divider />
+        <Button isRounded onClick={onClick}>
+          {buttonText}
+        </Button>
+        <Divider />
+      </FlexContainer>
+    </HorizontalGutters>
+  </Modal>
+);
+=======
+import { withResponsive } from 'utils/with-responsive';
+
+import { getFormMarkup } from './utils/getFormMarkup';
+
+const Component = ({
+  buttonText,
+  isFormOpen,
+  isOpen,
+  isUserOnMobile,
+  onClick,
+  onSubmit,
+  text,
+  trigger,
+}) =>
+  isUserOnMobile ? (
+    <Modal closeIcon={null} hasRoundedCorners isOpen={isOpen} trigger={trigger}>
+      <HorizontalGutters>
+        <FlexContainer
+          alignItems="center"
+          flexDirection="column"
+          justifyContent="center"
+        >
+          <Divider />
+          <Paragraph>{text}</Paragraph>
+          <Divider />
+          <Button isRounded onClick={onClick}>
+            {buttonText}
+          </Button>
+          <Divider />
+        </FlexContainer>
+      </HorizontalGutters>
+    </Modal>
+  ) : (
+    <div className="cookies-form">
+      {getFormMarkup(isFormOpen, onSubmit, buttonText, text)}
+    </div>
+  );
+>>>>>>> Stashed changes
+
+Component.displayName = 'CookieAlert';
+
+Component.defaultProps = {
+  buttonText: 'Accept',
+  isOpen: false,
+<<<<<<< Updated upstream
+  linkText: 'Learn more',
+  linkUrl: '/',
+  onClose: Function.prototype,
+  trigger: <Button isRounded>Sample text</Button>,
+=======
+  trigger: null,
+  isFormOpen: true,
+>>>>>>> Stashed changes
+};
+
+Component.propTypes = {
+  /** The text to display on the button inside the modal. */
+  buttonText: PropTypes.string,
+<<<<<<< Updated upstream
+  /** Is the modal open. */
+  isOpen: PropTypes.bool,
+  /** The text to display as a link. */
+  linkText: PropTypes.string,
+  /** The url for the link text. */
+  linkUrl: PropTypes.string,
+  /** The function called when the modal button is clicked. */
+  onClick: PropTypes.func.isRequired,
+  /** The function called when the modal is closed. */
+  onClose: PropTypes.func,
+=======
+  /** Is the cookies form visible */
+  isFormOpen: PropTypes.bool,
+  /** Is the modal open. */
+  isOpen: PropTypes.bool,
+  /** The text to display as a link. */
+  /**
+   * Is the user on a mobile device.
+   * Provided by `withResponsive` so ignored in the styleguide.
+   * @ignore
+   */
+  isUserOnMobile: PropTypes.bool.isRequired,
+  /** The function called when the modal button is clicked. */
+  onClick: PropTypes.func.isRequired,
+  /** The function to call when the form is submitted
+   *  @param {Object} values - The values of the inputs in the form.
+   */
+  onSubmit: PropTypes.func.isRequired,
+>>>>>>> Stashed changes
+  /** The text to display in the modal. */
+  text: PropTypes.string.isRequired,
+  /** The element to be clicked to display the modal. */
+  trigger: PropTypes.node,
+};
+<<<<<<< Updated upstream
+=======
+
+export const ComponentWithResponsive = withResponsive(Component);
+>>>>>>> Stashed changes

--- a/src/components/general-widgets/CookieAlert/component.spec.js
+++ b/src/components/general-widgets/CookieAlert/component.spec.js
@@ -1,0 +1,73 @@
+<<<<<<< Updated upstream
+import { shallow } from 'enzyme';
+import React from 'react';
+import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
+
+import { Component as CookieAlert } from './component';
+=======
+import { shallow, mount } from 'enzyme';
+import React from 'react';
+import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
+
+import { ComponentWithResponsive as CookieAlert } from './component';
+>>>>>>> Stashed changes
+
+const props = {
+  text: 'some text',
+  linkUrl: '/',
+  linkText: 'A link',
+  onClick: jest.fn(),
+<<<<<<< Updated upstream
+  onClose: jest.fn(),
+=======
+  onSubmit: jest.fn(),
+>>>>>>> Stashed changes
+  buttonText: 'There is some text',
+  trigger: <div />,
+};
+
+const getCookieAlert = () => shallow(<CookieAlert {...props} />);
+
+<<<<<<< Updated upstream
+describe('The `CookieAlert` component', () => {
+  it('should return the right structure', () => {
+    const actual = getCookieAlert();
+
+    expect(actual).toMatchSnapshot();
+  });
+
+  it('should have `displayName` `CookieAlert`', () => {
+    expectComponentToHaveDisplayName(CookieAlert, 'CookieAlert');
+=======
+const getWrappedCookieAlert = extraProps => {
+  const Child = getCookieAlert().prop('as');
+
+  return mount(<Child isUserOnMobile={extraProps} {...props} />);
+};
+
+describe('The `CookieAlert` component', () => {
+  describe('if isUserOnMobile is true', () => {
+    it('should return the right structure', () => {
+      const isUserOnMobile = true;
+      const actual = getWrappedCookieAlert(isUserOnMobile);
+
+      expect(actual).toMatchSnapshot();
+    });
+  });
+
+  describe('if isUserOnMobile is false', () => {
+    it('should return the right structure', () => {
+      const isUserOnMobile = false;
+      const actual = getWrappedCookieAlert(isUserOnMobile);
+
+      expect(actual).toMatchSnapshot();
+    });
+  });
+
+  it('should have `displayName` `CookieAlert`', () => {
+    const wrapper = getCookieAlert().prop('as');
+
+    expectComponentToHaveDisplayName(wrapper, 'CookieAlert');
+>>>>>>> Stashed changes
+  });
+});

--- a/src/components/general-widgets/CookieAlert/index.js
+++ b/src/components/general-widgets/CookieAlert/index.js
@@ -1,0 +1,5 @@
+<<<<<<< Updated upstream
+export { Component as CookieAlert } from './component';
+=======
+export { ComponentWithResponsive as CookieAlert } from './component';
+>>>>>>> Stashed changes

--- a/src/components/general-widgets/CookieAlert/utils/__snapshots__/gerFormMarkup.spec.js.snap
+++ b/src/components/general-widgets/CookieAlert/utils/__snapshots__/gerFormMarkup.spec.js.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`\`getFormMarkup\` if isOpen is false should return false 1`] = `false`;
+
+exports[`\`getFormMarkup\` if isOpen is true should render the right structure 1`] = `
+<Form
+  actionLink={null}
+  autoComplete={null}
+  errorMessage=""
+  headingText={null}
+  onSubmit={[MockFunction]}
+  submitButtonText="Le Goose"
+  successMessage=""
+  validation={Object {}}
+>
+  <Paragraph
+    size="medium"
+    weight={null}
+  >
+    eau
+  </Paragraph>
+</Form>
+`;

--- a/src/components/general-widgets/CookieAlert/utils/gerFormMarkup.spec.js
+++ b/src/components/general-widgets/CookieAlert/utils/gerFormMarkup.spec.js
@@ -1,0 +1,23 @@
+import { getFormMarkup } from './getFormMarkup';
+
+describe('`getFormMarkup`', () => {
+  const isOpen = true;
+  const onSubmit = jest.fn();
+  const buttonText = 'Le Goose';
+  const text = 'eau';
+
+  describe('if isOpen is true', () => {
+    it('should render the right structure', () => {
+      const actual = getFormMarkup(isOpen, onSubmit, buttonText, text);
+
+      expect(actual).toMatchSnapshot();
+    });
+  });
+  describe('if isOpen is false', () => {
+    it('should return false', () => {
+      const actual = getFormMarkup(false, onSubmit, buttonText, text);
+
+      expect(actual).toMatchSnapshot();
+    });
+  });
+});

--- a/src/components/general-widgets/CookieAlert/utils/getFormMarkup.js
+++ b/src/components/general-widgets/CookieAlert/utils/getFormMarkup.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+import { Form } from 'collections/Form';
+import { Paragraph } from 'typography/Paragraph';
+
+export const getFormMarkup = (isOpen, onSubmit, buttonText, text) =>
+  isOpen && (
+    <Form onSubmit={onSubmit} submitButtonText={buttonText}>
+      <Paragraph>{text}</Paragraph>
+    </Form>
+  );

--- a/src/components/general-widgets/HomepageHero/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/HomepageHero/__snapshots__/component.spec.js.snap
@@ -341,7 +341,32 @@ exports[`HomepageHero should render the right structure 1`] = `
                                   willDropdownsOpenAbove={false}
                                 >
                                   <Modal
+<<<<<<< Updated upstream
+                                    dimmer="inverted"
+                                    hasMargin={false}
+                                    isAlignedBottom={false}
+=======
+                                    closeIcon={
+                                      <Icon
+                                        color={null}
+                                        hasBorder={false}
+                                        isButton={false}
+                                        isCircular={false}
+                                        isColorInverted={false}
+                                        isDisabled={false}
+                                        isLabelLeft={false}
+                                        labelText={null}
+                                        labelWeight={null}
+                                        name="close"
+                                        path={null}
+                                        size={null}
+                                      />
+                                    }
+                                    hasRoundedCorners={false}
+>>>>>>> Stashed changes
                                     isFullscreen={true}
+                                    isJustifiedRight={false}
+                                    isModalRounded={false}
                                     onClose={[Function]}
                                     size="tiny"
                                     trigger={
@@ -362,6 +387,7 @@ exports[`HomepageHero should render the right structure 1`] = `
                                     }
                                   >
                                     <Modal
+                                      className=""
                                       closeIcon={
                                         <Icon
                                           color={null}
@@ -567,7 +593,32 @@ exports[`HomepageHero should render the right structure 1`] = `
                                 onClick={[Function]}
                               >
                                 <Modal
+<<<<<<< Updated upstream
+                                  dimmer="inverted"
+                                  hasMargin={false}
+                                  isAlignedBottom={false}
+=======
+                                  closeIcon={
+                                    <Icon
+                                      color={null}
+                                      hasBorder={false}
+                                      isButton={false}
+                                      isCircular={false}
+                                      isColorInverted={false}
+                                      isDisabled={false}
+                                      isLabelLeft={false}
+                                      labelText={null}
+                                      labelWeight={null}
+                                      name="close"
+                                      path={null}
+                                      size={null}
+                                    />
+                                  }
+                                  hasRoundedCorners={false}
+>>>>>>> Stashed changes
                                   isFullscreen={true}
+                                  isJustifiedRight={false}
+                                  isModalRounded={false}
                                   onClose={[Function]}
                                   size="tiny"
                                   trigger={
@@ -588,6 +639,7 @@ exports[`HomepageHero should render the right structure 1`] = `
                                   }
                                 >
                                   <Modal
+                                    className=""
                                     closeIcon={
                                       <Icon
                                         color={null}

--- a/src/components/general-widgets/OwnerLogin/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/OwnerLogin/__snapshots__/component.spec.js.snap
@@ -23,7 +23,32 @@ exports[`<OwnerLogin /> if \`props.errorMessage\` is passed should render the er
     actionLink={
       Object {
         "text": <Modal
+<<<<<<< Updated upstream
+          dimmer="inverted"
+          hasMargin={false}
+          isAlignedBottom={false}
+=======
+          closeIcon={
+            <Icon
+              color={null}
+              hasBorder={false}
+              isButton={false}
+              isCircular={false}
+              isColorInverted={false}
+              isDisabled={false}
+              isLabelLeft={false}
+              labelText={null}
+              labelWeight={null}
+              name="close"
+              path={null}
+              size={null}
+            />
+          }
+          hasRoundedCorners={false}
+>>>>>>> Stashed changes
           isFullscreen={false}
+          isJustifiedRight={false}
+          isModalRounded={false}
           onClose={[Function]}
           size="tiny"
           trigger={
@@ -265,7 +290,32 @@ exports[`<OwnerLogin /> if \`props.errorMessage\` is passed should render the er
                       target="_self"
                     >
                       <Modal
+<<<<<<< Updated upstream
+                        dimmer="inverted"
+                        hasMargin={false}
+                        isAlignedBottom={false}
+=======
+                        closeIcon={
+                          <Icon
+                            color={null}
+                            hasBorder={false}
+                            isButton={false}
+                            isCircular={false}
+                            isColorInverted={false}
+                            isDisabled={false}
+                            isLabelLeft={false}
+                            labelText={null}
+                            labelWeight={null}
+                            name="close"
+                            path={null}
+                            size={null}
+                          />
+                        }
+                        hasRoundedCorners={false}
+>>>>>>> Stashed changes
                         isFullscreen={false}
+                        isJustifiedRight={false}
+                        isModalRounded={false}
                         onClose={[Function]}
                         size="tiny"
                         trigger={
@@ -275,6 +325,7 @@ exports[`<OwnerLogin /> if \`props.errorMessage\` is passed should render the er
                         }
                       >
                         <Modal
+                          className=""
                           closeIcon={
                             <Icon
                               color={null}
@@ -429,7 +480,32 @@ exports[`<OwnerLogin /> if \`props.successMessage\` is passed should render the 
     actionLink={
       Object {
         "text": <Modal
+<<<<<<< Updated upstream
+          dimmer="inverted"
+          hasMargin={false}
+          isAlignedBottom={false}
+=======
+          closeIcon={
+            <Icon
+              color={null}
+              hasBorder={false}
+              isButton={false}
+              isCircular={false}
+              isColorInverted={false}
+              isDisabled={false}
+              isLabelLeft={false}
+              labelText={null}
+              labelWeight={null}
+              name="close"
+              path={null}
+              size={null}
+            />
+          }
+          hasRoundedCorners={false}
+>>>>>>> Stashed changes
           isFullscreen={false}
+          isJustifiedRight={false}
+          isModalRounded={false}
           onClose={[Function]}
           size="tiny"
           trigger={
@@ -671,7 +747,32 @@ exports[`<OwnerLogin /> if \`props.successMessage\` is passed should render the 
                       target="_self"
                     >
                       <Modal
+<<<<<<< Updated upstream
+                        dimmer="inverted"
+                        hasMargin={false}
+                        isAlignedBottom={false}
+=======
+                        closeIcon={
+                          <Icon
+                            color={null}
+                            hasBorder={false}
+                            isButton={false}
+                            isCircular={false}
+                            isColorInverted={false}
+                            isDisabled={false}
+                            isLabelLeft={false}
+                            labelText={null}
+                            labelWeight={null}
+                            name="close"
+                            path={null}
+                            size={null}
+                          />
+                        }
+                        hasRoundedCorners={false}
+>>>>>>> Stashed changes
                         isFullscreen={false}
+                        isJustifiedRight={false}
+                        isModalRounded={false}
                         onClose={[Function]}
                         size="tiny"
                         trigger={
@@ -681,6 +782,7 @@ exports[`<OwnerLogin /> if \`props.successMessage\` is passed should render the 
                         }
                       >
                         <Modal
+                          className=""
                           closeIcon={
                             <Icon
                               color={null}
@@ -835,7 +937,32 @@ exports[`<OwnerLogin /> should render the correct structure 1`] = `
     actionLink={
       Object {
         "text": <Modal
+<<<<<<< Updated upstream
+          dimmer="inverted"
+          hasMargin={false}
+          isAlignedBottom={false}
+=======
+          closeIcon={
+            <Icon
+              color={null}
+              hasBorder={false}
+              isButton={false}
+              isCircular={false}
+              isColorInverted={false}
+              isDisabled={false}
+              isLabelLeft={false}
+              labelText={null}
+              labelWeight={null}
+              name="close"
+              path={null}
+              size={null}
+            />
+          }
+          hasRoundedCorners={false}
+>>>>>>> Stashed changes
           isFullscreen={false}
+          isJustifiedRight={false}
+          isModalRounded={false}
           onClose={[Function]}
           size="tiny"
           trigger={
@@ -1057,7 +1184,32 @@ exports[`<OwnerLogin /> should render the correct structure 1`] = `
                       target="_self"
                     >
                       <Modal
+<<<<<<< Updated upstream
+                        dimmer="inverted"
+                        hasMargin={false}
+                        isAlignedBottom={false}
+=======
+                        closeIcon={
+                          <Icon
+                            color={null}
+                            hasBorder={false}
+                            isButton={false}
+                            isCircular={false}
+                            isColorInverted={false}
+                            isDisabled={false}
+                            isLabelLeft={false}
+                            labelText={null}
+                            labelWeight={null}
+                            name="close"
+                            path={null}
+                            size={null}
+                          />
+                        }
+                        hasRoundedCorners={false}
+>>>>>>> Stashed changes
                         isFullscreen={false}
+                        isJustifiedRight={false}
+                        isModalRounded={false}
                         onClose={[Function]}
                         size="tiny"
                         trigger={
@@ -1067,6 +1219,7 @@ exports[`<OwnerLogin /> should render the correct structure 1`] = `
                         }
                       >
                         <Modal
+                          className=""
                           closeIcon={
                             <Icon
                               color={null}

--- a/src/components/general-widgets/OwnerLogin/utils/__snapshots__/getForgotPasswordFormMarkup.spec.js.snap
+++ b/src/components/general-widgets/OwnerLogin/utils/__snapshots__/getForgotPasswordFormMarkup.spec.js.snap
@@ -2,7 +2,32 @@
 
 exports[`getForgotPasswordFormMarkup if \`forgotPasswordErrorMessage\` is passed should render the error message above the reset button 1`] = `
 <Modal
+<<<<<<< Updated upstream
+  dimmer="inverted"
+  hasMargin={false}
+  isAlignedBottom={false}
+=======
+  closeIcon={
+    <Icon
+      color={null}
+      hasBorder={false}
+      isButton={false}
+      isCircular={false}
+      isColorInverted={false}
+      isDisabled={false}
+      isLabelLeft={false}
+      labelText={null}
+      labelWeight={null}
+      name="close"
+      path={null}
+      size={null}
+    />
+  }
+  hasRoundedCorners={false}
+>>>>>>> Stashed changes
   isFullscreen={false}
+  isJustifiedRight={false}
+  isModalRounded={false}
   onClose={[Function]}
   size="tiny"
   trigger={
@@ -12,6 +37,7 @@ exports[`getForgotPasswordFormMarkup if \`forgotPasswordErrorMessage\` is passed
   }
 >
   <Modal
+    className=""
     closeIcon={
       <Icon
         color={null}
@@ -101,7 +127,32 @@ exports[`getForgotPasswordFormMarkup if \`forgotPasswordErrorMessage\` is passed
 
 exports[`getForgotPasswordFormMarkup if \`forgotPasswordSuccessMessage\` is passed should render the success message above the reset button 1`] = `
 <Modal
+<<<<<<< Updated upstream
+  dimmer="inverted"
+  hasMargin={false}
+  isAlignedBottom={false}
+=======
+  closeIcon={
+    <Icon
+      color={null}
+      hasBorder={false}
+      isButton={false}
+      isCircular={false}
+      isColorInverted={false}
+      isDisabled={false}
+      isLabelLeft={false}
+      labelText={null}
+      labelWeight={null}
+      name="close"
+      path={null}
+      size={null}
+    />
+  }
+  hasRoundedCorners={false}
+>>>>>>> Stashed changes
   isFullscreen={false}
+  isJustifiedRight={false}
+  isModalRounded={false}
   onClose={[Function]}
   size="tiny"
   trigger={
@@ -111,6 +162,7 @@ exports[`getForgotPasswordFormMarkup if \`forgotPasswordSuccessMessage\` is pass
   }
 >
   <Modal
+    className=""
     closeIcon={
       <Icon
         color={null}
@@ -200,7 +252,32 @@ exports[`getForgotPasswordFormMarkup if \`forgotPasswordSuccessMessage\` is pass
 
 exports[`getForgotPasswordFormMarkup should return the right structure  1`] = `
 <Modal
+<<<<<<< Updated upstream
+  dimmer="inverted"
+  hasMargin={false}
+  isAlignedBottom={false}
+=======
+  closeIcon={
+    <Icon
+      color={null}
+      hasBorder={false}
+      isButton={false}
+      isCircular={false}
+      isColorInverted={false}
+      isDisabled={false}
+      isLabelLeft={false}
+      labelText={null}
+      labelWeight={null}
+      name="close"
+      path={null}
+      size={null}
+    />
+  }
+  hasRoundedCorners={false}
+>>>>>>> Stashed changes
   isFullscreen={false}
+  isJustifiedRight={false}
+  isModalRounded={false}
   onClose={[Function]}
   size="tiny"
   trigger={
@@ -210,6 +287,7 @@ exports[`getForgotPasswordFormMarkup should return the right structure  1`] = `
   }
 >
   <Modal
+    className=""
     closeIcon={
       <Icon
         color={null}

--- a/src/components/general-widgets/SearchBar/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/SearchBar/__snapshots__/component.spec.js.snap
@@ -2598,12 +2598,18 @@ exports[`<SearchBar /> if \`isDisplayedAsModal === true\` should render the righ
   willDropdownsOpenAbove={false}
 >
   <Modal
+    dimmer="inverted"
+    hasMargin={false}
+    isAlignedBottom={false}
     isFullscreen={true}
+    isJustifiedRight={false}
+    isModalRounded={false}
     onClose={[Function]}
     size="tiny"
     trigger={<div />}
   >
     <Modal
+      className=""
       closeIcon={
         <Icon
           color={null}
@@ -2794,7 +2800,12 @@ exports[`<SearchBar /> if \`isDisplayedAsModal\` is true should render the right
       className="right floated top aligned seven wide column"
     >
       <Modal
+        dimmer="inverted"
+        hasMargin={false}
+        isAlignedBottom={false}
         isFullscreen={true}
+        isJustifiedRight={false}
+        isModalRounded={false}
         onClose={[Function]}
         size="tiny"
         trigger={
@@ -2815,6 +2826,7 @@ exports[`<SearchBar /> if \`isDisplayedAsModal\` is true should render the right
         }
       >
         <Modal
+          className=""
           closeIcon={
             <Icon
               color={null}

--- a/src/components/media/Gallery/__snapshots__/component.spec.js.snap
+++ b/src/components/media/Gallery/__snapshots__/component.spec.js.snap
@@ -2,7 +2,32 @@
 
 exports[`<Gallery /> by default should render the right structure 1`] = `
 <Modal
+<<<<<<< Updated upstream
+  dimmer="inverted"
+  hasMargin={false}
+  isAlignedBottom={false}
+=======
+  closeIcon={
+    <Icon
+      color={null}
+      hasBorder={false}
+      isButton={false}
+      isCircular={false}
+      isColorInverted={false}
+      isDisabled={false}
+      isLabelLeft={false}
+      labelText={null}
+      labelWeight={null}
+      name="close"
+      path={null}
+      size={null}
+    />
+  }
+  hasRoundedCorners={false}
+>>>>>>> Stashed changes
   isFullscreen={true}
+  isJustifiedRight={false}
+  isModalRounded={false}
   onClose={[Function]}
   size="tiny"
   trigger="someTrigger"
@@ -102,7 +127,32 @@ exports[`<Gallery /> by default should render the right structure 1`] = `
 
 exports[`<Gallery /> if \`props.heading\` is defined should render the right structure 1`] = `
 <Modal
+<<<<<<< Updated upstream
+  dimmer="inverted"
+  hasMargin={false}
+  isAlignedBottom={false}
+=======
+  closeIcon={
+    <Icon
+      color={null}
+      hasBorder={false}
+      isButton={false}
+      isCircular={false}
+      isColorInverted={false}
+      isDisabled={false}
+      isLabelLeft={false}
+      labelText={null}
+      labelWeight={null}
+      name="close"
+      path={null}
+      size={null}
+    />
+  }
+  hasRoundedCorners={false}
+>>>>>>> Stashed changes
   isFullscreen={true}
+  isJustifiedRight={false}
+  isModalRounded={false}
   onClose={[Function]}
   size="tiny"
   trigger="someTrigger"

--- a/src/components/property-page-widgets/Description/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Description/__snapshots__/component.spec.js.snap
@@ -626,7 +626,32 @@ exports[`<Description /> if \`props.extraDescriptionText\` is passed the last \`
                 >
                   Maecenas et efficitur diam. Etiam non ante urna. Donec imperdiet cursus lectus, luctus vestibulum urna aliquet vel. Donec non vehicula est. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos...
                   <Modal
+<<<<<<< Updated upstream
+                    dimmer="inverted"
+                    hasMargin={false}
+                    isAlignedBottom={false}
+=======
+                    closeIcon={
+                      <Icon
+                        color={null}
+                        hasBorder={false}
+                        isButton={false}
+                        isCircular={false}
+                        isColorInverted={false}
+                        isDisabled={false}
+                        isLabelLeft={false}
+                        labelText={null}
+                        labelWeight={null}
+                        name="close"
+                        path={null}
+                        size={null}
+                      />
+                    }
+                    hasRoundedCorners={false}
+>>>>>>> Stashed changes
                     isFullscreen={false}
+                    isJustifiedRight={false}
+                    isModalRounded={false}
                     onClose={[Function]}
                     size="tiny"
                     trigger={
@@ -639,6 +664,7 @@ exports[`<Description /> if \`props.extraDescriptionText\` is passed the last \`
                     }
                   >
                     <Modal
+                      className=""
                       closeIcon={
                         <Icon
                           color={null}

--- a/src/components/property-page-widgets/Pictures/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Pictures/__snapshots__/component.spec.js.snap
@@ -1125,7 +1125,32 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                 }
               >
                 <Modal
+<<<<<<< Updated upstream
+                  dimmer="inverted"
+                  hasMargin={false}
+                  isAlignedBottom={false}
+=======
+                  closeIcon={
+                    <Icon
+                      color={null}
+                      hasBorder={false}
+                      isButton={false}
+                      isCircular={false}
+                      isColorInverted={false}
+                      isDisabled={false}
+                      isLabelLeft={false}
+                      labelText={null}
+                      labelWeight={null}
+                      name="close"
+                      path={null}
+                      size={null}
+                    />
+                  }
+                  hasRoundedCorners={false}
+>>>>>>> Stashed changes
                   isFullscreen={true}
+                  isJustifiedRight={false}
+                  isModalRounded={false}
                   onClose={[Function]}
                   size="tiny"
                   trigger={
@@ -1140,6 +1165,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                   }
                 >
                   <Modal
+                    className=""
                     closeIcon={
                       <Icon
                         color={null}

--- a/src/components/property-page-widgets/PolicyAndNotes/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/PolicyAndNotes/__snapshots__/component.spec.js.snap
@@ -371,7 +371,32 @@ exports[`<PolicyAndNotes /> if \`props.extraNotesText\` is passed should have th
                     className="top aligned twelve wide column"
                   >
                     <Modal
+<<<<<<< Updated upstream
+                      dimmer="inverted"
+                      hasMargin={false}
+                      isAlignedBottom={false}
+=======
+                      closeIcon={
+                        <Icon
+                          color={null}
+                          hasBorder={false}
+                          isButton={false}
+                          isCircular={false}
+                          isColorInverted={false}
+                          isDisabled={false}
+                          isLabelLeft={false}
+                          labelText={null}
+                          labelWeight={null}
+                          name="close"
+                          path={null}
+                          size={null}
+                        />
+                      }
+                      hasRoundedCorners={false}
+>>>>>>> Stashed changes
                       isFullscreen={false}
+                      isJustifiedRight={false}
+                      isModalRounded={false}
                       onClose={[Function]}
                       size="tiny"
                       trigger={
@@ -386,6 +411,7 @@ exports[`<PolicyAndNotes /> if \`props.extraNotesText\` is passed should have th
                       }
                     >
                       <Modal
+                        className=""
                         closeIcon={
                           <Icon
                             color={null}

--- a/src/components/property-page-widgets/PropertyPageHero/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/PropertyPageHero/__snapshots__/component.spec.js.snap
@@ -329,7 +329,32 @@ exports[`PropertyPageHero by default if there are fewer than two images should r
                                   willDropdownsOpenAbove={false}
                                 >
                                   <Modal
+<<<<<<< Updated upstream
+                                    dimmer="inverted"
+                                    hasMargin={false}
+                                    isAlignedBottom={false}
+=======
+                                    closeIcon={
+                                      <Icon
+                                        color={null}
+                                        hasBorder={false}
+                                        isButton={false}
+                                        isCircular={false}
+                                        isColorInverted={false}
+                                        isDisabled={false}
+                                        isLabelLeft={false}
+                                        labelText={null}
+                                        labelWeight={null}
+                                        name="close"
+                                        path={null}
+                                        size={null}
+                                      />
+                                    }
+                                    hasRoundedCorners={false}
+>>>>>>> Stashed changes
                                     isFullscreen={true}
+                                    isJustifiedRight={false}
+                                    isModalRounded={false}
                                     onClose={[Function]}
                                     size="tiny"
                                     trigger={
@@ -350,6 +375,7 @@ exports[`PropertyPageHero by default if there are fewer than two images should r
                                     }
                                   >
                                     <Modal
+                                      className=""
                                       closeIcon={
                                         <Icon
                                           color={null}
@@ -553,7 +579,32 @@ exports[`PropertyPageHero by default if there are fewer than two images should r
                                 onClick={[Function]}
                               >
                                 <Modal
+<<<<<<< Updated upstream
+                                  dimmer="inverted"
+                                  hasMargin={false}
+                                  isAlignedBottom={false}
+=======
+                                  closeIcon={
+                                    <Icon
+                                      color={null}
+                                      hasBorder={false}
+                                      isButton={false}
+                                      isCircular={false}
+                                      isColorInverted={false}
+                                      isDisabled={false}
+                                      isLabelLeft={false}
+                                      labelText={null}
+                                      labelWeight={null}
+                                      name="close"
+                                      path={null}
+                                      size={null}
+                                    />
+                                  }
+                                  hasRoundedCorners={false}
+>>>>>>> Stashed changes
                                   isFullscreen={true}
+                                  isJustifiedRight={false}
+                                  isModalRounded={false}
                                   onClose={[Function]}
                                   size="tiny"
                                   trigger={
@@ -574,6 +625,7 @@ exports[`PropertyPageHero by default if there are fewer than two images should r
                                   }
                                 >
                                   <Modal
+                                    className=""
                                     closeIcon={
                                       <Icon
                                         color={null}
@@ -1144,7 +1196,32 @@ exports[`PropertyPageHero by default should render the right structure 1`] = `
                                   willDropdownsOpenAbove={false}
                                 >
                                   <Modal
+<<<<<<< Updated upstream
+                                    dimmer="inverted"
+                                    hasMargin={false}
+                                    isAlignedBottom={false}
+=======
+                                    closeIcon={
+                                      <Icon
+                                        color={null}
+                                        hasBorder={false}
+                                        isButton={false}
+                                        isCircular={false}
+                                        isColorInverted={false}
+                                        isDisabled={false}
+                                        isLabelLeft={false}
+                                        labelText={null}
+                                        labelWeight={null}
+                                        name="close"
+                                        path={null}
+                                        size={null}
+                                      />
+                                    }
+                                    hasRoundedCorners={false}
+>>>>>>> Stashed changes
                                     isFullscreen={true}
+                                    isJustifiedRight={false}
+                                    isModalRounded={false}
                                     onClose={[Function]}
                                     size="tiny"
                                     trigger={
@@ -1165,6 +1242,7 @@ exports[`PropertyPageHero by default should render the right structure 1`] = `
                                     }
                                   >
                                     <Modal
+                                      className=""
                                       closeIcon={
                                         <Icon
                                           color={null}
@@ -1368,7 +1446,32 @@ exports[`PropertyPageHero by default should render the right structure 1`] = `
                                 onClick={[Function]}
                               >
                                 <Modal
+<<<<<<< Updated upstream
+                                  dimmer="inverted"
+                                  hasMargin={false}
+                                  isAlignedBottom={false}
+=======
+                                  closeIcon={
+                                    <Icon
+                                      color={null}
+                                      hasBorder={false}
+                                      isButton={false}
+                                      isCircular={false}
+                                      isColorInverted={false}
+                                      isDisabled={false}
+                                      isLabelLeft={false}
+                                      labelText={null}
+                                      labelWeight={null}
+                                      name="close"
+                                      path={null}
+                                      size={null}
+                                    />
+                                  }
+                                  hasRoundedCorners={false}
+>>>>>>> Stashed changes
                                   isFullscreen={true}
+                                  isJustifiedRight={false}
+                                  isModalRounded={false}
                                   onClose={[Function]}
                                   size="tiny"
                                   trigger={
@@ -1389,6 +1492,7 @@ exports[`PropertyPageHero by default should render the right structure 1`] = `
                                   }
                                 >
                                   <Modal
+                                    className=""
                                     closeIcon={
                                       <Icon
                                         color={null}
@@ -1677,7 +1781,32 @@ exports[`PropertyPageHero by default should render the right structure 1`] = `
                       }
                     >
                       <Modal
+<<<<<<< Updated upstream
+                        dimmer="inverted"
+                        hasMargin={false}
+                        isAlignedBottom={false}
+=======
+                        closeIcon={
+                          <Icon
+                            color={null}
+                            hasBorder={false}
+                            isButton={false}
+                            isCircular={false}
+                            isColorInverted={false}
+                            isDisabled={false}
+                            isLabelLeft={false}
+                            labelText={null}
+                            labelWeight={null}
+                            name="close"
+                            path={null}
+                            size={null}
+                          />
+                        }
+                        hasRoundedCorners={false}
+>>>>>>> Stashed changes
                         isFullscreen={true}
+                        isJustifiedRight={false}
+                        isModalRounded={false}
                         onClose={[Function]}
                         size="tiny"
                         trigger={
@@ -1698,6 +1827,7 @@ exports[`PropertyPageHero by default should render the right structure 1`] = `
                         }
                       >
                         <Modal
+                          className=""
                           closeIcon={
                             <Icon
                               color={null}

--- a/src/components/property-page-widgets/PropertyPageSearchBar/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/PropertyPageSearchBar/__snapshots__/component.spec.js.snap
@@ -2922,7 +2922,32 @@ exports[`<PropertyPageSearchBar /> should have the right structure 1`] = `
                                     className="right floated top aligned seven wide column"
                                   >
                                     <Modal
+<<<<<<< Updated upstream
+                                      dimmer="inverted"
+                                      hasMargin={false}
+                                      isAlignedBottom={false}
+=======
+                                      closeIcon={
+                                        <Icon
+                                          color={null}
+                                          hasBorder={false}
+                                          isButton={false}
+                                          isCircular={false}
+                                          isColorInverted={false}
+                                          isDisabled={false}
+                                          isLabelLeft={false}
+                                          labelText={null}
+                                          labelWeight={null}
+                                          name="close"
+                                          path={null}
+                                          size={null}
+                                        />
+                                      }
+                                      hasRoundedCorners={false}
+>>>>>>> Stashed changes
                                       isFullscreen={true}
+                                      isJustifiedRight={false}
+                                      isModalRounded={false}
                                       onClose={[Function]}
                                       size="tiny"
                                       trigger={
@@ -2943,6 +2968,7 @@ exports[`<PropertyPageSearchBar /> should have the right structure 1`] = `
                                       }
                                     >
                                       <Modal
+                                        className=""
                                         closeIcon={
                                           <Icon
                                             color={null}

--- a/src/components/property-page-widgets/Reviews/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Reviews/__snapshots__/component.spec.js.snap
@@ -305,7 +305,32 @@ exports[`<Reviews /> should render the right structure 1`] = `
                     className="right floated top aligned six wide computer seven wide mobile seven wide tablet column"
                   >
                     <Modal
+<<<<<<< Updated upstream
+                      dimmer="inverted"
+                      hasMargin={false}
+                      isAlignedBottom={false}
+=======
+                      closeIcon={
+                        <Icon
+                          color={null}
+                          hasBorder={false}
+                          isButton={false}
+                          isCircular={false}
+                          isColorInverted={false}
+                          isDisabled={false}
+                          isLabelLeft={false}
+                          labelText={null}
+                          labelWeight={null}
+                          name="close"
+                          path={null}
+                          size={null}
+                        />
+                      }
+                      hasRoundedCorners={false}
+>>>>>>> Stashed changes
                       isFullscreen={false}
+                      isJustifiedRight={false}
+                      isModalRounded={false}
                       onClose={[Function]}
                       size="tiny"
                       trigger={
@@ -326,6 +351,7 @@ exports[`<Reviews /> should render the right structure 1`] = `
                       }
                     >
                       <Modal
+                        className=""
                         closeIcon={
                           <Icon
                             color={null}

--- a/src/components/property-page-widgets/Reviews/utils/__snapshots__/getModalFormMarkup.spec.js.snap
+++ b/src/components/property-page-widgets/Reviews/utils/__snapshots__/getModalFormMarkup.spec.js.snap
@@ -2,7 +2,32 @@
 
 exports[`getModalFormMarkup should have the right structure with default props 1`] = `
 <Modal
+<<<<<<< Updated upstream
+  dimmer="inverted"
+  hasMargin={false}
+  isAlignedBottom={false}
+=======
+  closeIcon={
+    <Icon
+      color={null}
+      hasBorder={false}
+      isButton={false}
+      isCircular={false}
+      isColorInverted={false}
+      isDisabled={false}
+      isLabelLeft={false}
+      labelText={null}
+      labelWeight={null}
+      name="close"
+      path={null}
+      size={null}
+    />
+  }
+  hasRoundedCorners={false}
+>>>>>>> Stashed changes
   isFullscreen={false}
+  isJustifiedRight={false}
+  isModalRounded={false}
   onClose={[Function]}
   size="tiny"
   trigger={
@@ -21,6 +46,7 @@ exports[`getModalFormMarkup should have the right structure with default props 1
   }
 >
   <Modal
+    className=""
     closeIcon={
       <Icon
         color={null}
@@ -254,7 +280,32 @@ exports[`getModalFormMarkup should have the right structure with default props 1
 
 exports[`getModalFormMarkup should render the right structure when props are passed 1`] = `
 <Modal
+<<<<<<< Updated upstream
+  dimmer="inverted"
+  hasMargin={false}
+  isAlignedBottom={false}
+=======
+  closeIcon={
+    <Icon
+      color={null}
+      hasBorder={false}
+      isButton={false}
+      isCircular={false}
+      isColorInverted={false}
+      isDisabled={false}
+      isLabelLeft={false}
+      labelText={null}
+      labelWeight={null}
+      name="close"
+      path={null}
+      size={null}
+    />
+  }
+  hasRoundedCorners={false}
+>>>>>>> Stashed changes
   isFullscreen={false}
+  isJustifiedRight={false}
+  isModalRounded={false}
   onClose={[Function]}
   size="tiny"
   trigger={
@@ -275,6 +326,7 @@ exports[`getModalFormMarkup should render the right structure when props are pas
   }
 >
   <Modal
+    className=""
     closeIcon={
       <Icon
         color={null}

--- a/src/components/property-page-widgets/RoomType/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/RoomType/__snapshots__/component.spec.js.snap
@@ -476,7 +476,32 @@ exports[`<RoomType /> by default should render the correct structure 1`] = `
                                     className="mobile only right aligned middle aligned two wide column"
                                   >
                                     <Modal
+<<<<<<< Updated upstream
+                                      dimmer="inverted"
+                                      hasMargin={false}
+                                      isAlignedBottom={false}
+=======
+                                      closeIcon={
+                                        <Icon
+                                          color={null}
+                                          hasBorder={false}
+                                          isButton={false}
+                                          isCircular={false}
+                                          isColorInverted={false}
+                                          isDisabled={false}
+                                          isLabelLeft={false}
+                                          labelText={null}
+                                          labelWeight={null}
+                                          name="close"
+                                          path={null}
+                                          size={null}
+                                        />
+                                      }
+                                      hasRoundedCorners={false}
+>>>>>>> Stashed changes
                                       isFullscreen={false}
+                                      isJustifiedRight={false}
+                                      isModalRounded={false}
                                       onClose={[Function]}
                                       size="tiny"
                                       trigger={
@@ -497,6 +522,7 @@ exports[`<RoomType /> by default should render the correct structure 1`] = `
                                       }
                                     >
                                       <Modal
+                                        className=""
                                         closeIcon={
                                           <Icon
                                             color={null}
@@ -838,7 +864,32 @@ exports[`<RoomType /> by default should render the correct structure 1`] = `
                                           className="tablet only computer only bottom aligned four wide column"
                                         >
                                           <Modal
+<<<<<<< Updated upstream
+                                            dimmer="inverted"
+                                            hasMargin={false}
+                                            isAlignedBottom={false}
+=======
+                                            closeIcon={
+                                              <Icon
+                                                color={null}
+                                                hasBorder={false}
+                                                isButton={false}
+                                                isCircular={false}
+                                                isColorInverted={false}
+                                                isDisabled={false}
+                                                isLabelLeft={false}
+                                                labelText={null}
+                                                labelWeight={null}
+                                                name="close"
+                                                path={null}
+                                                size={null}
+                                              />
+                                            }
+                                            hasRoundedCorners={false}
+>>>>>>> Stashed changes
                                             isFullscreen={false}
+                                            isJustifiedRight={false}
+                                            isModalRounded={false}
                                             onClose={[Function]}
                                             size="small"
                                             trigger={
@@ -853,6 +904,7 @@ exports[`<RoomType /> by default should render the correct structure 1`] = `
                                             }
                                           >
                                             <Modal
+                                              className=""
                                               closeIcon={
                                                 <Icon
                                                   color={null}
@@ -1641,7 +1693,32 @@ exports[`<RoomType /> if \`isUserOnMobile === true\` should render the correct s
                                     className="mobile only right aligned middle aligned two wide column"
                                   >
                                     <Modal
+<<<<<<< Updated upstream
+                                      dimmer="inverted"
+                                      hasMargin={false}
+                                      isAlignedBottom={false}
+=======
+                                      closeIcon={
+                                        <Icon
+                                          color={null}
+                                          hasBorder={false}
+                                          isButton={false}
+                                          isCircular={false}
+                                          isColorInverted={false}
+                                          isDisabled={false}
+                                          isLabelLeft={false}
+                                          labelText={null}
+                                          labelWeight={null}
+                                          name="close"
+                                          path={null}
+                                          size={null}
+                                        />
+                                      }
+                                      hasRoundedCorners={false}
+>>>>>>> Stashed changes
                                       isFullscreen={false}
+                                      isJustifiedRight={false}
+                                      isModalRounded={false}
                                       onClose={[Function]}
                                       size="tiny"
                                       trigger={
@@ -1662,6 +1739,7 @@ exports[`<RoomType /> if \`isUserOnMobile === true\` should render the correct s
                                       }
                                     >
                                       <Modal
+                                        className=""
                                         closeIcon={
                                           <Icon
                                             color={null}
@@ -1976,7 +2054,32 @@ exports[`<RoomType /> if \`isUserOnMobile === true\` should render the correct s
                                           className="tablet only computer only bottom aligned four wide column"
                                         >
                                           <Modal
+<<<<<<< Updated upstream
+                                            dimmer="inverted"
+                                            hasMargin={false}
+                                            isAlignedBottom={false}
+=======
+                                            closeIcon={
+                                              <Icon
+                                                color={null}
+                                                hasBorder={false}
+                                                isButton={false}
+                                                isCircular={false}
+                                                isColorInverted={false}
+                                                isDisabled={false}
+                                                isLabelLeft={false}
+                                                labelText={null}
+                                                labelWeight={null}
+                                                name="close"
+                                                path={null}
+                                                size={null}
+                                              />
+                                            }
+                                            hasRoundedCorners={false}
+>>>>>>> Stashed changes
                                             isFullscreen={false}
+                                            isJustifiedRight={false}
+                                            isModalRounded={false}
                                             onClose={[Function]}
                                             size="small"
                                             trigger={
@@ -1991,6 +2094,7 @@ exports[`<RoomType /> if \`isUserOnMobile === true\` should render the correct s
                                             }
                                           >
                                             <Modal
+                                              className=""
                                               closeIcon={
                                                 <Icon
                                                   color={null}

--- a/src/components/property-page-widgets/RoomTypes/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/RoomTypes/__snapshots__/component.spec.js.snap
@@ -686,7 +686,32 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                           className="mobile only right aligned middle aligned two wide column"
                                         >
                                           <Modal
+<<<<<<< Updated upstream
+                                            dimmer="inverted"
+                                            hasMargin={false}
+                                            isAlignedBottom={false}
+=======
+                                            closeIcon={
+                                              <Icon
+                                                color={null}
+                                                hasBorder={false}
+                                                isButton={false}
+                                                isCircular={false}
+                                                isColorInverted={false}
+                                                isDisabled={false}
+                                                isLabelLeft={false}
+                                                labelText={null}
+                                                labelWeight={null}
+                                                name="close"
+                                                path={null}
+                                                size={null}
+                                              />
+                                            }
+                                            hasRoundedCorners={false}
+>>>>>>> Stashed changes
                                             isFullscreen={false}
+                                            isJustifiedRight={false}
+                                            isModalRounded={false}
                                             onClose={[Function]}
                                             size="tiny"
                                             trigger={
@@ -707,6 +732,7 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                             }
                                           >
                                             <Modal
+                                              className=""
                                               closeIcon={
                                                 <Icon
                                                   color={null}
@@ -1145,7 +1171,32 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                                 className="tablet only computer only bottom aligned four wide column"
                                               >
                                                 <Modal
+<<<<<<< Updated upstream
+                                                  dimmer="inverted"
+                                                  hasMargin={false}
+                                                  isAlignedBottom={false}
+=======
+                                                  closeIcon={
+                                                    <Icon
+                                                      color={null}
+                                                      hasBorder={false}
+                                                      isButton={false}
+                                                      isCircular={false}
+                                                      isColorInverted={false}
+                                                      isDisabled={false}
+                                                      isLabelLeft={false}
+                                                      labelText={null}
+                                                      labelWeight={null}
+                                                      name="close"
+                                                      path={null}
+                                                      size={null}
+                                                    />
+                                                  }
+                                                  hasRoundedCorners={false}
+>>>>>>> Stashed changes
                                                   isFullscreen={false}
+                                                  isJustifiedRight={false}
+                                                  isModalRounded={false}
                                                   onClose={[Function]}
                                                   size="small"
                                                   trigger={
@@ -1160,6 +1211,7 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                                   }
                                                 >
                                                   <Modal
+                                                    className=""
                                                     closeIcon={
                                                       <Icon
                                                         color={null}
@@ -2020,7 +2072,32 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                           className="mobile only right aligned middle aligned two wide column"
                                         >
                                           <Modal
+<<<<<<< Updated upstream
+                                            dimmer="inverted"
+                                            hasMargin={false}
+                                            isAlignedBottom={false}
+=======
+                                            closeIcon={
+                                              <Icon
+                                                color={null}
+                                                hasBorder={false}
+                                                isButton={false}
+                                                isCircular={false}
+                                                isColorInverted={false}
+                                                isDisabled={false}
+                                                isLabelLeft={false}
+                                                labelText={null}
+                                                labelWeight={null}
+                                                name="close"
+                                                path={null}
+                                                size={null}
+                                              />
+                                            }
+                                            hasRoundedCorners={false}
+>>>>>>> Stashed changes
                                             isFullscreen={false}
+                                            isJustifiedRight={false}
+                                            isModalRounded={false}
                                             onClose={[Function]}
                                             size="tiny"
                                             trigger={
@@ -2041,6 +2118,7 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                             }
                                           >
                                             <Modal
+                                              className=""
                                               closeIcon={
                                                 <Icon
                                                   color={null}
@@ -2470,7 +2548,32 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                                 className="tablet only computer only bottom aligned four wide column"
                                               >
                                                 <Modal
+<<<<<<< Updated upstream
+                                                  dimmer="inverted"
+                                                  hasMargin={false}
+                                                  isAlignedBottom={false}
+=======
+                                                  closeIcon={
+                                                    <Icon
+                                                      color={null}
+                                                      hasBorder={false}
+                                                      isButton={false}
+                                                      isCircular={false}
+                                                      isColorInverted={false}
+                                                      isDisabled={false}
+                                                      isLabelLeft={false}
+                                                      labelText={null}
+                                                      labelWeight={null}
+                                                      name="close"
+                                                      path={null}
+                                                      size={null}
+                                                    />
+                                                  }
+                                                  hasRoundedCorners={false}
+>>>>>>> Stashed changes
                                                   isFullscreen={false}
+                                                  isJustifiedRight={false}
+                                                  isModalRounded={false}
                                                   onClose={[Function]}
                                                   size="small"
                                                   trigger={
@@ -2485,6 +2588,7 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                                   }
                                                 >
                                                   <Modal
+                                                    className=""
                                                     closeIcon={
                                                       <Icon
                                                         color={null}

--- a/src/styles/semantic/themes/livingstone/collections/form.overrides
+++ b/src/styles/semantic/themes/livingstone/collections/form.overrides
@@ -97,3 +97,26 @@
        Groups
 --------------------*/
 }
+
+/*-------------------
+       Cookies Form
+--------------------*/
+
+.cookies-form {
+  position: fixed;
+  bottom: 0;
+  right: 0;
+  margin: 30px;
+  max-width: 300px;
+  z-index: 3;
+
+  .ui.card.has-form {
+    padding: 30px;
+
+    .ui.button {
+      border-radius: 30px;
+      float: none;
+      margin: 0 auto;
+    }
+  }
+}

--- a/src/styles/semantic/themes/livingstone/modules/modal.overrides
+++ b/src/styles/semantic/themes/livingstone/modules/modal.overrides
@@ -51,6 +51,7 @@
 
   &.scrolling.modal {
     margin: 0 !important;
+    overflow: auto;
   }
 
   > .content > .link.item {
@@ -153,6 +154,47 @@
           transform: none;
         }
       }
+    }
+  }
+}
+
+/* Cookie Alert */
+
+.ui.modals.dimmer {
+  padding: 0;
+
+  @media screen and (min-width: @largeMonitorBreakpoint) {
+    background-color: transparent !important;
+  }
+
+  &:not(.inverted) {
+    background-color: rgba(51, 51, 51, 0.35);
+  }
+}
+
+.ui.modal.active {
+  position: relative;
+
+  &.is-modal-rounded {
+    border-radius: 4px;
+
+    .ui.basic.button {
+      padding: 0;
+    }
+  }
+
+  @media only screen and (min-width: @largeMonitorBreakpoint) {
+
+    &.is-justified-right {
+      align-self: flex-end;
+    }
+
+    &.is-aligned-bottom {
+      margin-top: auto !important;
+    }
+
+    &.has-margin {
+      margin: 30px;
     }
   }
 }


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1725)

### What **one** thing does this PR do?
The `Modal`  exposes props which allow for the behaviours show in the ticket; then, implements a new `CookieAlert` component with the required styles.

### Any other notes
![kapture 2019-01-29 at 12 46 19](https://user-images.githubusercontent.com/33876435/51906243-fe169b00-23c3-11e9-9e52-e88a4df30bee.gif)
