### PR TITLE
TE-1805 Roomtype icons are horizontally inline 

### DIFF
--- a/src/components/property-page-widgets/RoomType/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/RoomType/__snapshots__/component.spec.js.snap
@@ -526,6 +526,7 @@ exports[`<RoomType /> by default should render the correct structure 1`] = `
                               <GridColumn
                                 as={[Function]}
                                 className="only-horizontal-padding"
+                                computer={12}
                                 floated="left"
                                 horizontal={true}
                                 verticalAlignContent="top"
@@ -534,17 +535,18 @@ exports[`<RoomType /> by default should render the correct structure 1`] = `
                                 <GridColumn
                                   as={[Function]}
                                   className="only-horizontal-padding"
+                                  computer={12}
                                   floated="left"
                                   horizontal={true}
                                   verticalAlign="top"
                                   width={null}
                                 >
                                   <List
-                                    className="left floated top aligned column only-horizontal-padding"
+                                    className="left floated top aligned twelve wide computer column only-horizontal-padding"
                                     horizontal={true}
                                   >
                                     <div
-                                      className="ui horizontal list left floated top aligned column only-horizontal-padding"
+                                      className="ui horizontal list left floated top aligned twelve wide computer column only-horizontal-padding"
                                       role="list"
                                     >
                                       <ListItem
@@ -1477,6 +1479,7 @@ exports[`<RoomType /> if \`isUserOnMobile === true\` should render the correct s
                               <GridColumn
                                 as={[Function]}
                                 className="only-horizontal-padding"
+                                computer={12}
                                 floated="left"
                                 horizontal={true}
                                 verticalAlignContent="top"
@@ -1485,17 +1488,18 @@ exports[`<RoomType /> if \`isUserOnMobile === true\` should render the correct s
                                 <GridColumn
                                   as={[Function]}
                                   className="only-horizontal-padding"
+                                  computer={12}
                                   floated="left"
                                   horizontal={true}
                                   verticalAlign="top"
                                   width={null}
                                 >
                                   <List
-                                    className="left floated top aligned column only-horizontal-padding"
+                                    className="left floated top aligned twelve wide computer column only-horizontal-padding"
                                     horizontal={true}
                                   >
                                     <div
-                                      className="ui horizontal list left floated top aligned column only-horizontal-padding"
+                                      className="ui horizontal list left floated top aligned twelve wide computer column only-horizontal-padding"
                                       role="list"
                                     >
                                       <ListItem

--- a/src/components/property-page-widgets/RoomType/utils/getRoomFeaturesMarkup.js
+++ b/src/components/property-page-widgets/RoomType/utils/getRoomFeaturesMarkup.js
@@ -14,6 +14,7 @@ export const getRoomFeaturesMarkup = (showIcons, features) => (
   <GridColumn
     as={List}
     className="only-horizontal-padding"
+    computer={12}
     floated="left"
     horizontal
   >

--- a/src/components/property-page-widgets/RoomTypes/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/RoomTypes/__snapshots__/component.spec.js.snap
@@ -763,6 +763,7 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                     <GridColumn
                                       as={[Function]}
                                       className="only-horizontal-padding"
+                                      computer={12}
                                       floated="left"
                                       horizontal={true}
                                       verticalAlignContent="top"
@@ -771,17 +772,18 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                       <GridColumn
                                         as={[Function]}
                                         className="only-horizontal-padding"
+                                        computer={12}
                                         floated="left"
                                         horizontal={true}
                                         verticalAlign="top"
                                         width={null}
                                       >
                                         <List
-                                          className="left floated top aligned column only-horizontal-padding"
+                                          className="left floated top aligned twelve wide computer column only-horizontal-padding"
                                           horizontal={true}
                                         >
                                           <div
-                                            className="ui horizontal list left floated top aligned column only-horizontal-padding"
+                                            className="ui horizontal list left floated top aligned twelve wide computer column only-horizontal-padding"
                                             role="list"
                                           >
                                             <ListItem
@@ -1898,6 +1900,7 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                     <GridColumn
                                       as={[Function]}
                                       className="only-horizontal-padding"
+                                      computer={12}
                                       floated="left"
                                       horizontal={true}
                                       verticalAlignContent="top"
@@ -1906,17 +1909,18 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                       <GridColumn
                                         as={[Function]}
                                         className="only-horizontal-padding"
+                                        computer={12}
                                         floated="left"
                                         horizontal={true}
                                         verticalAlign="top"
                                         width={null}
                                       >
                                         <List
-                                          className="left floated top aligned column only-horizontal-padding"
+                                          className="left floated top aligned twelve wide computer column only-horizontal-padding"
                                           horizontal={true}
                                         >
                                           <div
-                                            className="ui horizontal list left floated top aligned column only-horizontal-padding"
+                                            className="ui horizontal list left floated top aligned twelve wide computer column only-horizontal-padding"
                                             role="list"
                                           >
                                             <ListItem


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1805)

### What **one** thing does this PR do?
Roomtype feature icons are horizontally inline

### Any other notes
### Before
![image](https://user-images.githubusercontent.com/10498995/52355941-98fe1d80-2a33-11e9-9092-7652770f5e6a.png)

### After
![image](https://user-images.githubusercontent.com/10498995/52355095-f85b2e00-2a31-11e9-966d-0bdfca55cc13.png)

