### PR TITLE
TE-1754 HTML component content is not respecting parent width.

### DIFF
--- a/src/components/general-widgets/HTML/Readme.md
+++ b/src/components/general-widgets/HTML/Readme.md
@@ -20,6 +20,19 @@ const {
 </HTML>
 ```
 
+#### Image Nesting
+
+```jsx
+const { image, nestedImage, flexWrappedImage } = require('./mock-data/examples');
+
+<HTML htmlString={image}>
+  <HTML htmlString={nestedImage}>
+    <HTML htmlString={flexWrappedImage}>
+    </HTML>
+  </HTML>
+</HTML>
+```
+
 #### Wrong HTML
 
 ```jsx

--- a/src/components/general-widgets/HTML/component.js
+++ b/src/components/general-widgets/HTML/component.js
@@ -27,11 +27,17 @@ export class Component extends PureComponent {
 
     return children ? (
       <div>
-        <div dangerouslySetInnerHTML={{ __html: cleanHTMLString }} />
+        <div
+          className="html-container"
+          dangerouslySetInnerHTML={{ __html: cleanHTMLString }}
+        />
         {children}
       </div>
     ) : (
-      <div dangerouslySetInnerHTML={{ __html: cleanHTMLString }} />
+      <div
+        className="html-container"
+        dangerouslySetInnerHTML={{ __html: cleanHTMLString }}
+      />
     );
   }
 }

--- a/src/components/general-widgets/HTML/component.spec.js
+++ b/src/components/general-widgets/HTML/component.spec.js
@@ -48,6 +48,7 @@ describe('<HTML />', () => {
           .at(0);
 
         expectComponentToHaveProps(wrapper, {
+          className: 'html-container',
           dangerouslySetInnerHTML: expect.objectContaining({
             __html: expect.any(String),
           }),
@@ -67,6 +68,7 @@ describe('<HTML />', () => {
         const wrapper = getHTMLWidget({ headings });
 
         expectComponentToHaveProps(wrapper, {
+          className: 'html-container',
           dangerouslySetInnerHTML: expect.objectContaining({
             __html: expect.any(String),
           }),

--- a/src/components/general-widgets/HTML/mock-data/examples.js
+++ b/src/components/general-widgets/HTML/mock-data/examples.js
@@ -7,6 +7,30 @@ export const headings = `
   </div>
 `;
 
+export const image = `<h2>Nested Image</h2><img src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"/>`;
+
+export const nestedImage = `
+  <div style="padding: 1rem;">
+    <h3>Nested image in a fixed width wrapper</h3>
+    <div style="width: 200px; box-shadow: inset 0 0 0 1px black; padding: 20px">
+      <img src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"/>
+      <img src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"/>
+    </div>
+  </div>`;
+
+export const flexWrappedImage = `
+<div style="padding: 1rem;">
+  <h3>Nested image in a flex wrapper</h3>
+  <div style="display: flex; flex-direction: row; padding: 20px; box-shadow: inset 0 0 0 1px black;">
+    <div style="margin: 5px;">
+      <img src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"/>
+    </div>
+    <div style="margin: 5px;">
+      <img src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"/>
+    </div>
+  </div>
+</div>`;
+
 export const malformedTable = `<TABLE><tr><td>Malformed Table 😱😱😱😱😱😱</tr></TABL>`;
 
 export const malformedQuotes = `<UL style="list-style-type: none;margin: 0;padding: 0;">

--- a/src/styles/semantic/themes/livingstone/globals/site.overrides
+++ b/src/styles/semantic/themes/livingstone/globals/site.overrides
@@ -625,3 +625,22 @@ blockquote.ui.quote .row {
     margin-right: 1em;
   }
 }
+
+/*----------------------
+       HTML Container
+-----------------------*/
+
+.html-container {
+  overflow: auto;
+
+  > img {
+    max-width: @htmlContainerImmediateImageChildMaxWidth;
+  }
+
+  & * {
+
+    img {
+      width: @htmlContainerImageChildWidth;
+    }
+  }
+}

--- a/src/styles/semantic/themes/livingstone/globals/site.variables
+++ b/src/styles/semantic/themes/livingstone/globals/site.variables
@@ -514,3 +514,9 @@
 @textPlaceholderShortMarginRight: @textPlaceholderFullLength - @textPlaceholderShortLength;
 @textPlaceholderMediumMarginRight: @textPlaceholderFullLength - @textPlaceholderMediumLength;
 @textPlaceholderLongMarginRight: @textPlaceholderFullLength - @textPlaceholderLongLength;
+
+/*----------------------
+       HTML Container
+-----------------------*/
+@htmlContainerImmediateImageChildMaxWidth: 100%;
+@htmlContainerImageChildWidth: 100%;


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1754)

### What **one** thing does this PR do?
Implements new styles for the `HTML` component in order to prevent content and image overflow; then, updates `HTML` docs with a nested image case.

### Behaviour
![kapture 2019-02-08 at 13 32 54](https://user-images.githubusercontent.com/33876435/52478598-26fa1580-2ba6-11e9-9818-57db44a83848.gif)

<img width="834" alt="screenshot 2019-02-08 at 13 34 20" src="https://user-images.githubusercontent.com/33876435/52478634-47c26b00-2ba6-11e9-907d-07d171fe9aa8.png">
