### PR TITLE
TE-1685 Fix Desktop Menu Modal layout

### DIFF
--- a/src/components/collections/Header/__snapshots__/component.spec.js.snap
+++ b/src/components/collections/Header/__snapshots__/component.spec.js.snap
@@ -69,12 +69,14 @@ exports[`<Header /> by default should render the right structure 1`] = `
           <div
             className="ui borderless ui text container menu"
           >
-            <Item
+            <MenuItem
               href="/"
+              link={true}
             >
               <a
-                className="item"
+                className="link item"
                 href="/"
+                onClick={[Function]}
               >
                 <Heading
                   className={null}
@@ -96,7 +98,7 @@ exports[`<Header /> by default should render the right structure 1`] = `
                   </Header>
                 </Heading>
               </a>
-            </Item>
+            </MenuItem>
             <ShowOn
               computer={false}
               mobile={true}
@@ -163,8 +165,9 @@ exports[`<Header /> by default should render the right structure 1`] = `
                           closeOnDocumentClick={false}
                           content={
                             Array [
-                              <Item
+                              <MenuItem
                                 href="/"
+                                link={true}
                               >
                                 <Heading
                                   className={null}
@@ -174,7 +177,7 @@ exports[`<Header /> by default should render the right structure 1`] = `
                                 >
                                   someLogoText
                                 </Heading>
-                              </Item>,
+                              </MenuItem>,
                               <Menu
                                 text={true}
                                 vertical={true}
@@ -775,12 +778,14 @@ exports[`<Header /> if \`props.isBackgroundFilled\` is true should render the ri
           <div
             className="ui borderless ui text container menu"
           >
-            <Item
+            <MenuItem
               href="/"
+              link={true}
             >
               <a
-                className="item"
+                className="link item"
                 href="/"
+                onClick={[Function]}
               >
                 <Heading
                   className={null}
@@ -802,7 +807,7 @@ exports[`<Header /> if \`props.isBackgroundFilled\` is true should render the ri
                   </Header>
                 </Heading>
               </a>
-            </Item>
+            </MenuItem>
             <ShowOn
               computer={false}
               mobile={true}
@@ -869,8 +874,9 @@ exports[`<Header /> if \`props.isBackgroundFilled\` is true should render the ri
                           closeOnDocumentClick={false}
                           content={
                             Array [
-                              <Item
+                              <MenuItem
                                 href="/"
+                                link={true}
                               >
                                 <Heading
                                   className={null}
@@ -880,7 +886,7 @@ exports[`<Header /> if \`props.isBackgroundFilled\` is true should render the ri
                                 >
                                   someLogoText
                                 </Heading>
-                              </Item>,
+                              </MenuItem>,
                               <Menu
                                 text={true}
                                 vertical={true}
@@ -1481,12 +1487,14 @@ exports[`<Header /> if navigation items exceed the header max width should rende
           <div
             className="ui borderless ui text container menu"
           >
-            <Item
+            <MenuItem
               href="/"
+              link={true}
             >
               <a
-                className="item"
+                className="link item"
                 href="/"
+                onClick={[Function]}
               >
                 <Heading
                   className={null}
@@ -1508,7 +1516,7 @@ exports[`<Header /> if navigation items exceed the header max width should rende
                   </Header>
                 </Heading>
               </a>
-            </Item>
+            </MenuItem>
             <ShowOn
               computer={true}
               mobile={true}
@@ -1575,8 +1583,9 @@ exports[`<Header /> if navigation items exceed the header max width should rende
                           closeOnDocumentClick={false}
                           content={
                             Array [
-                              <Item
+                              <MenuItem
                                 href="/"
+                                link={true}
                               >
                                 <Heading
                                   className={null}
@@ -1586,7 +1595,7 @@ exports[`<Header /> if navigation items exceed the header max width should rende
                                 >
                                   someLogoText
                                 </Heading>
-                              </Item>,
+                              </MenuItem>,
                               <Menu
                                 text={true}
                                 vertical={true}

--- a/src/components/collections/Header/utils/__snapshots__/getHiddenMenuMarkup.spec.js.snap
+++ b/src/components/collections/Header/utils/__snapshots__/getHiddenMenuMarkup.spec.js.snap
@@ -67,8 +67,9 @@ exports[`getHiddenMenuMarkup by default should render the right structure 1`] = 
               closeOnDocumentClick={false}
               content={
                 Array [
-                  <Item
+                  <MenuItem
                     href="/"
+                    link={true}
                   >
                     <Image
                       alt="someLogoText"
@@ -78,7 +79,7 @@ exports[`getHiddenMenuMarkup by default should render the right structure 1`] = 
                       srcSet="someLogoSrcSet"
                       ui={true}
                     />
-                  </Item>,
+                  </MenuItem>,
                   <Menu
                     text={true}
                     vertical={true}
@@ -596,8 +597,9 @@ exports[`getHiddenMenuMarkup if \`props.searchBarGuestsOptions\` and \`props.sea
               closeOnDocumentClick={false}
               content={
                 Array [
-                  <Item
+                  <MenuItem
                     href="/"
+                    link={true}
                   >
                     <Image
                       alt="someLogoText"
@@ -607,7 +609,7 @@ exports[`getHiddenMenuMarkup if \`props.searchBarGuestsOptions\` and \`props.sea
                       srcSet="someLogoSrcSet"
                       ui={true}
                     />
-                  </Item>,
+                  </MenuItem>,
                   <Menu
                     text={true}
                     vertical={true}

--- a/src/components/collections/Header/utils/__snapshots__/getLogoMarkup.spec.js.snap
+++ b/src/components/collections/Header/utils/__snapshots__/getLogoMarkup.spec.js.snap
@@ -1,12 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`getLogoMarkup by default should render the right structure 1`] = `
-<Item
+<MenuItem
   href="/"
+  link={true}
 >
   <a
-    className="item"
+    className="link item"
     href="/"
+    onClick={[Function]}
   >
     <Heading
       className={null}
@@ -28,16 +30,18 @@ exports[`getLogoMarkup by default should render the right structure 1`] = `
       </Header>
     </Heading>
   </a>
-</Item>
+</MenuItem>
 `;
 
 exports[`getLogoMarkup if \`logoSrc\`, \`logoSizes\` and \`logoSrcSet\` are passed should render the right structure 1`] = `
-<Item
+<MenuItem
   href="/"
+  link={true}
 >
   <a
-    className="item"
+    className="link item"
     href="/"
+    onClick={[Function]}
   >
     <Image
       alt="someLogoText"
@@ -56,5 +60,5 @@ exports[`getLogoMarkup if \`logoSrc\`, \`logoSizes\` and \`logoSrcSet\` are pass
       />
     </Image>
   </a>
-</Item>
+</MenuItem>
 `;

--- a/src/components/collections/Header/utils/getLogoMarkup.js
+++ b/src/components/collections/Header/utils/getLogoMarkup.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Item, Image } from 'semantic-ui-react';
+import { Menu, Image } from 'semantic-ui-react';
 
 import { Heading } from 'typography/Heading';
 
@@ -11,7 +11,7 @@ import { Heading } from 'typography/Heading';
  * @return {Object}
  */
 export const getLogoMarkup = (logoText, logoSrc, logoSizes, logoSrcSet) => (
-  <Item href="/">
+  <Menu.Item href="/" link>
     {logoSrc ? (
       <Image
         alt={logoText}
@@ -22,5 +22,5 @@ export const getLogoMarkup = (logoText, logoSrc, logoSizes, logoSrcSet) => (
     ) : (
       <Heading size="small">{logoText}</Heading>
     )}
-  </Item>
+  </Menu.Item>
 );

--- a/src/components/collections/Hero/__snapshots__/component.spec.js.snap
+++ b/src/components/collections/Hero/__snapshots__/component.spec.js.snap
@@ -176,12 +176,14 @@ exports[`<Hero /> by default should render the right structure 1`] = `
                   <div
                     className="ui borderless ui text container menu"
                   >
-                    <Item
+                    <MenuItem
                       href="/"
+                      link={true}
                     >
                       <a
-                        className="item"
+                        className="link item"
                         href="/"
+                        onClick={[Function]}
                       >
                         <Image
                           alt="Livingstone Cottage"
@@ -200,7 +202,7 @@ exports[`<Hero /> by default should render the right structure 1`] = `
                           />
                         </Image>
                       </a>
-                    </Item>
+                    </MenuItem>
                     <ShowOn
                       computer={false}
                       mobile={true}
@@ -570,8 +572,9 @@ exports[`<Hero /> by default should render the right structure 1`] = `
                                   closeOnDocumentClick={false}
                                   content={
                                     Array [
-                                      <Item
+                                      <MenuItem
                                         href="/"
+                                        link={true}
                                       >
                                         <Image
                                           alt="Livingstone Cottage"
@@ -581,7 +584,7 @@ exports[`<Hero /> by default should render the right structure 1`] = `
                                           srcSet="a load of logo src sets"
                                           ui={true}
                                         />
-                                      </Item>,
+                                      </MenuItem>,
                                       <Menu
                                         text={true}
                                         vertical={true}

--- a/src/components/general-widgets/HomepageHero/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/HomepageHero/__snapshots__/component.spec.js.snap
@@ -240,12 +240,14 @@ exports[`HomepageHero should render the right structure 1`] = `
                     <div
                       className="ui borderless ui text container menu"
                     >
-                      <Item
+                      <MenuItem
                         href="/"
+                        link={true}
                       >
                         <a
-                          className="item"
+                          className="link item"
                           href="/"
+                          onClick={[Function]}
                         >
                           <Image
                             alt="text"
@@ -264,7 +266,7 @@ exports[`HomepageHero should render the right structure 1`] = `
                             />
                           </Image>
                         </a>
-                      </Item>
+                      </MenuItem>
                       <ShowOn
                         computer={false}
                         mobile={true}
@@ -612,8 +614,9 @@ exports[`HomepageHero should render the right structure 1`] = `
                                     closeOnDocumentClick={false}
                                     content={
                                       Array [
-                                        <Item
+                                        <MenuItem
                                           href="/"
+                                          link={true}
                                         >
                                           <Image
                                             alt="text"
@@ -623,7 +626,7 @@ exports[`HomepageHero should render the right structure 1`] = `
                                             srcSet="a load of logo src sets"
                                             ui={true}
                                           />
-                                        </Item>,
+                                        </MenuItem>,
                                         <Menu
                                           text={true}
                                           vertical={true}

--- a/src/components/property-page-widgets/PropertyPageHero/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/PropertyPageHero/__snapshots__/component.spec.js.snap
@@ -232,12 +232,14 @@ exports[`PropertyPageHero by default if there are fewer than two images should r
                     <div
                       className="ui borderless ui text container menu"
                     >
-                      <Item
+                      <MenuItem
                         href="/"
+                        link={true}
                       >
                         <a
-                          className="item"
+                          className="link item"
                           href="/"
+                          onClick={[Function]}
                         >
                           <Image
                             alt="text"
@@ -256,7 +258,7 @@ exports[`PropertyPageHero by default if there are fewer than two images should r
                             />
                           </Image>
                         </a>
-                      </Item>
+                      </MenuItem>
                       <ShowOn
                         computer={false}
                         mobile={true}
@@ -598,8 +600,9 @@ exports[`PropertyPageHero by default if there are fewer than two images should r
                                     closeOnDocumentClick={false}
                                     content={
                                       Array [
-                                        <Item
+                                        <MenuItem
                                           href="/"
+                                          link={true}
                                         >
                                           <Image
                                             alt="text"
@@ -609,7 +612,7 @@ exports[`PropertyPageHero by default if there are fewer than two images should r
                                             srcSet="a load of logo src sets"
                                             ui={true}
                                           />
-                                        </Item>,
+                                        </MenuItem>,
                                         <Menu
                                           text={true}
                                           vertical={true}
@@ -1051,12 +1054,14 @@ exports[`PropertyPageHero by default should render the right structure 1`] = `
                     <div
                       className="ui borderless ui text container menu"
                     >
-                      <Item
+                      <MenuItem
                         href="/"
+                        link={true}
                       >
                         <a
-                          className="item"
+                          className="link item"
                           href="/"
+                          onClick={[Function]}
                         >
                           <Image
                             alt="text"
@@ -1075,7 +1080,7 @@ exports[`PropertyPageHero by default should render the right structure 1`] = `
                             />
                           </Image>
                         </a>
-                      </Item>
+                      </MenuItem>
                       <ShowOn
                         computer={false}
                         mobile={true}
@@ -1417,8 +1422,9 @@ exports[`PropertyPageHero by default should render the right structure 1`] = `
                                     closeOnDocumentClick={false}
                                     content={
                                       Array [
-                                        <Item
+                                        <MenuItem
                                           href="/"
+                                          link={true}
                                         >
                                           <Image
                                             alt="text"
@@ -1428,7 +1434,7 @@ exports[`PropertyPageHero by default should render the right structure 1`] = `
                                             srcSet="a load of logo src sets"
                                             ui={true}
                                           />
-                                        </Item>,
+                                        </MenuItem>,
                                         <Menu
                                           text={true}
                                           vertical={true}

--- a/src/styles/semantic/themes/livingstone/collections/menu.overrides
+++ b/src/styles/semantic/themes/livingstone/collections/menu.overrides
@@ -104,7 +104,6 @@
     margin-top: @verticalMenuInModalMarginTop;
 
     @media only screen and (max-width: @largeMonitorBreakpoint) {
-      margin-top: @verticalMenuInModalMarginTopMobile;
       justify-content: flex-start;
     }
 

--- a/src/styles/semantic/themes/livingstone/collections/menu.variables
+++ b/src/styles/semantic/themes/livingstone/collections/menu.variables
@@ -133,7 +133,6 @@
 @verticalMenuInModalSubItemPaddingLeft: @10px;
 
 @verticalMenuInModalMarginTop: 50px;
-@verticalMenuInModalMarginTopMobile: 20px;
 
 /* Secondary */
 

--- a/src/styles/semantic/themes/livingstone/modules/modal.overrides
+++ b/src/styles/semantic/themes/livingstone/modules/modal.overrides
@@ -51,10 +51,15 @@
 
   &.scrolling.modal {
     margin: 0 !important;
+    overflow: auto;
   }
 
   > .content > .link.item {
     display: inline-block;
+
+    > img:only-of-type {
+      max-height: @modalLogoMaxHeight;
+    }
   }
 
   > .content {

--- a/src/styles/semantic/themes/livingstone/modules/modal.variables
+++ b/src/styles/semantic/themes/livingstone/modules/modal.variables
@@ -16,6 +16,9 @@
 
 /* Header */
 
+/* Logo */
+@modalLogoMaxHeight: 60px;
+
 /* Content */
 @contentPadding: 30px 15%;
 @contentPaddingMobile: 15px 5%;


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1685)

### What **one** thing does this PR do?
Fixes the regression caused by the merge of the mentioned ticket.

### Current visible menu
![before-logo-header](https://user-images.githubusercontent.com/33876435/51979460-7c8b3f80-248d-11e9-8cd1-6687b5e46d77.gif)

### Current hidden menu
![hidden-logo-before](https://user-images.githubusercontent.com/33876435/51979479-890f9800-248d-11e9-940c-d4b8db77ad0f.gif)

### Current Modal
![modal-overflow-before](https://user-images.githubusercontent.com/33876435/51979512-a0e71c00-248d-11e9-9ce3-7de5777b4a60.gif)

### Visible menu after fix
![visible-menu-after](https://user-images.githubusercontent.com/33876435/51979545-b1979200-248d-11e9-93c0-6341c1c176a7.gif)

### Hidden menu after fix
![hidden-menu-before](https://user-images.githubusercontent.com/33876435/51979580-c7a55280-248d-11e9-8a5a-aa1c94d7b4ad.gif)

### Modal after fix
![modal-after](https://user-images.githubusercontent.com/33876435/51979605-d5f36e80-248d-11e9-88e6-d29ee571750c.gif)




