### PR TITLE
TE-1690 Footer should be at the bottom of the page

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -63,6 +63,7 @@ export { GridRow } from './components/layout/GridRow';
 export { HorizontalGutters } from './components/layout/HorizontalGutters';
 export { ShowOn } from './components/layout/ShowOn';
 export { VerticalGutters } from './components/layout/VerticalGutters';
+export { Viewport } from './components/layout/Viewport';
 
 // Media
 export { FullBleed } from './components/media/FullBleed';


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1690)

### What **one** thing does this PR do?
Adds missing export for the `Viewport` component. 

