### PR TITLE
TE-1888 Respect target attr html

### DIFF
--- a/src/components/general-widgets/CookieAlert/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/CookieAlert/__snapshots__/component.spec.js.snap
@@ -120,7 +120,7 @@ exports[`The \`CookieAlert\` component if \`isOpen\` is true should return the 
                 >
                   <div
                     class="flex-container"
-                    style="display: flex; height: 100%; align-items: center; flex-direction: column; justify-content: center;"
+                    style="display: flex; flex-grow: 1; height: 100%; align-items: center; flex-direction: column; justify-content: center;"
                   >
                     <div
                       class="ui hidden divider"
@@ -424,7 +424,7 @@ exports[`The \`CookieAlert\` component if \`isUserOnMobile\` is true should retu
                 >
                   <div
                     class="flex-container"
-                    style="display: flex; height: 100%; align-items: center; flex-direction: column; justify-content: center;"
+                    style="display: flex; flex-grow: 1; height: 100%; align-items: center; flex-direction: column; justify-content: center;"
                   >
                     <div
                       class="ui hidden divider"
@@ -470,7 +470,7 @@ exports[`The \`CookieAlert\` component if \`isUserOnMobile\` is true should retu
                 >
                   <div
                     class="flex-container"
-                    style="display: flex; height: 100%; align-items: center; flex-direction: column; justify-content: center;"
+                    style="display: flex; flex-grow: 1; height: 100%; align-items: center; flex-direction: column; justify-content: center;"
                   >
                     <div
                       class="ui hidden divider"

--- a/src/components/general-widgets/HTML/component.js
+++ b/src/components/general-widgets/HTML/component.js
@@ -17,7 +17,9 @@ export class Component extends PureComponent {
       // `DOMPurify.sanitize` is in `componentDidMount` so that it
       // is not called during server side rendering.
       // Reason: DOMPurify depends on browser features.
-      cleanHTMLString: DOMPurify.sanitize(this.props.htmlString),
+      cleanHTMLString: DOMPurify.sanitize(this.props.htmlString, {
+        ADD_ATTR: ['target'],
+      }),
     });
   };
 

--- a/src/components/general-widgets/HTML/component.spec.js
+++ b/src/components/general-widgets/HTML/component.spec.js
@@ -1,3 +1,5 @@
+jest.mock('dompurify');
+
 import React from 'react';
 import { shallow } from 'enzyme';
 import {
@@ -6,6 +8,11 @@ import {
   expectComponentToHaveDisplayName,
   expectComponentToHaveProps,
 } from '@lodgify/enzyme-jest-expect-helpers';
+import DOMPurify from 'dompurify';
+
+const SANITIZED_STRING = '🤬';
+
+DOMPurify.sanitize.mockReturnValue(SANITIZED_STRING);
 
 import { Component as HTML } from './component';
 
@@ -73,6 +80,25 @@ describe('<HTML />', () => {
             __html: expect.any(String),
           }),
         });
+      });
+    });
+  });
+
+  describe('`componentDidMount`', () => {
+    it('should call `this.setState` with the correct shape', () => {
+      const wrapper = getHTMLWidget();
+
+      wrapper.instance().setState = jest.fn();
+      wrapper.instance().componentDidMount();
+
+      expect(wrapper.instance().setState).toHaveBeenCalledWith({
+        cleanHTMLString: SANITIZED_STRING,
+      });
+    });
+
+    it('should call `DOMPurify.sanitize` with the correct arguments', () => {
+      expect(DOMPurify.sanitize).toHaveBeenCalledWith('', {
+        ADD_ATTR: ['target'],
       });
     });
   });


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1888)

### What **one** thing does this PR do?
Html attribute `target` is no longer sanitised in HTML component

### Any other notes
#### After
![image](https://user-images.githubusercontent.com/10498995/53031989-3e6eb380-346e-11e9-918b-8943e541b1a5.png)

#### Before
![image](https://user-images.githubusercontent.com/10498995/53032072-66f6ad80-346e-11e9-95e9-735ab7ff091f.png)
