### PR TITLE
TE-1755 Add placeholders to`RoomTypes`

### DIFF
--- a/src/components/elements/BlockPlaceholder/__snapshots__/component.spec.js.snap
+++ b/src/components/elements/BlockPlaceholder/__snapshots__/component.spec.js.snap
@@ -2,12 +2,12 @@
 
 exports[`<BlockPlaceholder /> should have the right structure 1`] = `
 <BlockPlaceholder
-  isFluid={true}
+  isFluid={false}
   isRectangular={false}
   isSquare={false}
 >
   <div
-    className="placeholder block fluid"
+    className="placeholder block"
   />
 </BlockPlaceholder>
 `;

--- a/src/components/elements/BlockPlaceholder/component.js
+++ b/src/components/elements/BlockPlaceholder/component.js
@@ -19,13 +19,13 @@ export const Component = ({ isFluid, isRectangular, isSquare }) => (
 Component.displayName = 'BlockPlaceholder';
 
 Component.defaultProps = {
-  isFluid: true,
+  isFluid: false,
   isSquare: false,
   isRectangular: false,
 };
 
 Component.propTypes = {
-  /** The placeholder fills the width of its parent. */
+  /** The placeholder fills the height and width of its parent. */
   isFluid: PropTypes.bool,
   /** The placeholder maintains 4:3 proportions. */
   isRectangular: PropTypes.bool,

--- a/src/components/general-widgets/FeaturedRoomType/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/FeaturedRoomType/__snapshots__/component.spec.js.snap
@@ -6,7 +6,7 @@ exports[`<FeaturedRoomType /> if \`props.isShowingPlaceholder\` is \`true\` shou
   href="/"
 >
   <BlockPlaceholder
-    isFluid={true}
+    isFluid={false}
     isRectangular={true}
     isSquare={false}
   />

--- a/src/components/general-widgets/FeaturedRoomTypes/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/FeaturedRoomTypes/__snapshots__/component.spec.js.snap
@@ -387,12 +387,12 @@ exports[`<FeaturedRoomTypes /> if \`props.featuredRoomTypes\` length === 0 and \
                     onClick={[Function]}
                   >
                     <BlockPlaceholder
-                      isFluid={true}
+                      isFluid={false}
                       isRectangular={true}
                       isSquare={false}
                     >
                       <div
-                        className="placeholder block fluid rectangle"
+                        className="placeholder block rectangle"
                       />
                     </BlockPlaceholder>
                     <CardContent>
@@ -492,12 +492,12 @@ exports[`<FeaturedRoomTypes /> if \`props.featuredRoomTypes\` length === 0 and \
                     onClick={[Function]}
                   >
                     <BlockPlaceholder
-                      isFluid={true}
+                      isFluid={false}
                       isRectangular={true}
                       isSquare={false}
                     >
                       <div
-                        className="placeholder block fluid rectangle"
+                        className="placeholder block rectangle"
                       />
                     </BlockPlaceholder>
                     <CardContent>
@@ -597,12 +597,12 @@ exports[`<FeaturedRoomTypes /> if \`props.featuredRoomTypes\` length === 0 and \
                     onClick={[Function]}
                   >
                     <BlockPlaceholder
-                      isFluid={true}
+                      isFluid={false}
                       isRectangular={true}
                       isSquare={false}
                     >
                       <div
-                        className="placeholder block fluid rectangle"
+                        className="placeholder block rectangle"
                       />
                     </BlockPlaceholder>
                     <CardContent>

--- a/src/components/property-page-widgets/Rates/utils/getTablePlaceholderMarkup.js
+++ b/src/components/property-page-widgets/Rates/utils/getTablePlaceholderMarkup.js
@@ -12,11 +12,11 @@ export const getTablePlaceholderMarkup = () => (
     <TextPlaceholder length="full" />
     <TextPlaceholder length="full" />
     <Divider />
-    <BlockPlaceholder />
+    <BlockPlaceholder isFluid />
     <Divider />
-    <BlockPlaceholder />
+    <BlockPlaceholder isFluid />
     <Divider />
-    <BlockPlaceholder />
+    <BlockPlaceholder isFluid />
     <Divider />
   </Fragment>
 );

--- a/src/components/property-page-widgets/RoomType/Readme.md
+++ b/src/components/property-page-widgets/RoomType/Readme.md
@@ -39,17 +39,17 @@ const availableAmenities = [
 const description = "There are not many cities that have experienced such social and political extremes in recent history as Amsterdam. In the 20th century alone, Amsterdam faced the atrocities of war for the first time in 400 years, became the radical center of 1960s social movements and witnessed a complete about-face in its core economy.";
 
 const images = [
-  { 
+  {
     alternativeText: 'Two cats',
     url: 'https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg',
-    title: 'Two cats' 
+    title: 'Two cats'
   },
-  { 
+  {
     alternativeText: 'Two more cats',
     url: 'https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg',
-    title: 'Two more cats' 
+    title: 'Two more cats'
   },
-  { 
+  {
     alternativeText: 'Much cats',
     url: 'https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg',
     title: 'Much cats'
@@ -64,7 +64,7 @@ const extraRoomTypeFeatures = [
 const roomTypeFeatures = [
   { iconName: 'double bed',  labelText: '1 Bedroom' },
   { iconName: 'guests',  labelText: '2 Guests' },
-  { iconName: 'bathroom',  labelText: '1 Bathroom' }, 
+  { iconName: 'bathroom',  labelText: '1 Bathroom' },
 ];
 
 <RoomType
@@ -76,5 +76,20 @@ const roomTypeFeatures = [
   extraFeatures={extraRoomTypeFeatures}
   slideShowImages={images}
   amenities={availableAmenities}
+/>
+```
+
+### States
+
+#### Showing placeholder
+
+```jsx
+<RoomType
+  amenities={[]}
+  features={[]}
+  name=""
+  nightPrice=""
+  isShowingPlaceholder
+  slideShowImages={[]}
 />
 ```

--- a/src/components/property-page-widgets/RoomType/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/RoomType/__snapshots__/component.spec.js.snap
@@ -40,6 +40,7 @@ exports[`<RoomType /> by default should render the correct structure 1`] = `
       },
     ]
   }
+  isShowingPlaceholder={false}
   isUserOnMobile={false}
   locationName="Catania"
   name="The Cat House"
@@ -953,6 +954,253 @@ exports[`<RoomType /> by default should render the correct structure 1`] = `
 </RoomType>
 `;
 
+exports[`<RoomType /> if \`isShowingPlaceholder\` is \`true\` should render the correct structure 1`] = `
+<RoomType
+  amenities={
+    Array [
+      Object {
+        "iconName": "leaf",
+        "items": Array [
+          "Toaster",
+          "Microwave",
+          "Coffee Machine",
+        ],
+        "name": "Cooking",
+      },
+      Object {
+        "iconName": "paw",
+        "items": Array [
+          "Bidet",
+          "Hair Dryer",
+          "Iron & Board",
+        ],
+        "name": "Bathroom & Laundry",
+      },
+    ]
+  }
+  description="yayayay"
+  extraFeatures={
+    Array [
+      Object {
+        "labelText": "1 Dining-Room",
+      },
+    ]
+  }
+  features={
+    Array [
+      Object {
+        "iconName": "double bed",
+        "labelText": "1 Bedroom",
+      },
+    ]
+  }
+  isShowingPlaceholder={true}
+  isUserOnMobile={false}
+  locationName="Catania"
+  name="The Cat House"
+  nightPrice="$280"
+  propertyType="Bed and breakfast"
+  propertyUrl="/"
+  ratingNumber={4}
+  slideShowImages={
+    Array [
+      Object {
+        "alternativeText": "Two cats",
+        "title": "Two cats",
+        "url": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
+      },
+      Object {
+        "alternativeText": "Two more cats",
+        "title": "Two more cats",
+        "url": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
+      },
+      Object {
+        "alternativeText": "Much cats",
+        "title": "Much cats",
+        "url": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
+      },
+    ]
+  }
+>
+  <Card
+    className="has-room-type-gallery"
+    fluid={true}
+  >
+    <div
+      className="ui fluid card has-room-type-gallery"
+      onClick={[Function]}
+    >
+      <Grid
+        areColumnsCentered={false}
+      >
+        <Grid
+          centered={false}
+        >
+          <div
+            className="ui grid"
+          >
+            <GridRow
+              horizontalAlignContent="left"
+            >
+              <GridRow
+                textAlign="left"
+              >
+                <div
+                  className="left aligned row"
+                >
+                  <GridColumn
+                    computer={4}
+                    mobile={12}
+                    verticalAlignContent={null}
+                    width={null}
+                  >
+                    <GridColumn
+                      computer={4}
+                      mobile={12}
+                      verticalAlign={null}
+                      width={null}
+                    >
+                      <div
+                        className="four wide computer twelve wide mobile column"
+                      >
+                        <BlockPlaceholder
+                          isFluid={true}
+                          isRectangular={false}
+                          isSquare={false}
+                        >
+                          <div
+                            className="placeholder block fluid"
+                          />
+                        </BlockPlaceholder>
+                      </div>
+                    </GridColumn>
+                  </GridColumn>
+                  <GridColumn
+                    computer={8}
+                    mobile={12}
+                    verticalAlignContent="top"
+                    width={null}
+                  >
+                    <GridColumn
+                      computer={8}
+                      mobile={12}
+                      verticalAlign="top"
+                      width={null}
+                    >
+                      <div
+                        className="top aligned eight wide computer twelve wide mobile column"
+                      >
+                        <Grid
+                          areColumnsCentered={false}
+                          padded={true}
+                        >
+                          <Grid
+                            centered={false}
+                            padded={true}
+                          >
+                            <div
+                              className="ui padded grid"
+                            >
+                              <GridColumn
+                                verticalAlignContent="top"
+                                width={null}
+                              >
+                                <GridColumn
+                                  verticalAlign="top"
+                                  width={null}
+                                >
+                                  <div
+                                    className="top aligned column"
+                                  >
+                                    <Divider
+                                      className=""
+                                      hasLine={false}
+                                      size="medium"
+                                    >
+                                      <Divider
+                                        className=""
+                                        hidden={true}
+                                        section={false}
+                                      >
+                                        <div
+                                          className="ui hidden divider"
+                                        />
+                                      </Divider>
+                                    </Divider>
+                                    <TextPlaceholder
+                                      isFluid={true}
+                                      length="short"
+                                    >
+                                      <div
+                                        className="placeholder text short fluid"
+                                      />
+                                    </TextPlaceholder>
+                                    <TextPlaceholder
+                                      isFluid={true}
+                                      length="medium"
+                                    >
+                                      <div
+                                        className="placeholder text medium fluid"
+                                      />
+                                    </TextPlaceholder>
+                                    <Divider
+                                      className=""
+                                      hasLine={false}
+                                      size="medium"
+                                    >
+                                      <Divider
+                                        className=""
+                                        hidden={true}
+                                        section={false}
+                                      >
+                                        <div
+                                          className="ui hidden divider"
+                                        />
+                                      </Divider>
+                                    </Divider>
+                                    <TextPlaceholder
+                                      isFluid={true}
+                                      length="short"
+                                    >
+                                      <div
+                                        className="placeholder text short fluid"
+                                      />
+                                    </TextPlaceholder>
+                                    <Divider
+                                      className=""
+                                      hasLine={false}
+                                      size="medium"
+                                    >
+                                      <Divider
+                                        className=""
+                                        hidden={true}
+                                        section={false}
+                                      >
+                                        <div
+                                          className="ui hidden divider"
+                                        />
+                                      </Divider>
+                                    </Divider>
+                                  </div>
+                                </GridColumn>
+                              </GridColumn>
+                            </div>
+                          </Grid>
+                        </Grid>
+                      </div>
+                    </GridColumn>
+                  </GridColumn>
+                </div>
+              </GridRow>
+            </GridRow>
+          </div>
+        </Grid>
+      </Grid>
+    </div>
+  </Card>
+</RoomType>
+`;
+
 exports[`<RoomType /> if \`isUserOnMobile === true\` should render the correct structure 1`] = `
 <RoomType
   amenities={
@@ -993,6 +1241,7 @@ exports[`<RoomType /> if \`isUserOnMobile === true\` should render the correct s
       },
     ]
   }
+  isShowingPlaceholder={false}
   isUserOnMobile={true}
   locationName="Catania"
   name="The Cat House"

--- a/src/components/property-page-widgets/RoomType/component.js
+++ b/src/components/property-page-widgets/RoomType/component.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { Card } from 'semantic-ui-react';
 
@@ -6,6 +6,8 @@ import { Divider } from 'elements/Divider';
 import { Grid } from 'layout/Grid';
 import { GridColumn } from 'layout/GridColumn';
 import { GridRow } from 'layout/GridRow';
+import { BlockPlaceholder } from 'elements/BlockPlaceholder';
+import { TextPlaceholder } from 'elements/TextPlaceholder';
 import { Link } from 'elements/Link';
 import { Icon, ICON_NAMES } from 'elements/Icon';
 import { Modal } from 'elements/Modal';
@@ -27,6 +29,7 @@ const Component = ({
   description,
   extraFeatures,
   features,
+  isShowingPlaceholder,
   isUserOnMobile,
   name,
   nightPrice,
@@ -37,80 +40,98 @@ const Component = ({
     <Grid>
       <GridRow>
         <GridColumn computer={4} mobile={12} verticalAlignContent={null}>
-          <Slideshow
-            hasShadow={false}
-            images={slideShowImages}
-            isRounded={false}
-            isShowingBulletNavigation={false}
-            isStretched
-          />
+          {isShowingPlaceholder ? (
+            <BlockPlaceholder isFluid />
+          ) : (
+            <Slideshow
+              hasShadow={false}
+              images={slideShowImages}
+              isRounded={false}
+              isShowingBulletNavigation={false}
+              isStretched
+            />
+          )}
         </GridColumn>
         <GridColumn computer={8} mobile={12}>
           <Grid padded>
-            <GridColumn computer={12} floated="left" mobile={10}>
-              <Heading>{name}</Heading>
-            </GridColumn>
-            <GridColumn
-              only="mobile"
-              textAlign="right"
-              verticalAlignContent="middle"
-              width={2}
-            >
-              <Modal
-                trigger={
-                  <Icon
-                    color="yellow"
-                    isCircular
-                    isColorInverted
-                    name={ICON_NAMES.INFO}
-                    size="small"
-                  />
-                }
-              >
-                {getModalContentMarkup(
-                  amenities,
-                  description,
-                  extraFeatures,
-                  features,
-                  name,
-                  nightPrice,
-                  ratingNumber,
-                  slideShowImages,
-                  isUserOnMobile
-                )}
-              </Modal>
-            </GridColumn>
-            {getRoomFeaturesMarkup(isUserOnMobile, features)}
-            <GridRow>
-              <GridColumn
-                only="tablet computer"
-                verticalAlignContent="bottom"
-                width={4}
-              >
-                <Modal size="small" trigger={<Link>More Info</Link>}>
-                  {getModalContentMarkup(
-                    amenities,
-                    description,
-                    extraFeatures,
-                    features,
-                    name,
-                    nightPrice,
-                    ratingNumber,
-                    slideShowImages,
-                    isUserOnMobile
-                  )}
-                </Modal>
+            {isShowingPlaceholder ? (
+              <GridColumn>
+                <Divider />
+                <TextPlaceholder length="short" />
+                <TextPlaceholder length="medium" />
+                <Divider />
+                <TextPlaceholder length="short" />
+                <Divider />
               </GridColumn>
-              <GridColumn
-                textAlign={isUserOnMobile ? 'left' : 'right'}
-                width={8}
-              >
-                <Card.Description>
-                  {getNightPriceMarkup(nightPrice)}
-                </Card.Description>
-                <ShowOn mobile parent={Divider} />
-              </GridColumn>
-            </GridRow>
+            ) : (
+              <Fragment>
+                <GridColumn computer={12} floated="left" mobile={10}>
+                  <Heading>{name}</Heading>
+                </GridColumn>
+                <GridColumn
+                  only="mobile"
+                  textAlign="right"
+                  verticalAlignContent="middle"
+                  width={2}
+                >
+                  <Modal
+                    trigger={
+                      <Icon
+                        color="yellow"
+                        isCircular
+                        isColorInverted
+                        name={ICON_NAMES.INFO}
+                        size="small"
+                      />
+                    }
+                  >
+                    {getModalContentMarkup(
+                      amenities,
+                      description,
+                      extraFeatures,
+                      features,
+                      name,
+                      nightPrice,
+                      ratingNumber,
+                      slideShowImages,
+                      isUserOnMobile
+                    )}
+                  </Modal>
+                </GridColumn>
+
+                {getRoomFeaturesMarkup(isUserOnMobile, features)}
+                <GridRow>
+                  <GridColumn
+                    only="tablet computer"
+                    verticalAlignContent="bottom"
+                    width={4}
+                  >
+                    <Modal size="small" trigger={<Link>More Info</Link>}>
+                      {getModalContentMarkup(
+                        amenities,
+                        description,
+                        extraFeatures,
+                        features,
+                        name,
+                        nightPrice,
+                        ratingNumber,
+                        slideShowImages,
+                        isUserOnMobile
+                      )}
+                    </Modal>
+                  </GridColumn>
+                  <GridColumn
+                    textAlign={isUserOnMobile ? 'left' : 'right'}
+                    width={8}
+                  >
+                    <Card.Description>
+                      {getNightPriceMarkup(nightPrice)}
+                    </Card.Description>
+                    <ShowOn mobile parent={Divider} />
+                  </GridColumn>
+                </GridRow>
+              </Fragment>
+            )}
           </Grid>
         </GridColumn>
       </GridRow>
@@ -123,6 +144,7 @@ Component.displayName = 'RoomType';
 Component.defaultProps = {
   description: null,
   extraFeatures: [],
+  isShowingPlaceholder: false,
   ratingNumber: null,
 };
 
@@ -162,6 +184,8 @@ Component.propTypes = {
       labelText: PropTypes.string.isRequired,
     })
   ).isRequired,
+  /** Is the component showing placeholders to reserve space for content which will appear. */
+  isShowingPlaceholder: PropTypes.bool,
   /**
    * Is the user on a mobile device.
    * Provided by `withResponsive` so ignored in the styleguide.

--- a/src/components/property-page-widgets/RoomType/component.spec.js
+++ b/src/components/property-page-widgets/RoomType/component.spec.js
@@ -84,6 +84,14 @@ describe('<RoomType />', () => {
     });
   });
 
+  describe('if `isShowingPlaceholder` is `true`', () => {
+    it('should render the correct structure', () => {
+      const actual = getWrappedRoomType({ isShowingPlaceholder: true });
+
+      expect(actual).toMatchSnapshot();
+    });
+  });
+
   it('should have the right `displayName`', () => {
     const component = getRoomType().prop('as');
 

--- a/src/components/property-page-widgets/RoomTypes/Readme.md
+++ b/src/components/property-page-widgets/RoomTypes/Readme.md
@@ -5,3 +5,14 @@ const { roomTypes } = require('./mock-data/roomTypes');
   roomTypes={roomTypes}
 />
 ```
+
+### States
+
+#### Showing placeholder
+
+```jsx
+<RoomTypes
+  isShowingPlaceholder
+  roomTypes={[]}
+/>
+```

--- a/src/components/property-page-widgets/RoomTypes/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/RoomTypes/__snapshots__/component.spec.js.snap
@@ -1,7 +1,442 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<RoomTypes /> should render the right structure 1`] = `
+exports[`<RoomTypes /> if \`isShowingPlaceholder\` is \`true\` if \`roomTypes.length\` is \`0\` should render the right structure 1`] = `
 <RoomTypes
+  isShowingPlaceholder={true}
+  roomTypes={Array []}
+>
+  <WithResponsive(RoomType)
+    amenities={Array []}
+    features={Array []}
+    isShowingPlaceholder={true}
+    key="0"
+    name=""
+    nightPrice=""
+    slideShowImages={Array []}
+  >
+    <Responsive
+      amenities={Array []}
+      as={[Function]}
+      features={Array []}
+      isShowingPlaceholder={true}
+      isUserOnMobile={false}
+      name=""
+      nightPrice=""
+      onUpdate={[Function]}
+      slideShowImages={Array []}
+      windowInnerWidth={1024}
+    >
+      <RoomType
+        amenities={Array []}
+        description={null}
+        extraFeatures={Array []}
+        features={Array []}
+        isShowingPlaceholder={true}
+        isUserOnMobile={false}
+        name=""
+        nightPrice=""
+        ratingNumber={null}
+        slideShowImages={Array []}
+        windowInnerWidth={1024}
+      >
+        <Card
+          className="has-room-type-gallery"
+          fluid={true}
+        >
+          <div
+            className="ui fluid card has-room-type-gallery"
+            onClick={[Function]}
+          >
+            <Grid
+              areColumnsCentered={false}
+            >
+              <Grid
+                centered={false}
+              >
+                <div
+                  className="ui grid"
+                >
+                  <GridRow
+                    horizontalAlignContent="left"
+                  >
+                    <GridRow
+                      textAlign="left"
+                    >
+                      <div
+                        className="left aligned row"
+                      >
+                        <GridColumn
+                          computer={4}
+                          mobile={12}
+                          verticalAlignContent={null}
+                          width={null}
+                        >
+                          <GridColumn
+                            computer={4}
+                            mobile={12}
+                            verticalAlign={null}
+                            width={null}
+                          >
+                            <div
+                              className="four wide computer twelve wide mobile column"
+                            >
+                              <BlockPlaceholder
+                                isFluid={true}
+                                isRectangular={false}
+                                isSquare={false}
+                              >
+                                <div
+                                  className="placeholder block fluid"
+                                />
+                              </BlockPlaceholder>
+                            </div>
+                          </GridColumn>
+                        </GridColumn>
+                        <GridColumn
+                          computer={8}
+                          mobile={12}
+                          verticalAlignContent="top"
+                          width={null}
+                        >
+                          <GridColumn
+                            computer={8}
+                            mobile={12}
+                            verticalAlign="top"
+                            width={null}
+                          >
+                            <div
+                              className="top aligned eight wide computer twelve wide mobile column"
+                            >
+                              <Grid
+                                areColumnsCentered={false}
+                                padded={true}
+                              >
+                                <Grid
+                                  centered={false}
+                                  padded={true}
+                                >
+                                  <div
+                                    className="ui padded grid"
+                                  >
+                                    <GridColumn
+                                      verticalAlignContent="top"
+                                      width={null}
+                                    >
+                                      <GridColumn
+                                        verticalAlign="top"
+                                        width={null}
+                                      >
+                                        <div
+                                          className="top aligned column"
+                                        >
+                                          <Divider
+                                            className=""
+                                            hasLine={false}
+                                            size="medium"
+                                          >
+                                            <Divider
+                                              className=""
+                                              hidden={true}
+                                              section={false}
+                                            >
+                                              <div
+                                                className="ui hidden divider"
+                                              />
+                                            </Divider>
+                                          </Divider>
+                                          <TextPlaceholder
+                                            isFluid={true}
+                                            length="short"
+                                          >
+                                            <div
+                                              className="placeholder text short fluid"
+                                            />
+                                          </TextPlaceholder>
+                                          <TextPlaceholder
+                                            isFluid={true}
+                                            length="medium"
+                                          >
+                                            <div
+                                              className="placeholder text medium fluid"
+                                            />
+                                          </TextPlaceholder>
+                                          <Divider
+                                            className=""
+                                            hasLine={false}
+                                            size="medium"
+                                          >
+                                            <Divider
+                                              className=""
+                                              hidden={true}
+                                              section={false}
+                                            >
+                                              <div
+                                                className="ui hidden divider"
+                                              />
+                                            </Divider>
+                                          </Divider>
+                                          <TextPlaceholder
+                                            isFluid={true}
+                                            length="short"
+                                          >
+                                            <div
+                                              className="placeholder text short fluid"
+                                            />
+                                          </TextPlaceholder>
+                                          <Divider
+                                            className=""
+                                            hasLine={false}
+                                            size="medium"
+                                          >
+                                            <Divider
+                                              className=""
+                                              hidden={true}
+                                              section={false}
+                                            >
+                                              <div
+                                                className="ui hidden divider"
+                                              />
+                                            </Divider>
+                                          </Divider>
+                                        </div>
+                                      </GridColumn>
+                                    </GridColumn>
+                                  </div>
+                                </Grid>
+                              </Grid>
+                            </div>
+                          </GridColumn>
+                        </GridColumn>
+                      </div>
+                    </GridRow>
+                  </GridRow>
+                </div>
+              </Grid>
+            </Grid>
+          </div>
+        </Card>
+      </RoomType>
+    </Responsive>
+  </WithResponsive(RoomType)>
+  <WithResponsive(RoomType)
+    amenities={Array []}
+    features={Array []}
+    isShowingPlaceholder={true}
+    key="1"
+    name=""
+    nightPrice=""
+    slideShowImages={Array []}
+  >
+    <Responsive
+      amenities={Array []}
+      as={[Function]}
+      features={Array []}
+      isShowingPlaceholder={true}
+      isUserOnMobile={false}
+      name=""
+      nightPrice=""
+      onUpdate={[Function]}
+      slideShowImages={Array []}
+      windowInnerWidth={1024}
+    >
+      <RoomType
+        amenities={Array []}
+        description={null}
+        extraFeatures={Array []}
+        features={Array []}
+        isShowingPlaceholder={true}
+        isUserOnMobile={false}
+        name=""
+        nightPrice=""
+        ratingNumber={null}
+        slideShowImages={Array []}
+        windowInnerWidth={1024}
+      >
+        <Card
+          className="has-room-type-gallery"
+          fluid={true}
+        >
+          <div
+            className="ui fluid card has-room-type-gallery"
+            onClick={[Function]}
+          >
+            <Grid
+              areColumnsCentered={false}
+            >
+              <Grid
+                centered={false}
+              >
+                <div
+                  className="ui grid"
+                >
+                  <GridRow
+                    horizontalAlignContent="left"
+                  >
+                    <GridRow
+                      textAlign="left"
+                    >
+                      <div
+                        className="left aligned row"
+                      >
+                        <GridColumn
+                          computer={4}
+                          mobile={12}
+                          verticalAlignContent={null}
+                          width={null}
+                        >
+                          <GridColumn
+                            computer={4}
+                            mobile={12}
+                            verticalAlign={null}
+                            width={null}
+                          >
+                            <div
+                              className="four wide computer twelve wide mobile column"
+                            >
+                              <BlockPlaceholder
+                                isFluid={true}
+                                isRectangular={false}
+                                isSquare={false}
+                              >
+                                <div
+                                  className="placeholder block fluid"
+                                />
+                              </BlockPlaceholder>
+                            </div>
+                          </GridColumn>
+                        </GridColumn>
+                        <GridColumn
+                          computer={8}
+                          mobile={12}
+                          verticalAlignContent="top"
+                          width={null}
+                        >
+                          <GridColumn
+                            computer={8}
+                            mobile={12}
+                            verticalAlign="top"
+                            width={null}
+                          >
+                            <div
+                              className="top aligned eight wide computer twelve wide mobile column"
+                            >
+                              <Grid
+                                areColumnsCentered={false}
+                                padded={true}
+                              >
+                                <Grid
+                                  centered={false}
+                                  padded={true}
+                                >
+                                  <div
+                                    className="ui padded grid"
+                                  >
+                                    <GridColumn
+                                      verticalAlignContent="top"
+                                      width={null}
+                                    >
+                                      <GridColumn
+                                        verticalAlign="top"
+                                        width={null}
+                                      >
+                                        <div
+                                          className="top aligned column"
+                                        >
+                                          <Divider
+                                            className=""
+                                            hasLine={false}
+                                            size="medium"
+                                          >
+                                            <Divider
+                                              className=""
+                                              hidden={true}
+                                              section={false}
+                                            >
+                                              <div
+                                                className="ui hidden divider"
+                                              />
+                                            </Divider>
+                                          </Divider>
+                                          <TextPlaceholder
+                                            isFluid={true}
+                                            length="short"
+                                          >
+                                            <div
+                                              className="placeholder text short fluid"
+                                            />
+                                          </TextPlaceholder>
+                                          <TextPlaceholder
+                                            isFluid={true}
+                                            length="medium"
+                                          >
+                                            <div
+                                              className="placeholder text medium fluid"
+                                            />
+                                          </TextPlaceholder>
+                                          <Divider
+                                            className=""
+                                            hasLine={false}
+                                            size="medium"
+                                          >
+                                            <Divider
+                                              className=""
+                                              hidden={true}
+                                              section={false}
+                                            >
+                                              <div
+                                                className="ui hidden divider"
+                                              />
+                                            </Divider>
+                                          </Divider>
+                                          <TextPlaceholder
+                                            isFluid={true}
+                                            length="short"
+                                          >
+                                            <div
+                                              className="placeholder text short fluid"
+                                            />
+                                          </TextPlaceholder>
+                                          <Divider
+                                            className=""
+                                            hasLine={false}
+                                            size="medium"
+                                          >
+                                            <Divider
+                                              className=""
+                                              hidden={true}
+                                              section={false}
+                                            >
+                                              <div
+                                                className="ui hidden divider"
+                                              />
+                                            </Divider>
+                                          </Divider>
+                                        </div>
+                                      </GridColumn>
+                                    </GridColumn>
+                                  </div>
+                                </Grid>
+                              </Grid>
+                            </div>
+                          </GridColumn>
+                        </GridColumn>
+                      </div>
+                    </GridRow>
+                  </GridRow>
+                </div>
+              </Grid>
+            </Grid>
+          </div>
+        </Card>
+      </RoomType>
+    </Responsive>
+  </WithResponsive(RoomType)>
+</RoomTypes>
+`;
+
+exports[`<RoomTypes /> if \`isShowingPlaceholder\` is \`true\` should render the right structure 1`] = `
+<RoomTypes
+  isShowingPlaceholder={true}
   roomTypes={
     Array [
       Object {
@@ -159,6 +594,7 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
       ]
     }
     guestsNumber={3}
+    isShowingPlaceholder={true}
     key="The Cat House0"
     name="The Cat House"
     nightPrice="$280"
@@ -225,6 +661,7 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
         ]
       }
       guestsNumber={3}
+      isShowingPlaceholder={true}
       isUserOnMobile={false}
       name="The Cat House"
       nightPrice="$280"
@@ -292,6 +729,860 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
           ]
         }
         guestsNumber={3}
+        isShowingPlaceholder={true}
+        isUserOnMobile={false}
+        name="The Cat House"
+        nightPrice="$280"
+        onClickCheckAvailability={[Function]}
+        ratingNumber={3.4}
+        slideShowImages={
+          Array [
+            Object {
+              "alternativeText": "Two more cats",
+              "title": "Two more cats",
+              "url": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
+            },
+            Object {
+              "alternativeText": "Some cats",
+              "title": "Some cats",
+              "url": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
+            },
+          ]
+        }
+        windowInnerWidth={1024}
+      >
+        <Card
+          className="has-room-type-gallery"
+          fluid={true}
+        >
+          <div
+            className="ui fluid card has-room-type-gallery"
+            onClick={[Function]}
+          >
+            <Grid
+              areColumnsCentered={false}
+            >
+              <Grid
+                centered={false}
+              >
+                <div
+                  className="ui grid"
+                >
+                  <GridRow
+                    horizontalAlignContent="left"
+                  >
+                    <GridRow
+                      textAlign="left"
+                    >
+                      <div
+                        className="left aligned row"
+                      >
+                        <GridColumn
+                          computer={4}
+                          mobile={12}
+                          verticalAlignContent={null}
+                          width={null}
+                        >
+                          <GridColumn
+                            computer={4}
+                            mobile={12}
+                            verticalAlign={null}
+                            width={null}
+                          >
+                            <div
+                              className="four wide computer twelve wide mobile column"
+                            >
+                              <BlockPlaceholder
+                                isFluid={true}
+                                isRectangular={false}
+                                isSquare={false}
+                              >
+                                <div
+                                  className="placeholder block fluid"
+                                />
+                              </BlockPlaceholder>
+                            </div>
+                          </GridColumn>
+                        </GridColumn>
+                        <GridColumn
+                          computer={8}
+                          mobile={12}
+                          verticalAlignContent="top"
+                          width={null}
+                        >
+                          <GridColumn
+                            computer={8}
+                            mobile={12}
+                            verticalAlign="top"
+                            width={null}
+                          >
+                            <div
+                              className="top aligned eight wide computer twelve wide mobile column"
+                            >
+                              <Grid
+                                areColumnsCentered={false}
+                                padded={true}
+                              >
+                                <Grid
+                                  centered={false}
+                                  padded={true}
+                                >
+                                  <div
+                                    className="ui padded grid"
+                                  >
+                                    <GridColumn
+                                      verticalAlignContent="top"
+                                      width={null}
+                                    >
+                                      <GridColumn
+                                        verticalAlign="top"
+                                        width={null}
+                                      >
+                                        <div
+                                          className="top aligned column"
+                                        >
+                                          <Divider
+                                            className=""
+                                            hasLine={false}
+                                            size="medium"
+                                          >
+                                            <Divider
+                                              className=""
+                                              hidden={true}
+                                              section={false}
+                                            >
+                                              <div
+                                                className="ui hidden divider"
+                                              />
+                                            </Divider>
+                                          </Divider>
+                                          <TextPlaceholder
+                                            isFluid={true}
+                                            length="short"
+                                          >
+                                            <div
+                                              className="placeholder text short fluid"
+                                            />
+                                          </TextPlaceholder>
+                                          <TextPlaceholder
+                                            isFluid={true}
+                                            length="medium"
+                                          >
+                                            <div
+                                              className="placeholder text medium fluid"
+                                            />
+                                          </TextPlaceholder>
+                                          <Divider
+                                            className=""
+                                            hasLine={false}
+                                            size="medium"
+                                          >
+                                            <Divider
+                                              className=""
+                                              hidden={true}
+                                              section={false}
+                                            >
+                                              <div
+                                                className="ui hidden divider"
+                                              />
+                                            </Divider>
+                                          </Divider>
+                                          <TextPlaceholder
+                                            isFluid={true}
+                                            length="short"
+                                          >
+                                            <div
+                                              className="placeholder text short fluid"
+                                            />
+                                          </TextPlaceholder>
+                                          <Divider
+                                            className=""
+                                            hasLine={false}
+                                            size="medium"
+                                          >
+                                            <Divider
+                                              className=""
+                                              hidden={true}
+                                              section={false}
+                                            >
+                                              <div
+                                                className="ui hidden divider"
+                                              />
+                                            </Divider>
+                                          </Divider>
+                                        </div>
+                                      </GridColumn>
+                                    </GridColumn>
+                                  </div>
+                                </Grid>
+                              </Grid>
+                            </div>
+                          </GridColumn>
+                        </GridColumn>
+                      </div>
+                    </GridRow>
+                  </GridRow>
+                </div>
+              </Grid>
+            </Grid>
+          </div>
+        </Card>
+      </RoomType>
+    </Responsive>
+  </WithResponsive(RoomType)>
+  <WithResponsive(RoomType)
+    amenities={
+      Array [
+        Object {
+          "iconName": "leaf",
+          "items": Array [
+            "Toaster",
+            "Microwave",
+            "Coffee Machine",
+          ],
+          "name": "Cooking",
+        },
+      ]
+    }
+    bathroomsNumber={2}
+    bedsNumber={3}
+    checkAvailability={[Function]}
+    description="Description goes here"
+    extraFeatures={Array []}
+    features={
+      Array [
+        Object {
+          "iconName": "double bed",
+          "labelText": "1 Bedroom",
+        },
+        Object {
+          "iconName": "guests",
+          "labelText": "2 Guests",
+        },
+        Object {
+          "iconName": "bathroom",
+          "labelText": "1 Bathroom",
+        },
+      ]
+    }
+    guestsNumber={3}
+    isShowingPlaceholder={true}
+    key="The Other Cat House1"
+    name="The Other Cat House"
+    nightPrice="$280"
+    onClickCheckAvailability={[Function]}
+    ratingNumber={3.4}
+    slideShowImages={
+      Array [
+        Object {
+          "alternativeText": "Two more cats",
+          "title": "Two more cats",
+          "url": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
+        },
+        Object {
+          "alternativeText": "Some cats",
+          "title": "Some cats",
+          "url": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
+        },
+      ]
+    }
+  >
+    <Responsive
+      amenities={
+        Array [
+          Object {
+            "iconName": "leaf",
+            "items": Array [
+              "Toaster",
+              "Microwave",
+              "Coffee Machine",
+            ],
+            "name": "Cooking",
+          },
+        ]
+      }
+      as={[Function]}
+      bathroomsNumber={2}
+      bedsNumber={3}
+      checkAvailability={[Function]}
+      description="Description goes here"
+      extraFeatures={Array []}
+      features={
+        Array [
+          Object {
+            "iconName": "double bed",
+            "labelText": "1 Bedroom",
+          },
+          Object {
+            "iconName": "guests",
+            "labelText": "2 Guests",
+          },
+          Object {
+            "iconName": "bathroom",
+            "labelText": "1 Bathroom",
+          },
+        ]
+      }
+      guestsNumber={3}
+      isShowingPlaceholder={true}
+      isUserOnMobile={false}
+      name="The Other Cat House"
+      nightPrice="$280"
+      onClickCheckAvailability={[Function]}
+      onUpdate={[Function]}
+      ratingNumber={3.4}
+      slideShowImages={
+        Array [
+          Object {
+            "alternativeText": "Two more cats",
+            "title": "Two more cats",
+            "url": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
+          },
+          Object {
+            "alternativeText": "Some cats",
+            "title": "Some cats",
+            "url": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
+          },
+        ]
+      }
+      windowInnerWidth={1024}
+    >
+      <RoomType
+        amenities={
+          Array [
+            Object {
+              "iconName": "leaf",
+              "items": Array [
+                "Toaster",
+                "Microwave",
+                "Coffee Machine",
+              ],
+              "name": "Cooking",
+            },
+          ]
+        }
+        bathroomsNumber={2}
+        bedsNumber={3}
+        checkAvailability={[Function]}
+        description="Description goes here"
+        extraFeatures={Array []}
+        features={
+          Array [
+            Object {
+              "iconName": "double bed",
+              "labelText": "1 Bedroom",
+            },
+            Object {
+              "iconName": "guests",
+              "labelText": "2 Guests",
+            },
+            Object {
+              "iconName": "bathroom",
+              "labelText": "1 Bathroom",
+            },
+          ]
+        }
+        guestsNumber={3}
+        isShowingPlaceholder={true}
+        isUserOnMobile={false}
+        name="The Other Cat House"
+        nightPrice="$280"
+        onClickCheckAvailability={[Function]}
+        ratingNumber={3.4}
+        slideShowImages={
+          Array [
+            Object {
+              "alternativeText": "Two more cats",
+              "title": "Two more cats",
+              "url": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
+            },
+            Object {
+              "alternativeText": "Some cats",
+              "title": "Some cats",
+              "url": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
+            },
+          ]
+        }
+        windowInnerWidth={1024}
+      >
+        <Card
+          className="has-room-type-gallery"
+          fluid={true}
+        >
+          <div
+            className="ui fluid card has-room-type-gallery"
+            onClick={[Function]}
+          >
+            <Grid
+              areColumnsCentered={false}
+            >
+              <Grid
+                centered={false}
+              >
+                <div
+                  className="ui grid"
+                >
+                  <GridRow
+                    horizontalAlignContent="left"
+                  >
+                    <GridRow
+                      textAlign="left"
+                    >
+                      <div
+                        className="left aligned row"
+                      >
+                        <GridColumn
+                          computer={4}
+                          mobile={12}
+                          verticalAlignContent={null}
+                          width={null}
+                        >
+                          <GridColumn
+                            computer={4}
+                            mobile={12}
+                            verticalAlign={null}
+                            width={null}
+                          >
+                            <div
+                              className="four wide computer twelve wide mobile column"
+                            >
+                              <BlockPlaceholder
+                                isFluid={true}
+                                isRectangular={false}
+                                isSquare={false}
+                              >
+                                <div
+                                  className="placeholder block fluid"
+                                />
+                              </BlockPlaceholder>
+                            </div>
+                          </GridColumn>
+                        </GridColumn>
+                        <GridColumn
+                          computer={8}
+                          mobile={12}
+                          verticalAlignContent="top"
+                          width={null}
+                        >
+                          <GridColumn
+                            computer={8}
+                            mobile={12}
+                            verticalAlign="top"
+                            width={null}
+                          >
+                            <div
+                              className="top aligned eight wide computer twelve wide mobile column"
+                            >
+                              <Grid
+                                areColumnsCentered={false}
+                                padded={true}
+                              >
+                                <Grid
+                                  centered={false}
+                                  padded={true}
+                                >
+                                  <div
+                                    className="ui padded grid"
+                                  >
+                                    <GridColumn
+                                      verticalAlignContent="top"
+                                      width={null}
+                                    >
+                                      <GridColumn
+                                        verticalAlign="top"
+                                        width={null}
+                                      >
+                                        <div
+                                          className="top aligned column"
+                                        >
+                                          <Divider
+                                            className=""
+                                            hasLine={false}
+                                            size="medium"
+                                          >
+                                            <Divider
+                                              className=""
+                                              hidden={true}
+                                              section={false}
+                                            >
+                                              <div
+                                                className="ui hidden divider"
+                                              />
+                                            </Divider>
+                                          </Divider>
+                                          <TextPlaceholder
+                                            isFluid={true}
+                                            length="short"
+                                          >
+                                            <div
+                                              className="placeholder text short fluid"
+                                            />
+                                          </TextPlaceholder>
+                                          <TextPlaceholder
+                                            isFluid={true}
+                                            length="medium"
+                                          >
+                                            <div
+                                              className="placeholder text medium fluid"
+                                            />
+                                          </TextPlaceholder>
+                                          <Divider
+                                            className=""
+                                            hasLine={false}
+                                            size="medium"
+                                          >
+                                            <Divider
+                                              className=""
+                                              hidden={true}
+                                              section={false}
+                                            >
+                                              <div
+                                                className="ui hidden divider"
+                                              />
+                                            </Divider>
+                                          </Divider>
+                                          <TextPlaceholder
+                                            isFluid={true}
+                                            length="short"
+                                          >
+                                            <div
+                                              className="placeholder text short fluid"
+                                            />
+                                          </TextPlaceholder>
+                                          <Divider
+                                            className=""
+                                            hasLine={false}
+                                            size="medium"
+                                          >
+                                            <Divider
+                                              className=""
+                                              hidden={true}
+                                              section={false}
+                                            >
+                                              <div
+                                                className="ui hidden divider"
+                                              />
+                                            </Divider>
+                                          </Divider>
+                                        </div>
+                                      </GridColumn>
+                                    </GridColumn>
+                                  </div>
+                                </Grid>
+                              </Grid>
+                            </div>
+                          </GridColumn>
+                        </GridColumn>
+                      </div>
+                    </GridRow>
+                  </GridRow>
+                </div>
+              </Grid>
+            </Grid>
+          </div>
+        </Card>
+      </RoomType>
+    </Responsive>
+  </WithResponsive(RoomType)>
+</RoomTypes>
+`;
+
+exports[`<RoomTypes /> should render the right structure 1`] = `
+<RoomTypes
+  isShowingPlaceholder={false}
+  roomTypes={
+    Array [
+      Object {
+        "amenities": Array [
+          Object {
+            "iconName": "leaf",
+            "items": Array [
+              "Toaster",
+              "Microwave",
+              "Coffee Machine",
+            ],
+            "name": "Cooking",
+          },
+          Object {
+            "iconName": "paw",
+            "items": Array [
+              "Bidet",
+              "Hair Dryer",
+              "Iron & Board",
+            ],
+            "name": "Bathroom & Laundry",
+          },
+        ],
+        "bathroomsNumber": 2,
+        "bedsNumber": 3,
+        "checkAvailability": [Function],
+        "description": "Description goes here",
+        "extraFeatures": Array [],
+        "features": Array [
+          Object {
+            "iconName": "double bed",
+            "labelText": "1 Bedroom",
+          },
+          Object {
+            "iconName": "guests",
+            "labelText": "2 Guests",
+          },
+          Object {
+            "iconName": "bathroom",
+            "labelText": "1 Bathroom",
+          },
+        ],
+        "guestsNumber": 3,
+        "name": "The Cat House",
+        "nightPrice": "$280",
+        "onClickCheckAvailability": [Function],
+        "ratingNumber": 3.4,
+        "slideShowImages": Array [
+          Object {
+            "alternativeText": "Two more cats",
+            "title": "Two more cats",
+            "url": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
+          },
+          Object {
+            "alternativeText": "Some cats",
+            "title": "Some cats",
+            "url": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
+          },
+        ],
+      },
+      Object {
+        "amenities": Array [
+          Object {
+            "iconName": "leaf",
+            "items": Array [
+              "Toaster",
+              "Microwave",
+              "Coffee Machine",
+            ],
+            "name": "Cooking",
+          },
+        ],
+        "bathroomsNumber": 2,
+        "bedsNumber": 3,
+        "checkAvailability": [Function],
+        "description": "Description goes here",
+        "extraFeatures": Array [],
+        "features": Array [
+          Object {
+            "iconName": "double bed",
+            "labelText": "1 Bedroom",
+          },
+          Object {
+            "iconName": "guests",
+            "labelText": "2 Guests",
+          },
+          Object {
+            "iconName": "bathroom",
+            "labelText": "1 Bathroom",
+          },
+        ],
+        "guestsNumber": 3,
+        "name": "The Other Cat House",
+        "nightPrice": "$280",
+        "onClickCheckAvailability": [Function],
+        "ratingNumber": 3.4,
+        "slideShowImages": Array [
+          Object {
+            "alternativeText": "Two more cats",
+            "title": "Two more cats",
+            "url": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
+          },
+          Object {
+            "alternativeText": "Some cats",
+            "title": "Some cats",
+            "url": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
+          },
+        ],
+      },
+    ]
+  }
+>
+  <WithResponsive(RoomType)
+    amenities={
+      Array [
+        Object {
+          "iconName": "leaf",
+          "items": Array [
+            "Toaster",
+            "Microwave",
+            "Coffee Machine",
+          ],
+          "name": "Cooking",
+        },
+        Object {
+          "iconName": "paw",
+          "items": Array [
+            "Bidet",
+            "Hair Dryer",
+            "Iron & Board",
+          ],
+          "name": "Bathroom & Laundry",
+        },
+      ]
+    }
+    bathroomsNumber={2}
+    bedsNumber={3}
+    checkAvailability={[Function]}
+    description="Description goes here"
+    extraFeatures={Array []}
+    features={
+      Array [
+        Object {
+          "iconName": "double bed",
+          "labelText": "1 Bedroom",
+        },
+        Object {
+          "iconName": "guests",
+          "labelText": "2 Guests",
+        },
+        Object {
+          "iconName": "bathroom",
+          "labelText": "1 Bathroom",
+        },
+      ]
+    }
+    guestsNumber={3}
+    isShowingPlaceholder={false}
+    key="The Cat House0"
+    name="The Cat House"
+    nightPrice="$280"
+    onClickCheckAvailability={[Function]}
+    ratingNumber={3.4}
+    slideShowImages={
+      Array [
+        Object {
+          "alternativeText": "Two more cats",
+          "title": "Two more cats",
+          "url": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
+        },
+        Object {
+          "alternativeText": "Some cats",
+          "title": "Some cats",
+          "url": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
+        },
+      ]
+    }
+  >
+    <Responsive
+      amenities={
+        Array [
+          Object {
+            "iconName": "leaf",
+            "items": Array [
+              "Toaster",
+              "Microwave",
+              "Coffee Machine",
+            ],
+            "name": "Cooking",
+          },
+          Object {
+            "iconName": "paw",
+            "items": Array [
+              "Bidet",
+              "Hair Dryer",
+              "Iron & Board",
+            ],
+            "name": "Bathroom & Laundry",
+          },
+        ]
+      }
+      as={[Function]}
+      bathroomsNumber={2}
+      bedsNumber={3}
+      checkAvailability={[Function]}
+      description="Description goes here"
+      extraFeatures={Array []}
+      features={
+        Array [
+          Object {
+            "iconName": "double bed",
+            "labelText": "1 Bedroom",
+          },
+          Object {
+            "iconName": "guests",
+            "labelText": "2 Guests",
+          },
+          Object {
+            "iconName": "bathroom",
+            "labelText": "1 Bathroom",
+          },
+        ]
+      }
+      guestsNumber={3}
+      isShowingPlaceholder={false}
+      isUserOnMobile={false}
+      name="The Cat House"
+      nightPrice="$280"
+      onClickCheckAvailability={[Function]}
+      onUpdate={[Function]}
+      ratingNumber={3.4}
+      slideShowImages={
+        Array [
+          Object {
+            "alternativeText": "Two more cats",
+            "title": "Two more cats",
+            "url": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
+          },
+          Object {
+            "alternativeText": "Some cats",
+            "title": "Some cats",
+            "url": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
+          },
+        ]
+      }
+      windowInnerWidth={1024}
+    >
+      <RoomType
+        amenities={
+          Array [
+            Object {
+              "iconName": "leaf",
+              "items": Array [
+                "Toaster",
+                "Microwave",
+                "Coffee Machine",
+              ],
+              "name": "Cooking",
+            },
+            Object {
+              "iconName": "paw",
+              "items": Array [
+                "Bidet",
+                "Hair Dryer",
+                "Iron & Board",
+              ],
+              "name": "Bathroom & Laundry",
+            },
+          ]
+        }
+        bathroomsNumber={2}
+        bedsNumber={3}
+        checkAvailability={[Function]}
+        description="Description goes here"
+        extraFeatures={Array []}
+        features={
+          Array [
+            Object {
+              "iconName": "double bed",
+              "labelText": "1 Bedroom",
+            },
+            Object {
+              "iconName": "guests",
+              "labelText": "2 Guests",
+            },
+            Object {
+              "iconName": "bathroom",
+              "labelText": "1 Bathroom",
+            },
+          ]
+        }
+        guestsNumber={3}
+        isShowingPlaceholder={false}
         isUserOnMobile={false}
         name="The Cat House"
         nightPrice="$280"
@@ -1323,6 +2614,7 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
       ]
     }
     guestsNumber={3}
+    isShowingPlaceholder={false}
     key="The Other Cat House1"
     name="The Other Cat House"
     nightPrice="$280"
@@ -1380,6 +2672,7 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
         ]
       }
       guestsNumber={3}
+      isShowingPlaceholder={false}
       isUserOnMobile={false}
       name="The Other Cat House"
       nightPrice="$280"
@@ -1438,6 +2731,7 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
           ]
         }
         guestsNumber={3}
+        isShowingPlaceholder={false}
         isUserOnMobile={false}
         name="The Other Cat House"
         nightPrice="$280"

--- a/src/components/property-page-widgets/RoomTypes/component.js
+++ b/src/components/property-page-widgets/RoomTypes/component.js
@@ -4,21 +4,38 @@ import PropTypes from 'prop-types';
 import { RoomType } from 'property-page-widgets/RoomType';
 import { buildKeyFromStrings } from 'utils/build-key-from-strings';
 
+import { PLACEHOLDERS } from './constants';
+
 /**
  * The standard widget for displaying a list of room types.
  */
 // eslint-disable-next-line jsdoc/require-jsdoc
-export const Component = ({ roomTypes }) => (
-  <Fragment>
-    {roomTypes.map((roomType, index) => (
-      <RoomType key={buildKeyFromStrings(roomType.name, index)} {...roomType} />
-    ))}
-  </Fragment>
-);
+export const Component = ({ isShowingPlaceholder, roomTypes }) => {
+  const roomTypesToMap =
+    isShowingPlaceholder && roomTypes.length === 0 ? PLACEHOLDERS : roomTypes;
+
+  return (
+    <Fragment>
+      {roomTypesToMap.map((roomType, index) => (
+        <RoomType
+          isShowingPlaceholder={isShowingPlaceholder}
+          key={buildKeyFromStrings(roomType.name, index)}
+          {...roomType}
+        />
+      ))}
+    </Fragment>
+  );
+};
 
 Component.displayName = 'RoomTypes';
 
+Component.defaultProps = {
+  isShowingPlaceholder: false,
+};
+
 Component.propTypes = {
+  /** Is the component showing placeholders to reserve space for content which will appear. */
+  isShowingPlaceholder: PropTypes.bool,
   /** An array of [`RoomType`](#/RoomType) props objects */
   roomTypes: PropTypes.arrayOf(PropTypes.object).isRequired,
 };

--- a/src/components/property-page-widgets/RoomTypes/component.spec.js
+++ b/src/components/property-page-widgets/RoomTypes/component.spec.js
@@ -28,6 +28,25 @@ describe('<RoomTypes />', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  describe('if `isShowingPlaceholder` is `true`', () => {
+    it('should render the right structure', () => {
+      const wrapper = getRoomTypes({ isShowingPlaceholder: true });
+
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    describe('if `roomTypes.length` is `0`', () => {
+      it('should render the right structure', () => {
+        const wrapper = getRoomTypes({
+          isShowingPlaceholder: true,
+          roomTypes: [],
+        });
+
+        expect(wrapper).toMatchSnapshot();
+      });
+    });
+  });
+
   it('should have `displayName` `RoomTypes`', () => {
     expectComponentToHaveDisplayName(RoomTypes, 'RoomTypes');
   });

--- a/src/components/property-page-widgets/RoomTypes/constants.js
+++ b/src/components/property-page-widgets/RoomTypes/constants.js
@@ -1,0 +1,13 @@
+const PLACEHOLDER_DATA = {
+  amenities: [],
+  features: [],
+  name: '',
+  nightPrice: '',
+  slideShowImages: [],
+};
+
+const NUMBER_OF_PLACEHOLDERS = 2;
+
+export const PLACEHOLDERS = Array(NUMBER_OF_PLACEHOLDERS).fill(
+  PLACEHOLDER_DATA
+);

--- a/src/styles/semantic/themes/livingstone/globals/site.overrides
+++ b/src/styles/semantic/themes/livingstone/globals/site.overrides
@@ -571,6 +571,10 @@ blockquote.ui.quote .row {
 .placeholder.block {
   height: @blockPlaceholderDefaultHeight;
 
+  &.fluid {
+    min-height: 100%;
+  }
+
   &.square {
     padding-top: 100%;
   }


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1755)

### What **one** thing does this PR do?
Adds placeholders to `RoomTypes`

### Any other notes
I changed the behaviour of `BlockPlaceholder` to fill container height when `props.isFluid` is true.
I made all the consequent changes to make sure this doesn't disrupt existing consumption of `BlockPlaceholder`.

#### Desktop
![screenshot 2019-02-08 at 15 50 34](https://user-images.githubusercontent.com/8591501/52487422-eb6b4580-2bbd-11e9-9e91-ef560a0a45cb.png)

#### Mobile
![screenshot 2019-02-08 at 15 50 49](https://user-images.githubusercontent.com/8591501/52487421-ead2af00-2bbd-11e9-8044-d00b9cd28bb9.png)

