### PR TITLE
TE-1883 Divider standardise margins

### DIFF
--- a/src/components/elements/Divider/__snapshots__/component.spec.js.snap
+++ b/src/components/elements/Divider/__snapshots__/component.spec.js.snap
@@ -36,6 +36,24 @@ exports[`<Divider /> if \`props.hasLine === true\` should render the right struc
 </Divider>
 `;
 
+exports[`<Divider /> if \`props.size === "huge"\` should render the right structure 1`] = `
+<Divider
+  className=""
+  hasLine={false}
+  size="huge"
+>
+  <Divider
+    className="is-size-huge"
+    hidden={true}
+    section={false}
+  >
+    <div
+      className="ui hidden divider is-size-huge"
+    />
+  </Divider>
+</Divider>
+`;
+
 exports[`<Divider /> if \`props.size === "large"\` should render the right structure 1`] = `
 <Divider
   className=""

--- a/src/components/elements/Divider/component.js
+++ b/src/components/elements/Divider/component.js
@@ -13,6 +13,7 @@ export const Component = ({ className, hasLine, size }) => (
   <Divider
     className={getClassNames(className, {
       'is-size-small': size === 'small',
+      'is-size-huge': size === 'huge',
     })}
     hidden={!hasLine}
     section={getIsSizeLarge(size)}
@@ -37,5 +38,5 @@ Component.propTypes = {
   /** Does the divider have a visible line. */
   hasLine: PropTypes.bool,
   /** The size of the divider. */
-  size: PropTypes.oneOf(['small', 'medium', 'large']),
+  size: PropTypes.oneOf(['small', 'medium', 'large', 'huge']),
 };

--- a/src/components/elements/Divider/component.spec.js
+++ b/src/components/elements/Divider/component.spec.js
@@ -31,6 +31,14 @@ describe('<Divider />', () => {
     });
   });
 
+  describe('if `props.size === "huge"`', () => {
+    it('should render the right structure', () => {
+      const actual = getDivider({ size: 'huge' });
+
+      expect(actual).toMatchSnapshot();
+    });
+  });
+
   it('should have `displayName` Divider', () => {
     expectComponentToHaveDisplayName(Divider, 'Divider');
   });

--- a/src/components/media/Gallery/__snapshots__/component.spec.js.snap
+++ b/src/components/media/Gallery/__snapshots__/component.spec.js.snap
@@ -96,7 +96,7 @@ exports[`<Gallery /> by default should render the right structure 1`] = `
     <Divider
       className=""
       hasLine={false}
-      size="large"
+      size="huge"
     />
   </HorizontalGutters>
 </Modal>
@@ -204,7 +204,7 @@ exports[`<Gallery /> if \`props.heading\` is defined should render the right str
     <Divider
       className=""
       hasLine={false}
-      size="large"
+      size="huge"
     />
   </HorizontalGutters>
 </Modal>

--- a/src/components/media/Gallery/component.js
+++ b/src/components/media/Gallery/component.js
@@ -36,7 +36,7 @@ export const Component = ({ heading, images, trigger }) => (
           ))}
         </GridRow>
       </Grid>
-      <Divider size="large" />
+      <Divider size="huge" />
     </HorizontalGutters>
   </Modal>
 );

--- a/src/components/property-page-widgets/Pictures/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Pictures/__snapshots__/component.spec.js.snap
@@ -295,15 +295,15 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                     <Divider
                       className=""
                       hasLine={false}
-                      size="small"
+                      size="medium"
                     >
                       <Divider
-                        className="is-size-small"
+                        className=""
                         hidden={true}
                         section={false}
                       >
                         <div
-                          className="ui hidden divider is-size-small"
+                          className="ui hidden divider"
                         />
                       </Divider>
                     </Divider>
@@ -487,15 +487,15 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                     <Divider
                       className=""
                       hasLine={false}
-                      size="small"
+                      size="medium"
                     >
                       <Divider
-                        className="is-size-small"
+                        className=""
                         hidden={true}
                         section={false}
                       >
                         <div
-                          className="ui hidden divider is-size-small"
+                          className="ui hidden divider"
                         />
                       </Divider>
                     </Divider>
@@ -679,15 +679,15 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                     <Divider
                       className=""
                       hasLine={false}
-                      size="small"
+                      size="medium"
                     >
                       <Divider
-                        className="is-size-small"
+                        className=""
                         hidden={true}
                         section={false}
                       >
                         <div
-                          className="ui hidden divider is-size-small"
+                          className="ui hidden divider"
                         />
                       </Divider>
                     </Divider>
@@ -871,15 +871,15 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                     <Divider
                       className=""
                       hasLine={false}
-                      size="small"
+                      size="medium"
                     >
                       <Divider
-                        className="is-size-small"
+                        className=""
                         hidden={true}
                         section={false}
                       >
                         <div
-                          className="ui hidden divider is-size-small"
+                          className="ui hidden divider"
                         />
                       </Divider>
                     </Divider>
@@ -1063,15 +1063,15 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                     <Divider
                       className=""
                       hasLine={false}
-                      size="small"
+                      size="medium"
                     >
                       <Divider
-                        className="is-size-small"
+                        className=""
                         hidden={true}
                         section={false}
                       >
                         <div
-                          className="ui hidden divider is-size-small"
+                          className="ui hidden divider"
                         />
                       </Divider>
                     </Divider>
@@ -1361,7 +1361,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                         <Divider
                           className=""
                           hasLine={false}
-                          size="large"
+                          size="huge"
                         />
                       </HorizontalGutters>
                     }

--- a/src/components/property-page-widgets/Pictures/component.js
+++ b/src/components/property-page-widgets/Pictures/component.js
@@ -55,7 +55,7 @@ export const Component = ({
                 size="huge"
               />
             </ShowOn>
-            <Divider size="small" />
+            <Divider />
           </GridColumn>
         )
       )}

--- a/src/components/property-page-widgets/PropertyPageHero/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/PropertyPageHero/__snapshots__/component.spec.js.snap
@@ -1832,7 +1832,7 @@ exports[`PropertyPageHero by default should render the right structure 1`] = `
                               <Divider
                                 className=""
                                 hasLine={false}
-                                size="large"
+                                size="huge"
                               />
                             </HorizontalGutters>
                           }

--- a/src/components/property-page-widgets/Rates/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Rates/__snapshots__/component.spec.js.snap
@@ -2527,15 +2527,15 @@ exports[`<Rates /> if \`props.isShowingPlaceholder\` is true should have the rig
               <Divider
                 className=""
                 hasLine={false}
-                size="large"
+                size="huge"
               >
                 <Divider
-                  className=""
+                  className="is-size-huge"
                   hidden={true}
-                  section={true}
+                  section={false}
                 >
                   <div
-                    className="ui hidden section divider"
+                    className="ui hidden divider is-size-huge"
                   />
                 </Divider>
               </Divider>
@@ -2689,15 +2689,15 @@ exports[`<Rates /> if \`props.isShowingPlaceholder\` is true should have the rig
               <Divider
                 className=""
                 hasLine={false}
-                size="large"
+                size="huge"
               >
                 <Divider
-                  className=""
+                  className="is-size-huge"
                   hidden={true}
-                  section={true}
+                  section={false}
                 >
                   <div
-                    className="ui hidden section divider"
+                    className="ui hidden divider is-size-huge"
                   />
                 </Divider>
               </Divider>
@@ -2851,15 +2851,15 @@ exports[`<Rates /> if \`props.isShowingPlaceholder\` is true should have the rig
               <Divider
                 className=""
                 hasLine={false}
-                size="large"
+                size="huge"
               >
                 <Divider
-                  className=""
+                  className="is-size-huge"
                   hidden={true}
-                  section={true}
+                  section={false}
                 >
                   <div
-                    className="ui hidden section divider"
+                    className="ui hidden divider is-size-huge"
                   />
                 </Divider>
               </Divider>

--- a/src/components/property-page-widgets/Rates/utils/__snapshots__/getCardsPlaceholderMarkup.spec.js.snap
+++ b/src/components/property-page-widgets/Rates/utils/__snapshots__/getCardsPlaceholderMarkup.spec.js.snap
@@ -79,15 +79,15 @@ Array [
           <Divider
             className=""
             hasLine={false}
-            size="large"
+            size="huge"
           >
             <Divider
-              className=""
+              className="is-size-huge"
               hidden={true}
-              section={true}
+              section={false}
             >
               <div
-                className="ui hidden section divider"
+                className="ui hidden divider is-size-huge"
               />
             </Divider>
           </Divider>
@@ -241,15 +241,15 @@ Array [
           <Divider
             className=""
             hasLine={false}
-            size="large"
+            size="huge"
           >
             <Divider
-              className=""
+              className="is-size-huge"
               hidden={true}
-              section={true}
+              section={false}
             >
               <div
-                className="ui hidden section divider"
+                className="ui hidden divider is-size-huge"
               />
             </Divider>
           </Divider>
@@ -403,15 +403,15 @@ Array [
           <Divider
             className=""
             hasLine={false}
-            size="large"
+            size="huge"
           >
             <Divider
-              className=""
+              className="is-size-huge"
               hidden={true}
-              section={true}
+              section={false}
             >
               <div
-                className="ui hidden section divider"
+                className="ui hidden divider is-size-huge"
               />
             </Divider>
           </Divider>

--- a/src/components/property-page-widgets/Rates/utils/getCardsPlaceholderMarkup.js
+++ b/src/components/property-page-widgets/Rates/utils/getCardsPlaceholderMarkup.js
@@ -18,7 +18,7 @@ export const getCardsPlaceholderMarkup = () => (
           <TextPlaceholder length="medium" />
           <TextPlaceholder length="medium" />
           <TextPlaceholder length="medium" />
-          <Divider size="large" />
+          <Divider size="huge" />
           <TextPlaceholder />
           <Divider />
           <TextPlaceholder />

--- a/src/styles/semantic/themes/livingstone/elements/divider.overrides
+++ b/src/styles/semantic/themes/livingstone/elements/divider.overrides
@@ -7,4 +7,8 @@
   &.is-size-small {
     margin: @sizeSmallMargin;
   }
+
+  &.is-size-huge {
+    margin: @sizeHugeMargin;
+  }
 }

--- a/src/styles/semantic/themes/livingstone/elements/divider.overrides
+++ b/src/styles/semantic/themes/livingstone/elements/divider.overrides
@@ -2,7 +2,7 @@
          Theme Overrides
 *******************************/
 
-.ui.horizontal.divider {
+.ui.divider {
 
   &.is-size-small {
     margin: @sizeSmallMargin;

--- a/src/styles/semantic/themes/livingstone/elements/divider.variables
+++ b/src/styles/semantic/themes/livingstone/elements/divider.variables
@@ -25,3 +25,5 @@
 
 /* Sizes */
 @sizeSmallMargin: @8px 0;
+
+@sizeHugeMargin: @40px 0;

--- a/src/styles/semantic/themes/livingstone/elements/divider.variables
+++ b/src/styles/semantic/themes/livingstone/elements/divider.variables
@@ -21,7 +21,7 @@
 /* Inverted */
 
 /* Section */
-@sectionMargin: 40px;
+@sectionMargin: @20px;
 
 /* Sizes */
 @sizeSmallMargin: @8px 0;


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1883)

### What **one** thing does this PR do?
Dividers with a size of large have decreased in size and Dividers of size huge have replaced the previous large size.

### Any other notes
- The css selector has been changed because `is-size-small` class wasn't getting any css applied to it.
- Size `large` has been changed to `@20px` and `huge` was added with `@40px`
