### PR TITLE
TE-1876 Header max width increase to 1350px

### DIFF
--- a/src/styles/semantic/themes/livingstone/elements/container.overrides
+++ b/src/styles/semantic/themes/livingstone/elements/container.overrides
@@ -37,5 +37,5 @@
 /* with menu */
 
 .container.ui.menu.text {
-  max-width: @maxWidth !important;
+  max-width: @containerWithMenuMaxWidth !important;
 }

--- a/src/styles/semantic/themes/livingstone/elements/container.variables
+++ b/src/styles/semantic/themes/livingstone/elements/container.variables
@@ -32,3 +32,10 @@
        Grid
 --------------------*/
 @gridColumnGutter: 0 2rem;
+
+/*--------------
+   Variations
+---------------*/
+
+/* with menu */
+@containerWithMenuMaxWidth: 1430px;


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1876)

### What **one** thing does this PR do?
Increases the header max width greater to that of the container.

### Any other notes
- There is a 40px padding on either side so that is taken into account which is why it's 1430px and not 1350px. 

![image](https://user-images.githubusercontent.com/10498995/52786150-67e8a300-305a-11e9-85ab-e1874b84d160.png)
