### PR TITLE
TE-1859 Fix z-index for input icons

### DIFF
--- a/src/styles/semantic/definitions/third-party-components/react-dates-datepicker.less
+++ b/src/styles/semantic/definitions/third-party-components/react-dates-datepicker.less
@@ -15,7 +15,8 @@
 /*
   Portal date picker
 */
-.DateRangePicker_picker__portal {
+.DateRangePicker_picker__portal,
+.SingleDatePicker_picker__portal {
   z-index: @pickerZIndex;
 }
 

--- a/src/styles/semantic/themes/default/third-party-components/react-dates-datepicker.variables
+++ b/src/styles/semantic/themes/default/third-party-components/react-dates-datepicker.variables
@@ -30,7 +30,7 @@
 
 /* Picker */
 @pickerFontColor: @greyEight;
-@pickerZIndex: 3;
+@pickerZIndex: 15;
 @pickerBoxShadow: @spreadShadow;
 @pickerMinHeight: 445px;
 

--- a/src/styles/semantic/themes/livingstone/modules/dropdown.overrides
+++ b/src/styles/semantic/themes/livingstone/modules/dropdown.overrides
@@ -186,6 +186,7 @@
   }
 
   &.focus {
+    z-index: @dropdownContainerFocusZIndex;
 
     & > i.icon {
       color: @textColor;

--- a/src/styles/semantic/themes/livingstone/modules/dropdown.variables
+++ b/src/styles/semantic/themes/livingstone/modules/dropdown.variables
@@ -6,6 +6,7 @@
        Element
 --------------------*/
 @dropdownContainerMinWidth: 90px;
+@dropdownContainerFocusZIndex: 14;
 
 @borderRadius: @3px;
 


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1859)

### What **one** thing does this PR do?
Icons no longer appear above dropdown menus or date range picker inputs.

### Any other notes
#### Dropdowns
![kapture 2019-02-13 at 12 04 34](https://user-images.githubusercontent.com/10498995/52707667-81211f00-2f88-11e9-9d36-834fe5ebd720.gif)

#### DateRangePicker
![image](https://user-images.githubusercontent.com/10498995/52707648-6d75b880-2f88-11e9-8b36-d9ca32b220c4.png)

