### PR TITLE
TE- 1874 Heading widgets do not break words and overlap on low width

### DIFF
--- a/src/styles/semantic/themes/livingstone/globals/site.overrides
+++ b/src/styles/semantic/themes/livingstone/globals/site.overrides
@@ -29,6 +29,10 @@
 /*--------------
   Page Heading
 ---------------*/
+.ui.header {
+  word-wrap: break-word;
+}
+
 h1.ui.header {
   line-height: @h1LineHeight;
 }


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1874)

### What **one** thing does this PR do?
Implements word-break for every single ui header.

### Any other notes
![kapture 2019-02-20 at 17 12 10](https://user-images.githubusercontent.com/33876435/53106471-6f64ec00-3533-11e9-89bc-dcc949f906f6.gif)

