### PR TITLE
TE-1906 Stack Amenities on mobile

### DIFF
--- a/src/components/general-widgets/FeaturedProperties/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/FeaturedProperties/__snapshots__/component.spec.js.snap
@@ -33,9 +33,11 @@ exports[`<FeaturedProperties /> by default should render the right structure 1`]
 >
   <Grid
     areColumnsCentered={false}
+    isStackable={false}
   >
     <Grid
       centered={false}
+      stackable={false}
     >
       <div
         className="ui grid"
@@ -685,9 +687,11 @@ exports[`<FeaturedProperties /> if \`props.headingText\` is passed should render
 >
   <Grid
     areColumnsCentered={false}
+    isStackable={false}
   >
     <Grid
       centered={false}
+      stackable={false}
     >
       <div
         className="ui grid"
@@ -1345,9 +1349,11 @@ exports[`<FeaturedProperties /> if \`props.isShowingPlaceholder\` === true and \
 >
   <Grid
     areColumnsCentered={false}
+    isStackable={false}
   >
     <Grid
       centered={false}
+      stackable={false}
     >
       <div
         className="ui grid"

--- a/src/components/general-widgets/FeaturedRoomTypes/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/FeaturedRoomTypes/__snapshots__/component.spec.js.snap
@@ -31,9 +31,11 @@ exports[`<FeaturedRoomTypes /> by default should render the right structure 1`] 
 >
   <Grid
     areColumnsCentered={false}
+    isStackable={false}
   >
     <Grid
       centered={false}
+      stackable={false}
     >
       <div
         className="ui grid"
@@ -340,9 +342,11 @@ exports[`<FeaturedRoomTypes /> if \`props.featuredRoomTypes\` length === 0 and \
 >
   <Grid
     areColumnsCentered={false}
+    isStackable={false}
   >
     <Grid
       centered={false}
+      stackable={false}
     >
       <div
         className="ui grid"
@@ -744,9 +748,11 @@ exports[`<FeaturedRoomTypes /> if \`props.headingText\` is passed should render 
 >
   <Grid
     areColumnsCentered={false}
+    isStackable={false}
   >
     <Grid
       centered={false}
+      stackable={false}
     >
       <div
         className="ui grid"

--- a/src/components/general-widgets/HomepageHero/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/HomepageHero/__snapshots__/component.spec.js.snap
@@ -391,9 +391,11 @@ exports[`HomepageHero should render the right structure 1`] = `
                   >
                     <Grid
                       areColumnsCentered={true}
+                      isStackable={false}
                     >
                       <Grid
                         centered={true}
+                        stackable={false}
                       >
                         <div
                           className="ui centered grid"

--- a/src/components/general-widgets/Promotion/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/Promotion/__snapshots__/component.spec.js.snap
@@ -22,7 +22,7 @@ exports[`The \`Promotion\` component if \`backgroundImageUrl\` prop is passed sh
       <Grid
         areColumnsCentered={false}
         className="first-grid"
-        stackable={true}
+        isStackable={true}
         stretched={true}
       >
         <Grid
@@ -109,11 +109,13 @@ exports[`The \`Promotion\` component if \`backgroundImageUrl\` prop is passed sh
                         </ResponsiveImage>
                         <Grid
                           areColumnsCentered={false}
+                          isStackable={false}
                           padded={true}
                         >
                           <Grid
                             centered={false}
                             padded={true}
+                            stackable={false}
                           >
                             <div
                               className="ui padded grid"
@@ -322,7 +324,7 @@ exports[`The \`Promotion\` component if \`discountCode\` prop is passed should h
       <Grid
         areColumnsCentered={false}
         className="first-grid"
-        stackable={true}
+        isStackable={true}
         stretched={true}
       >
         <Grid
@@ -366,11 +368,13 @@ exports[`The \`Promotion\` component if \`discountCode\` prop is passed should h
                       >
                         <Grid
                           areColumnsCentered={false}
+                          isStackable={false}
                           padded={true}
                         >
                           <Grid
                             centered={false}
                             padded={true}
+                            stackable={false}
                           >
                             <div
                               className="ui padded grid"
@@ -764,7 +768,7 @@ exports[`The \`Promotion\` component if \`headingText\` prop is passed should ha
       <Grid
         areColumnsCentered={false}
         className="first-grid"
-        stackable={true}
+        isStackable={true}
         stretched={true}
       >
         <Grid
@@ -808,11 +812,13 @@ exports[`The \`Promotion\` component if \`headingText\` prop is passed should ha
                       >
                         <Grid
                           areColumnsCentered={false}
+                          isStackable={false}
                           padded={true}
                         >
                           <Grid
                             centered={false}
                             padded={true}
+                            stackable={false}
                           >
                             <div
                               className="ui padded grid"
@@ -1121,7 +1127,7 @@ exports[`The \`Promotion\` component should have the right structure 1`] = `
       <Grid
         areColumnsCentered={false}
         className="first-grid"
-        stackable={true}
+        isStackable={true}
         stretched={true}
       >
         <Grid
@@ -1165,11 +1171,13 @@ exports[`The \`Promotion\` component should have the right structure 1`] = `
                       >
                         <Grid
                           areColumnsCentered={false}
+                          isStackable={false}
                           padded={true}
                         >
                           <Grid
                             centered={false}
                             padded={true}
+                            stackable={false}
                           >
                             <div
                               className="ui padded grid"

--- a/src/components/general-widgets/Promotion/component.js
+++ b/src/components/general-widgets/Promotion/component.js
@@ -37,7 +37,7 @@ export const Component = ({
   placeholderBackgroundImage,
 }) => (
   <Segment basic className="is-promotion" onClick={onClick}>
-    <Grid className="first-grid" stackable stretched>
+    <Grid className="first-grid" isStackable stretched>
       <GridRow verticalAlign="middle">
         <GridColumn
           className="content-section"

--- a/src/components/general-widgets/Review/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/Review/__snapshots__/component.spec.js.snap
@@ -29,9 +29,11 @@ exports[`<Review /> if \`props.isShowingPlaceholder\` should render the right st
             >
               <Grid
                 areColumnsCentered={false}
+                isStackable={false}
               >
                 <Grid
                   centered={false}
+                  stackable={false}
                 >
                   <div
                     className="ui grid"
@@ -231,9 +233,11 @@ exports[`<Review /> if \`props.reviewResponse\` is passed should render the righ
             >
               <Grid
                 areColumnsCentered={false}
+                isStackable={false}
               >
                 <Grid
                   centered={false}
+                  stackable={false}
                 >
                   <div
                     className="ui grid"
@@ -511,9 +515,11 @@ exports[`<Review /> if \`props.reviewResponse\` is passed should render the righ
               >
                 <Grid
                   areColumnsCentered={false}
+                  isStackable={false}
                 >
                   <Grid
                     centered={false}
+                    stackable={false}
                   >
                     <div
                       className="ui grid"
@@ -656,9 +662,11 @@ exports[`<Review /> should render the right structure 1`] = `
             >
               <Grid
                 areColumnsCentered={false}
+                isStackable={false}
               >
                 <Grid
                   centered={false}
+                  stackable={false}
                 >
                   <div
                     className="ui grid"

--- a/src/components/general-widgets/SearchBar/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/SearchBar/__snapshots__/component.spec.js.snap
@@ -1053,9 +1053,11 @@ exports[`<SearchBar /> if \`props.isFixed\` is true should render the right stru
         >
           <Grid
             areColumnsCentered={false}
+            isStackable={false}
           >
             <Grid
               centered={false}
+              stackable={false}
             >
               <div
                 className="ui grid"

--- a/src/components/layout/Grid/component.js
+++ b/src/components/layout/Grid/component.js
@@ -10,17 +10,20 @@ import { Grid } from 'semantic-ui-react';
  * definition of Semantic UI.
  */
 // eslint-disable-next-line jsdoc/require-jsdoc
-export const Component = ({ areColumnsCentered, ...props }) => (
-  <Grid {...props} centered={areColumnsCentered} />
+export const Component = ({ areColumnsCentered, isStackable, ...props }) => (
+  <Grid {...props} centered={areColumnsCentered} stackable={isStackable} />
 );
 
 Component.displayName = 'Grid';
 
 Component.defaultProps = {
   areColumnsCentered: false,
+  isStackable: false,
 };
 
 Component.propTypes = {
   /** Are the columns in the grid centered. */
   areColumnsCentered: PropTypes.bool,
+  /** Do the items in the grid stack on top of one another on mobile devices. */
+  isStackable: PropTypes.bool,
 };

--- a/src/components/layout/Grid/component.spec.js
+++ b/src/components/layout/Grid/component.spec.js
@@ -23,7 +23,8 @@ describe('<Grid />', () => {
       const wrapper = getGrid();
 
       expectComponentToHaveProps(wrapper, {
-        centered: expect.any(Boolean),
+        centered: false,
+        stackable: false,
       });
     });
   });

--- a/src/components/media/Gallery/__snapshots__/component.spec.js.snap
+++ b/src/components/media/Gallery/__snapshots__/component.spec.js.snap
@@ -18,7 +18,7 @@ exports[`<Gallery /> by default should render the right structure 1`] = `
     <Grid
       areColumnsCentered={false}
       columns={2}
-      stackable={true}
+      isStackable={true}
     >
       <GridRow
         horizontalAlignContent="left"
@@ -126,7 +126,7 @@ exports[`<Gallery /> if \`props.heading\` is defined should render the right str
     <Grid
       areColumnsCentered={false}
       columns={2}
-      stackable={true}
+      isStackable={true}
     >
       <GridRow
         horizontalAlignContent="left"

--- a/src/components/media/Gallery/component.js
+++ b/src/components/media/Gallery/component.js
@@ -25,7 +25,7 @@ export const Component = ({ heading, images, trigger }) => (
           <Divider hasLine />
         </Fragment>
       )}
-      <Grid columns={2} stackable>
+      <Grid columns={2} isStackable>
         <GridRow>
           {images.map(({ label, imageUrl, ...otherProps }, index) => (
             <GridColumn key={buildKeyFromStrings(imageUrl, index)}>

--- a/src/components/property-page-widgets/Amenities/component.js
+++ b/src/components/property-page-widgets/Amenities/component.js
@@ -24,7 +24,7 @@ export const Component = ({
   isStacked,
   modalTriggerText,
 }) => (
-  <Grid className="is-amenities" columns={isStacked ? 1 : 3}>
+  <Grid className="is-amenities" columns={isStacked ? 1 : 3} isStackable>
     <GridRow>
       {headingText && (
         <GridColumn width={12}>

--- a/src/components/property-page-widgets/Amenities/component.spec.js
+++ b/src/components/property-page-widgets/Amenities/component.spec.js
@@ -8,13 +8,13 @@ import {
 } from '@lodgify/enzyme-jest-expect-helpers';
 
 import { getArrayOfLengthOfItem } from 'utils/get-array-of-length-of-item';
+import { Link } from 'elements/Link';
+import { Modal } from 'elements/Modal';
 import { VIEW_MORE } from 'utils/default-strings';
 import { Grid } from 'layout/Grid';
 import { GridRow } from 'layout/GridRow';
 import { GridColumn } from 'layout/GridColumn';
 import { Heading } from 'typography/Heading';
-import { Link } from 'elements/Link';
-import { Modal } from 'elements/Modal';
 
 import { twoAmenities, sixAmenities } from './mock-data/amenities';
 import { Component as Amenities } from './component';
@@ -187,7 +187,10 @@ describe('getAmenityMarkup', () => {
       it('should have the right props', () => {
         const wrapper = getSecondGrid();
 
-        expectComponentToHaveProps(wrapper, { padded: true, stackable: true });
+        expectComponentToHaveProps(wrapper, {
+          padded: true,
+          isStackable: true,
+        });
       });
 
       it('should render the right children', () => {

--- a/src/components/property-page-widgets/Amenities/utils/getAmenityMarkup.spec.js
+++ b/src/components/property-page-widgets/Amenities/utils/getAmenityMarkup.spec.js
@@ -8,12 +8,12 @@ import {
 
 import { getArrayOfLengthOfItem } from 'utils/get-array-of-length-of-item';
 import { VIEW_MORE } from 'utils/default-strings';
+import { Link } from 'elements/Link';
+import { Modal } from 'elements/Modal';
 import { Grid } from 'layout/Grid';
 import { GridColumn } from 'layout/GridColumn';
 import { GridRow } from 'layout/GridRow';
 import { Heading } from 'typography/Heading';
-import { Link } from 'elements/Link';
-import { Modal } from 'elements/Modal';
 
 import { twoAmenities, sixAmenities } from '../mock-data/amenities';
 
@@ -192,7 +192,10 @@ describe('getAmenityMarkup', () => {
       it('should have the right props', () => {
         const wrapper = getSecondGrid();
 
-        expectComponentToHaveProps(wrapper, { padded: true, stackable: true });
+        expectComponentToHaveProps(wrapper, {
+          padded: true,
+          isStackable: true,
+        });
       });
 
       it('should render the right children', () => {

--- a/src/components/property-page-widgets/Amenities/utils/getExtraItemsMarkup.js
+++ b/src/components/property-page-widgets/Amenities/utils/getExtraItemsMarkup.js
@@ -24,7 +24,7 @@ export const getExtraItemsMarkup = (
     <GridColumn width={12}>
       <Modal trigger={<Link>{modalTriggerText}</Link>}>
         <SemanticModal.Content>
-          <Grid className="is-amenities" columns={1} padded stackable>
+          <Grid className="is-amenities" columns={1} isStackable padded>
             <GridRow>{amenities.map(getCategoryMarkup)}</GridRow>
           </Grid>
         </SemanticModal.Content>

--- a/src/components/property-page-widgets/Availability/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Availability/__snapshots__/component.spec.js.snap
@@ -32,6 +32,7 @@ exports[`<Availability /> the wrapped component by default should render the rig
   </Heading>
   <Grid
     areColumnsCentered={false}
+    isStackable={false}
   >
     <GridRow
       horizontalAlignContent="left"
@@ -65,6 +66,7 @@ exports[`<Availability /> the wrapped component by default should render the rig
   >
     <Grid
       areColumnsCentered={false}
+      isStackable={false}
       padded={true}
     >
       <GridRow
@@ -280,6 +282,7 @@ exports[`<Availability /> the wrapped component by default should render the rig
   </Card>
   <Grid
     areColumnsCentered={false}
+    isStackable={false}
   >
     <GridColumn
       only="mobile"
@@ -323,6 +326,7 @@ exports[`<Availability /> the wrapped component if \`size(props.roomOptionsWithI
   </Heading>
   <Grid
     areColumnsCentered={false}
+    isStackable={false}
   >
     <GridRow
       horizontalAlignContent="left"
@@ -336,6 +340,7 @@ exports[`<Availability /> the wrapped component if \`size(props.roomOptionsWithI
       >
         <Grid
           areColumnsCentered={false}
+          isStackable={false}
         >
           <GridColumn
             computer={3}
@@ -417,6 +422,7 @@ exports[`<Availability /> the wrapped component if \`size(props.roomOptionsWithI
   >
     <Grid
       areColumnsCentered={false}
+      isStackable={false}
       padded={true}
     >
       <GridRow
@@ -632,6 +638,7 @@ exports[`<Availability /> the wrapped component if \`size(props.roomOptionsWithI
   </Card>
   <Grid
     areColumnsCentered={false}
+    isStackable={false}
   >
     <GridColumn
       only="mobile"

--- a/src/components/property-page-widgets/Description/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Description/__snapshots__/component.spec.js.snap
@@ -68,10 +68,12 @@ exports[`<Description /> if \`props.extraDescriptionText\` is passed the last \`
   <Grid
     areColumnsCentered={false}
     columns={1}
+    isStackable={false}
   >
     <Grid
       centered={false}
       columns={1}
+      stackable={false}
     >
       <div
         className="ui one column grid"
@@ -354,11 +356,13 @@ exports[`<Description /> if \`props.extraDescriptionText\` is passed the last \`
                   areColumnsCentered={false}
                   className="show-on-mobile"
                   columns={1}
+                  isStackable={false}
                 >
                   <Grid
                     centered={false}
                     className="show-on-mobile"
                     columns={1}
+                    stackable={false}
                   >
                     <div
                       className="ui one column grid show-on-mobile"
@@ -929,10 +933,12 @@ exports[`<Description /> if \`props.homeHighlights\` is empty should not render 
   <Grid
     areColumnsCentered={false}
     columns={1}
+    isStackable={false}
   >
     <Grid
       centered={false}
       columns={1}
+      stackable={false}
     >
       <div
         className="ui one column grid"
@@ -1215,11 +1221,13 @@ exports[`<Description /> if \`props.homeHighlights\` is empty should not render 
                   areColumnsCentered={false}
                   className="show-on-mobile"
                   columns={1}
+                  isStackable={false}
                 >
                   <Grid
                     centered={false}
                     className="show-on-mobile"
                     columns={1}
+                    stackable={false}
                   >
                     <div
                       className="ui one column grid show-on-mobile"
@@ -1559,10 +1567,12 @@ exports[`<Description /> should have the correct structure 1`] = `
   <Grid
     areColumnsCentered={false}
     columns={1}
+    isStackable={false}
   >
     <Grid
       centered={false}
       columns={1}
+      stackable={false}
     >
       <div
         className="ui one column grid"
@@ -1845,11 +1855,13 @@ exports[`<Description /> should have the correct structure 1`] = `
                   areColumnsCentered={false}
                   className="show-on-mobile"
                   columns={1}
+                  isStackable={false}
                 >
                   <Grid
                     centered={false}
                     className="show-on-mobile"
                     columns={1}
+                    stackable={false}
                   >
                     <div
                       className="ui one column grid show-on-mobile"

--- a/src/components/property-page-widgets/HostProfile/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/HostProfile/__snapshots__/component.spec.js.snap
@@ -16,10 +16,12 @@ exports[`<HostProfile /> if \`props.email\` is defined should render the right s
 >
   <Grid
     areColumnsCentered={false}
+    isStackable={false}
     textAlign="left"
   >
     <Grid
       centered={false}
+      stackable={false}
       textAlign="left"
     >
       <div
@@ -333,10 +335,12 @@ exports[`<HostProfile /> if \`props.languages\` is defined should render the rig
 >
   <Grid
     areColumnsCentered={false}
+    isStackable={false}
     textAlign="left"
   >
     <Grid
       centered={false}
+      stackable={false}
       textAlign="left"
     >
       <div
@@ -643,10 +647,12 @@ exports[`<HostProfile /> if \`props.phone\` is defined should render the right s
 >
   <Grid
     areColumnsCentered={false}
+    isStackable={false}
     textAlign="left"
   >
     <Grid
       centered={false}
+      stackable={false}
       textAlign="left"
     >
       <div
@@ -957,10 +963,12 @@ exports[`<HostProfile /> should render the right structure 1`] = `
 >
   <Grid
     areColumnsCentered={false}
+    isStackable={false}
     textAlign="left"
   >
     <Grid
       centered={false}
+      stackable={false}
       textAlign="left"
     >
       <div

--- a/src/components/property-page-widgets/Location/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Location/__snapshots__/component.spec.js.snap
@@ -39,7 +39,7 @@ exports[`<Location /> the \`Child\` of the \`Location\` component should have th
 >
   <Grid
     areColumnsCentered={false}
-    stackable={true}
+    isStackable={true}
   >
     <Grid
       centered={false}

--- a/src/components/property-page-widgets/Location/component.js
+++ b/src/components/property-page-widgets/Location/component.js
@@ -34,7 +34,7 @@ const Component = ({
   longitude,
   transportOptions,
 }) => (
-  <Grid stackable>
+  <Grid isStackable>
     <GridColumn width={12}>
       <Heading>{headingText}</Heading>
       <Subheading>{locationSummary}</Subheading>

--- a/src/components/property-page-widgets/Pictures/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Pictures/__snapshots__/component.spec.js.snap
@@ -68,10 +68,12 @@ exports[`<Pictures /> should render the correct structure 1`] = `
   <Grid
     areColumnsCentered={false}
     columns={3}
+    isStackable={false}
   >
     <Grid
       centered={false}
       columns={3}
+      stackable={false}
     >
       <div
         className="ui three column grid"
@@ -1181,7 +1183,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                         <Grid
                           areColumnsCentered={false}
                           columns={2}
-                          stackable={true}
+                          isStackable={true}
                         >
                           <GridRow
                             horizontalAlignContent="left"

--- a/src/components/property-page-widgets/PolicyAndNotes/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/PolicyAndNotes/__snapshots__/component.spec.js.snap
@@ -20,7 +20,7 @@ exports[`<PolicyAndNotes /> if \`props.cancellationPolicyRules\` is passed shoul
 >
   <Grid
     areColumnsCentered={false}
-    stackable={true}
+    isStackable={true}
   >
     <Grid
       centered={false}
@@ -156,7 +156,7 @@ exports[`<PolicyAndNotes /> if \`props.damageDepositRules\` is passed should hav
 >
   <Grid
     areColumnsCentered={false}
-    stackable={true}
+    isStackable={true}
   >
     <Grid
       centered={false}
@@ -296,7 +296,7 @@ exports[`<PolicyAndNotes /> if \`props.extraNotesText\` is passed should have th
 >
   <Grid
     areColumnsCentered={false}
-    stackable={true}
+    isStackable={true}
   >
     <Grid
       centered={false}
@@ -541,7 +541,7 @@ exports[`<PolicyAndNotes /> if \`props.notesText\` is passed should have the rig
 >
   <Grid
     areColumnsCentered={false}
-    stackable={true}
+    isStackable={true}
   >
     <Grid
       centered={false}
@@ -681,7 +681,7 @@ exports[`<PolicyAndNotes /> if \`props.paymentScheduleRules\` is passed should h
 >
   <Grid
     areColumnsCentered={false}
-    stackable={true}
+    isStackable={true}
   >
     <Grid
       centered={false}
@@ -824,7 +824,7 @@ exports[`<PolicyAndNotes /> should have the right structure 1`] = `
 >
   <Grid
     areColumnsCentered={false}
-    stackable={true}
+    isStackable={true}
   >
     <Grid
       centered={false}

--- a/src/components/property-page-widgets/PolicyAndNotes/component.js
+++ b/src/components/property-page-widgets/PolicyAndNotes/component.js
@@ -38,7 +38,7 @@ export const Component = ({
   paymentScheduleHeadingText,
   paymentScheduleRules,
 }) => (
-  <Grid stackable>
+  <Grid isStackable>
     <GridRow>
       <GridColumn width={12}>
         <Heading>{headingText}</Heading>

--- a/src/components/property-page-widgets/PropertyPageHero/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/PropertyPageHero/__snapshots__/component.spec.js.snap
@@ -656,7 +656,7 @@ exports[`PropertyPageHero should render the right structure 1`] = `
                               <Grid
                                 areColumnsCentered={false}
                                 columns={2}
-                                stackable={true}
+                                isStackable={true}
                               >
                                 <GridRow
                                   horizontalAlignContent="left"

--- a/src/components/property-page-widgets/PropertyPageSearchBar/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/PropertyPageSearchBar/__snapshots__/component.spec.js.snap
@@ -146,9 +146,11 @@ exports[`<PropertyPageSearchBar /> should have the right structure 1`] = `
                 >
                   <Grid
                     areColumnsCentered={false}
+                    isStackable={false}
                   >
                     <Grid
                       centered={false}
+                      stackable={false}
                     >
                       <div
                         className="ui grid"
@@ -1098,9 +1100,11 @@ exports[`<PropertyPageSearchBar /> should have the right structure 1`] = `
                 >
                   <Grid
                     areColumnsCentered={false}
+                    isStackable={false}
                   >
                     <Grid
                       centered={false}
+                      stackable={false}
                     >
                       <div
                         className="ui grid"

--- a/src/components/property-page-widgets/Rates/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Rates/__snapshots__/component.spec.js.snap
@@ -373,11 +373,13 @@ exports[`<Rates /> by default should have the right structure 1`] = `
             >
               <Grid
                 areColumnsCentered={false}
+                isStackable={false}
                 padded={true}
               >
                 <Grid
                   centered={false}
                   padded={true}
+                  stackable={false}
                 >
                   <div
                     className="ui padded grid"
@@ -722,11 +724,13 @@ exports[`<Rates /> by default should have the right structure 1`] = `
             >
               <Grid
                 areColumnsCentered={false}
+                isStackable={false}
                 padded={true}
               >
                 <Grid
                   centered={false}
                   padded={true}
+                  stackable={false}
                 >
                   <div
                     className="ui padded grid"
@@ -1071,11 +1075,13 @@ exports[`<Rates /> by default should have the right structure 1`] = `
             >
               <Grid
                 areColumnsCentered={false}
+                isStackable={false}
                 padded={true}
               >
                 <Grid
                   centered={false}
                   padded={true}
+                  stackable={false}
                 >
                   <div
                     className="ui padded grid"
@@ -3940,11 +3946,13 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
             >
               <Grid
                 areColumnsCentered={false}
+                isStackable={false}
                 padded={true}
               >
                 <Grid
                   centered={false}
                   padded={true}
+                  stackable={false}
                 >
                   <div
                     className="ui padded grid"
@@ -4289,11 +4297,13 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
             >
               <Grid
                 areColumnsCentered={false}
+                isStackable={false}
                 padded={true}
               >
                 <Grid
                   centered={false}
                   padded={true}
+                  stackable={false}
                 >
                   <div
                     className="ui padded grid"
@@ -4638,11 +4648,13 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
             >
               <Grid
                 areColumnsCentered={false}
+                isStackable={false}
                 padded={true}
               >
                 <Grid
                   centered={false}
                   padded={true}
+                  stackable={false}
                 >
                   <div
                     className="ui padded grid"

--- a/src/components/property-page-widgets/Reviews/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Reviews/__snapshots__/component.spec.js.snap
@@ -29,9 +29,11 @@ exports[`<Reviews /> if \`props.isShowingPlaceholder\` is \`true\` if \`props.re
 >
   <Grid
     areColumnsCentered={false}
+    isStackable={false}
   >
     <Grid
       centered={false}
+      stackable={false}
     >
       <div
         className="ui grid"
@@ -470,9 +472,11 @@ exports[`<Reviews /> if \`props.isShowingPlaceholder\` is \`true\` if \`props.re
                                 >
                                   <Grid
                                     areColumnsCentered={false}
+                                    isStackable={false}
                                   >
                                     <Grid
                                       centered={false}
+                                      stackable={false}
                                     >
                                       <div
                                         className="ui grid"
@@ -705,9 +709,11 @@ exports[`<Reviews /> if \`props.isShowingPlaceholder\` is \`true\` if \`props.re
                                 >
                                   <Grid
                                     areColumnsCentered={false}
+                                    isStackable={false}
                                   >
                                     <Grid
                                       centered={false}
+                                      stackable={false}
                                     >
                                       <div
                                         className="ui grid"
@@ -940,9 +946,11 @@ exports[`<Reviews /> if \`props.isShowingPlaceholder\` is \`true\` if \`props.re
                                 >
                                   <Grid
                                     areColumnsCentered={false}
+                                    isStackable={false}
                                   >
                                     <Grid
                                       centered={false}
+                                      stackable={false}
                                     >
                                       <div
                                         className="ui grid"
@@ -1188,9 +1196,11 @@ exports[`<Reviews /> if \`props.isShowingPlaceholder\` is \`true\` should render
 >
   <Grid
     areColumnsCentered={false}
+    isStackable={false}
   >
     <Grid
       centered={false}
+      stackable={false}
     >
       <div
         className="ui grid"
@@ -1635,9 +1645,11 @@ exports[`<Reviews /> if \`props.isShowingPlaceholder\` is \`true\` should render
                                 >
                                   <Grid
                                     areColumnsCentered={false}
+                                    isStackable={false}
                                   >
                                     <Grid
                                       centered={false}
+                                      stackable={false}
                                     >
                                       <div
                                         className="ui grid"
@@ -1799,9 +1811,11 @@ exports[`<Reviews /> if \`props.isShowingPlaceholder\` is \`true\` should render
                                   >
                                     <Grid
                                       areColumnsCentered={false}
+                                      isStackable={false}
                                     >
                                       <Grid
                                         centered={false}
+                                        stackable={false}
                                       >
                                         <div
                                           className="ui grid"
@@ -1981,9 +1995,11 @@ exports[`<Reviews /> if \`props.isShowingPlaceholder\` is \`true\` should render
                                 >
                                   <Grid
                                     areColumnsCentered={false}
+                                    isStackable={false}
                                   >
                                     <Grid
                                       centered={false}
+                                      stackable={false}
                                     >
                                       <div
                                         className="ui grid"
@@ -2229,9 +2245,11 @@ exports[`<Reviews /> should render the right structure 1`] = `
 >
   <Grid
     areColumnsCentered={false}
+    isStackable={false}
   >
     <Grid
       centered={false}
+      stackable={false}
     >
       <div
         className="ui grid"
@@ -2807,9 +2825,11 @@ exports[`<Reviews /> should render the right structure 1`] = `
                                 >
                                   <Grid
                                     areColumnsCentered={false}
+                                    isStackable={false}
                                   >
                                     <Grid
                                       centered={false}
+                                      stackable={false}
                                     >
                                       <div
                                         className="ui grid"
@@ -3087,9 +3107,11 @@ exports[`<Reviews /> should render the right structure 1`] = `
                                   >
                                     <Grid
                                       areColumnsCentered={false}
+                                      isStackable={false}
                                     >
                                       <Grid
                                         centered={false}
+                                        stackable={false}
                                       >
                                         <div
                                           className="ui grid"
@@ -3271,9 +3293,11 @@ exports[`<Reviews /> should render the right structure 1`] = `
                                 >
                                   <Grid
                                     areColumnsCentered={false}
+                                    isStackable={false}
                                   >
                                     <Grid
                                       centered={false}
+                                      stackable={false}
                                     >
                                       <div
                                         className="ui grid"

--- a/src/components/property-page-widgets/RoomType/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/RoomType/__snapshots__/component.spec.js.snap
@@ -78,9 +78,11 @@ exports[`<RoomType /> by default should render the correct structure 1`] = `
     >
       <Grid
         areColumnsCentered={false}
+        isStackable={false}
       >
         <Grid
           centered={false}
+          stackable={false}
         >
           <div
             className="ui grid"
@@ -193,11 +195,13 @@ exports[`<RoomType /> by default should render the correct structure 1`] = `
                       >
                         <Grid
                           areColumnsCentered={false}
+                          isStackable={false}
                           padded={true}
                         >
                           <Grid
                             centered={false}
                             padded={true}
+                            stackable={false}
                           >
                             <div
                               className="ui padded grid"
@@ -408,6 +412,7 @@ exports[`<RoomType /> by default should render the correct structure 1`] = `
                                             />
                                             <Grid
                                               areColumnsCentered={false}
+                                              isStackable={false}
                                             >
                                               <GridColumn
                                                 verticalAlignContent="bottom"
@@ -769,6 +774,7 @@ exports[`<RoomType /> by default should render the correct structure 1`] = `
                                                   />
                                                   <Grid
                                                     areColumnsCentered={false}
+                                                    isStackable={false}
                                                   >
                                                     <GridColumn
                                                       verticalAlignContent="bottom"
@@ -1032,9 +1038,11 @@ exports[`<RoomType /> if \`isShowingPlaceholder\` is \`true\` should render the 
     >
       <Grid
         areColumnsCentered={false}
+        isStackable={false}
       >
         <Grid
           centered={false}
+          stackable={false}
         >
           <div
             className="ui grid"
@@ -1092,11 +1100,13 @@ exports[`<RoomType /> if \`isShowingPlaceholder\` is \`true\` should render the 
                       >
                         <Grid
                           areColumnsCentered={false}
+                          isStackable={false}
                           padded={true}
                         >
                           <Grid
                             centered={false}
                             padded={true}
+                            stackable={false}
                           >
                             <div
                               className="ui padded grid"
@@ -1279,9 +1289,11 @@ exports[`<RoomType /> if \`isUserOnMobile === true\` should render the correct s
     >
       <Grid
         areColumnsCentered={false}
+        isStackable={false}
       >
         <Grid
           centered={false}
+          stackable={false}
         >
           <div
             className="ui grid"
@@ -1394,11 +1406,13 @@ exports[`<RoomType /> if \`isUserOnMobile === true\` should render the correct s
                       >
                         <Grid
                           areColumnsCentered={false}
+                          isStackable={false}
                           padded={true}
                         >
                           <Grid
                             centered={false}
                             padded={true}
+                            stackable={false}
                           >
                             <div
                               className="ui padded grid"
@@ -1609,6 +1623,7 @@ exports[`<RoomType /> if \`isUserOnMobile === true\` should render the correct s
                                             />
                                             <Grid
                                               areColumnsCentered={false}
+                                              isStackable={false}
                                             >
                                               <GridColumn
                                                 verticalAlignContent="bottom"
@@ -1943,6 +1958,7 @@ exports[`<RoomType /> if \`isUserOnMobile === true\` should render the correct s
                                                   />
                                                   <Grid
                                                     areColumnsCentered={false}
+                                                    isStackable={false}
                                                   >
                                                     <GridColumn
                                                       verticalAlignContent="bottom"

--- a/src/components/property-page-widgets/RoomType/utils/__snapshots__/getModalContentMarkup.spec.js.snap
+++ b/src/components/property-page-widgets/RoomType/utils/__snapshots__/getModalContentMarkup.spec.js.snap
@@ -395,14 +395,16 @@ exports[`getModalContentMarkup if \`props.description\` === null should not rend
         areColumnsCentered={false}
         className="is-amenities"
         columns={3}
+        isStackable={true}
       >
         <Grid
           centered={false}
           className="is-amenities"
           columns={3}
+          stackable={true}
         >
           <div
-            className="ui three column grid is-amenities"
+            className="ui stackable three column grid is-amenities"
           >
             <GridRow
               horizontalAlignContent="left"
@@ -583,9 +585,11 @@ exports[`getModalContentMarkup if \`props.description\` === null should not rend
     </Amenities>
     <Grid
       areColumnsCentered={false}
+      isStackable={false}
     >
       <Grid
         centered={false}
+        stackable={false}
       >
         <div
           className="ui grid"
@@ -874,14 +878,16 @@ exports[`getModalContentMarkup if \`props.ratingNumber\` === null should not ren
         areColumnsCentered={false}
         className="is-amenities"
         columns={3}
+        isStackable={true}
       >
         <Grid
           centered={false}
           className="is-amenities"
           columns={3}
+          stackable={true}
         >
           <div
-            className="ui three column grid is-amenities"
+            className="ui stackable three column grid is-amenities"
           >
             <GridRow
               horizontalAlignContent="left"
@@ -1062,9 +1068,11 @@ exports[`getModalContentMarkup if \`props.ratingNumber\` === null should not ren
     </Amenities>
     <Grid
       areColumnsCentered={false}
+      isStackable={false}
     >
       <Grid
         centered={false}
+        stackable={false}
       >
         <div
           className="ui grid"
@@ -1666,14 +1674,16 @@ exports[`getModalContentMarkup if \`props.slideShowImages.length\` > 1 should re
         areColumnsCentered={false}
         className="is-amenities"
         columns={3}
+        isStackable={true}
       >
         <Grid
           centered={false}
           className="is-amenities"
           columns={3}
+          stackable={true}
         >
           <div
-            className="ui three column grid is-amenities"
+            className="ui stackable three column grid is-amenities"
           >
             <GridRow
               horizontalAlignContent="left"
@@ -1854,9 +1864,11 @@ exports[`getModalContentMarkup if \`props.slideShowImages.length\` > 1 should re
     </Amenities>
     <Grid
       areColumnsCentered={false}
+      isStackable={false}
     >
       <Grid
         centered={false}
+        stackable={false}
       >
         <div
           className="ui grid"
@@ -2286,14 +2298,16 @@ exports[`getModalContentMarkup should return the correct structure 1`] = `
         areColumnsCentered={false}
         className="is-amenities"
         columns={3}
+        isStackable={true}
       >
         <Grid
           centered={false}
           className="is-amenities"
           columns={3}
+          stackable={true}
         >
           <div
-            className="ui three column grid is-amenities"
+            className="ui stackable three column grid is-amenities"
           >
             <GridRow
               horizontalAlignContent="left"
@@ -2474,9 +2488,11 @@ exports[`getModalContentMarkup should return the correct structure 1`] = `
     </Amenities>
     <Grid
       areColumnsCentered={false}
+      isStackable={false}
     >
       <Grid
         centered={false}
+        stackable={false}
       >
         <div
           className="ui grid"

--- a/src/components/property-page-widgets/RoomTypes/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/RoomTypes/__snapshots__/component.spec.js.snap
@@ -49,9 +49,11 @@ exports[`<RoomTypes /> if \`isShowingPlaceholder\` is \`true\` if \`roomTypes.le
           >
             <Grid
               areColumnsCentered={false}
+              isStackable={false}
             >
               <Grid
                 centered={false}
+                stackable={false}
               >
                 <div
                   className="ui grid"
@@ -109,11 +111,13 @@ exports[`<RoomTypes /> if \`isShowingPlaceholder\` is \`true\` if \`roomTypes.le
                             >
                               <Grid
                                 areColumnsCentered={false}
+                                isStackable={false}
                                 padded={true}
                               >
                                 <Grid
                                   centered={false}
                                   padded={true}
+                                  stackable={false}
                                 >
                                   <div
                                     className="ui padded grid"
@@ -262,9 +266,11 @@ exports[`<RoomTypes /> if \`isShowingPlaceholder\` is \`true\` if \`roomTypes.le
           >
             <Grid
               areColumnsCentered={false}
+              isStackable={false}
             >
               <Grid
                 centered={false}
+                stackable={false}
               >
                 <div
                   className="ui grid"
@@ -322,11 +328,13 @@ exports[`<RoomTypes /> if \`isShowingPlaceholder\` is \`true\` if \`roomTypes.le
                             >
                               <Grid
                                 areColumnsCentered={false}
+                                isStackable={false}
                                 padded={true}
                               >
                                 <Grid
                                   centered={false}
                                   padded={true}
+                                  stackable={false}
                                 >
                                   <div
                                     className="ui padded grid"
@@ -761,9 +769,11 @@ exports[`<RoomTypes /> if \`isShowingPlaceholder\` is \`true\` should render the
           >
             <Grid
               areColumnsCentered={false}
+              isStackable={false}
             >
               <Grid
                 centered={false}
+                stackable={false}
               >
                 <div
                   className="ui grid"
@@ -821,11 +831,13 @@ exports[`<RoomTypes /> if \`isShowingPlaceholder\` is \`true\` should render the
                             >
                               <Grid
                                 areColumnsCentered={false}
+                                isStackable={false}
                                 padded={true}
                               >
                                 <Grid
                                   centered={false}
                                   padded={true}
+                                  stackable={false}
                                 >
                                   <div
                                     className="ui padded grid"
@@ -1115,9 +1127,11 @@ exports[`<RoomTypes /> if \`isShowingPlaceholder\` is \`true\` should render the
           >
             <Grid
               areColumnsCentered={false}
+              isStackable={false}
             >
               <Grid
                 centered={false}
+                stackable={false}
               >
                 <div
                   className="ui grid"
@@ -1175,11 +1189,13 @@ exports[`<RoomTypes /> if \`isShowingPlaceholder\` is \`true\` should render the
                             >
                               <Grid
                                 areColumnsCentered={false}
+                                isStackable={false}
                                 padded={true}
                               >
                                 <Grid
                                   centered={false}
                                   padded={true}
+                                  stackable={false}
                                 >
                                   <div
                                     className="ui padded grid"
@@ -1614,9 +1630,11 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
           >
             <Grid
               areColumnsCentered={false}
+              isStackable={false}
             >
               <Grid
                 centered={false}
+                stackable={false}
               >
                 <div
                   className="ui grid"
@@ -1717,11 +1735,13 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                             >
                               <Grid
                                 areColumnsCentered={false}
+                                isStackable={false}
                                 padded={true}
                               >
                                 <Grid
                                   centered={false}
                                   padded={true}
+                                  stackable={false}
                                 >
                                   <div
                                     className="ui padded grid"
@@ -1935,6 +1955,7 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                                   />
                                                   <Grid
                                                     areColumnsCentered={false}
+                                                    isStackable={false}
                                                   >
                                                     <GridColumn
                                                       verticalAlignContent="bottom"
@@ -2393,6 +2414,7 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                                         />
                                                         <Grid
                                                           areColumnsCentered={false}
+                                                          isStackable={false}
                                                         >
                                                           <GridColumn
                                                             verticalAlignContent="bottom"
@@ -2763,9 +2785,11 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
           >
             <Grid
               areColumnsCentered={false}
+              isStackable={false}
             >
               <Grid
                 centered={false}
+                stackable={false}
               >
                 <div
                   className="ui grid"
@@ -2866,11 +2890,13 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                             >
                               <Grid
                                 areColumnsCentered={false}
+                                isStackable={false}
                                 padded={true}
                               >
                                 <Grid
                                   centered={false}
                                   padded={true}
+                                  stackable={false}
                                 >
                                   <div
                                     className="ui padded grid"
@@ -3075,6 +3101,7 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                                   />
                                                   <Grid
                                                     areColumnsCentered={false}
+                                                    isStackable={false}
                                                   >
                                                     <GridColumn
                                                       verticalAlignContent="bottom"
@@ -3524,6 +3551,7 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                                         />
                                                         <Grid
                                                           areColumnsCentered={false}
+                                                          isStackable={false}
                                                         >
                                                           <GridColumn
                                                             verticalAlignContent="bottom"

--- a/src/components/property-page-widgets/Rules/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Rules/__snapshots__/component.spec.js.snap
@@ -11,7 +11,7 @@ exports[`<Rules /> by default should render the right structure 1`] = `
 >
   <Grid
     areColumnsCentered={false}
-    stackable={true}
+    isStackable={true}
   >
     <Grid
       centered={false}
@@ -183,7 +183,7 @@ exports[`<Rules /> if \`props.rules\` length > 0 should render the right structu
 >
   <Grid
     areColumnsCentered={false}
-    stackable={true}
+    isStackable={true}
   >
     <Grid
       centered={false}

--- a/src/components/property-page-widgets/Rules/component.js
+++ b/src/components/property-page-widgets/Rules/component.js
@@ -24,7 +24,7 @@ export const Component = ({
   headingText,
   rules,
 }) => (
-  <Grid stackable>
+  <Grid isStackable>
     <GridColumn width={12}>
       <Heading>{headingText}</Heading>
     </GridColumn>


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-X)

### What **one** thing does this PR do?
Stacks the categories in `Amenities` on mobile

#### Before
![screenshot 2019-02-25 at 15 21 50](https://user-images.githubusercontent.com/8591501/53343929-c42cac00-3911-11e9-85e5-1da1da74bfb2.png)

#### After 
![screenshot 2019-02-25 at 15 21 13](https://user-images.githubusercontent.com/8591501/53343931-c42cac00-3911-11e9-9cb5-75def4aa9971.png)

