### PR TITLE
TE-1913 Expose target props

### DIFF
--- a/src/components/collections/Footer/component.js
+++ b/src/components/collections/Footer/component.js
@@ -87,15 +87,18 @@ export const Component = ({
         )}
         {size(socialMediaLinks) > 0 && (
           <Menu.Menu position="right">
-            {socialMediaLinks.map(({ href, iconName, iconPath }, index) => (
-              <Menu.Item
-                href={href}
-                key={buildKeyFromStrings(href, index)}
-                link
-              >
-                <Icon name={iconName} path={iconPath} />
-              </Menu.Item>
-            ))}
+            {socialMediaLinks.map(
+              ({ href, iconName, iconPath, target }, index) => (
+                <Menu.Item
+                  href={href}
+                  key={buildKeyFromStrings(href, index)}
+                  link
+                  target={target}
+                >
+                  <Icon name={iconName} path={iconPath} />
+                </Menu.Item>
+              )
+            )}
           </Menu.Menu>
         )}
         <Divider hasLine />
@@ -174,9 +177,12 @@ Component.propTypes = {
       subItems: PropTypes.arrayOf(
         PropTypes.shape({
           href: PropTypes.string.isRequired,
+          target: PropTypes.string,
           text: PropTypes.string.isRequired,
         })
       ),
+      /** Specifies where to display the linked navigation items URL. See [MDN docs `<a />` for more](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-target). */
+      target: PropTypes.string,
       /** The visible text for an item. */
       text: PropTypes.string.isRequired,
     })
@@ -206,6 +212,8 @@ Component.propTypes = {
       iconName: PropTypes.string,
       /** The path of the icon to display. See [`Icon` props](#/Icon) for guidance. */
       iconPath: PropTypes.string,
+      /** Specifies where to display the social media links URL. See [MDN docs `<a />` for more](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-target). */
+      target: PropTypes.string,
     })
   ),
 };

--- a/src/components/collections/Footer/utils/getMenuItemMarkup.js
+++ b/src/components/collections/Footer/utils/getMenuItemMarkup.js
@@ -11,8 +11,13 @@ import { buildKeyFromStrings } from 'utils/build-key-from-strings';
  * @return {Object}
  */
 // eslint-disable-next-line react/prop-types
-export const getMenuItemMarkup = ({ href, text }, index) => (
-  <Menu.Item href={href} key={buildKeyFromStrings(text, index)} link>
+export const getMenuItemMarkup = ({ href, text, target }, index) => (
+  <Menu.Item
+    href={href}
+    key={buildKeyFromStrings(text, index)}
+    link
+    target={target}
+  >
     {text}
   </Menu.Item>
 );

--- a/src/components/collections/Footer/utils/getMenuItemMarkup.spec.js
+++ b/src/components/collections/Footer/utils/getMenuItemMarkup.spec.js
@@ -7,7 +7,7 @@ import {
 
 import { getMenuItemMarkup } from './getMenuItemMarkup';
 
-const menuItem = { href: 'someHref', text: 'someText' };
+const menuItem = { href: 'someHref', text: 'someText', target: '🎯' };
 
 const getMenuItem = () => shallow(getMenuItemMarkup(menuItem, 0));
 
@@ -31,6 +31,7 @@ describe('getMenuItemMarkup', () => {
       expectComponentToHaveProps(wrapper, {
         href: menuItem.href,
         className: 'link item',
+        target: '🎯',
       });
     });
   });

--- a/src/components/collections/Header/component.js
+++ b/src/components/collections/Header/component.js
@@ -120,9 +120,12 @@ Component.propTypes = {
       subItems: PropTypes.arrayOf(
         PropTypes.shape({
           href: PropTypes.string.isRequired,
+          target: PropTypes.string,
           text: PropTypes.string.isRequired,
         })
       ),
+      /** Specifies where to display the linked navigation items URL. See [MDN docs `<a />` for more](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-target). */
+      target: PropTypes.string,
       /** The visible text for an item. */
       text: PropTypes.string.isRequired,
     })

--- a/src/components/collections/Header/utils/getHiddenMenuMarkup.js
+++ b/src/components/collections/Header/utils/getHiddenMenuMarkup.js
@@ -33,34 +33,43 @@ export const getHiddenMenuMarkup = ({
     <Modal isFullscreen trigger={<Icon name={ICON_NAMES.BARS} />}>
       {getLogoMarkup(logoText, logoSrc, logoSizes, logoSrcSet)}
       <Menu text vertical>
-        {navigationItems.map(({ subItems, text, href }, index) =>
-          size(subItems) ? (
-            <Accordion
-              as={Menu.Item}
-              key={buildKeyFromStrings(text, index)}
-              panels={[
-                {
-                  title: {
-                    content: text,
-                    key: buildKeyFromStrings(text, index),
+        {navigationItems.map(
+          ({ subItems, text, target: navigationItemTarget, href }, index) =>
+            size(subItems) ? (
+              <Accordion
+                as={Menu.Item}
+                key={buildKeyFromStrings(text, index)}
+                panels={[
+                  {
+                    title: {
+                      content: text,
+                      key: buildKeyFromStrings(text, index),
+                    },
+                    content: {
+                      content: subItems.map(
+                        ({ text, target: subItemTarget, href }, index) =>
+                          getLinkMarkup(
+                            text,
+                            href,
+                            subItemTarget,
+                            index,
+                            activeNavigationItemIndex
+                          )
+                      ),
+                      key: buildKeyFromStrings(index, text),
+                    },
                   },
-                  content: {
-                    content: subItems.map(({ text, href }, index) =>
-                      getLinkMarkup(
-                        text,
-                        href,
-                        index,
-                        activeNavigationItemIndex
-                      )
-                    ),
-                    key: buildKeyFromStrings(index, text),
-                  },
-                },
-              ]}
-            />
-          ) : (
-            getLinkMarkup(text, href, index, activeNavigationItemIndex)
-          )
+                ]}
+              />
+            ) : (
+              getLinkMarkup(
+                text,
+                href,
+                navigationItemTarget,
+                index,
+                activeNavigationItemIndex
+              )
+            )
         )}
       </Menu>
     </Modal>

--- a/src/components/collections/Header/utils/getLinkMarkup.js
+++ b/src/components/collections/Header/utils/getLinkMarkup.js
@@ -6,16 +6,24 @@ import { buildKeyFromStrings } from 'utils/build-key-from-strings';
 /**
  * @param  {string} text
  * @param  {string} href
+ * @param  {string} target
  * @param  {number} index
  * @param  {number} activeNavigationItemIndex
  * @return {Object}
  */
-export const getLinkMarkup = (text, href, index, activeNavigationItemIndex) => (
+export const getLinkMarkup = (
+  text,
+  href,
+  target,
+  index,
+  activeNavigationItemIndex
+) => (
   <Menu.Item
     active={index === activeNavigationItemIndex}
     href={href}
     key={buildKeyFromStrings(text, index)}
     link
+    target={target}
   >
     {text}
   </Menu.Item>

--- a/src/components/collections/Header/utils/getLinkMarkup.spec.js
+++ b/src/components/collections/Header/utils/getLinkMarkup.spec.js
@@ -10,9 +10,10 @@ import { getLinkMarkup } from './getLinkMarkup';
 const text = 'someText';
 const href = 'someHref';
 const index = 0;
+const target = '🎯';
 
 const getLinkMarkupAsComponent = activeNavigationItemIndex =>
-  shallow(getLinkMarkup(text, href, index, activeNavigationItemIndex));
+  shallow(getLinkMarkup(text, href, target, index, activeNavigationItemIndex));
 
 describe('getLinkMarkup', () => {
   it('should return a Semantic UI `Menu.Item` link component', () => {

--- a/src/components/collections/Header/utils/getStandardMenuMarkup.js
+++ b/src/components/collections/Header/utils/getStandardMenuMarkup.js
@@ -24,7 +24,7 @@ export const getStandardMenuMarkup = ({
   /* eslint-enable react/prop-types */
 }) => (
   <Fragment>
-    {navigationItems.map(({ subItems, text, href }, index) =>
+    {navigationItems.map(({ subItems, text, href, target }, index) =>
       size(subItems) > 0 ? (
         <Submenu
           isMenuItem
@@ -42,7 +42,7 @@ export const getStandardMenuMarkup = ({
           {text}
         </Submenu>
       ) : (
-        getLinkMarkup(text, href, index, activeNavigationItemIndex)
+        getLinkMarkup(text, href, target, index, activeNavigationItemIndex)
       )
     )}
     {primaryCTA && (

--- a/src/components/elements/Submenu/component.js
+++ b/src/components/elements/Submenu/component.js
@@ -78,6 +78,8 @@ Component.propTypes = {
     PropTypes.shape({
       /** The url for a link item. */
       href: PropTypes.string,
+      /** Specifies where to display the linked items URL. See [MDN docs `<a />` for more](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-target). */
+      target: PropTypes.string,
       /** The visible text for the item. */
       text: PropTypes.string,
       /** The underlying value for the item. */

--- a/src/components/general-widgets/CookieAlert/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/CookieAlert/__snapshots__/component.spec.js.snap
@@ -60,7 +60,7 @@ exports[`The \`CookieAlert\` component if \`isOpen\` is true should return the 
               href="/"
               isPositionedRight={false}
               onClick={[Function]}
-              willOpenInNewTab={false}
+              willOpenInNewTab={true}
             >
               A link
             </Link>
@@ -134,7 +134,7 @@ exports[`The \`CookieAlert\` component if \`isOpen\` is true should return the 
                       class="ui basic left floated button"
                       href="/"
                       role="button"
-                      target="_self"
+                      target="_blank"
                     >
                       A link
                     </a>
@@ -249,7 +249,7 @@ exports[`The \`CookieAlert\` component if \`isUserOnMobile\` is false should ret
                         onBlur={[Function]}
                         onChange={[Function]}
                         onClick={[Function]}
-                        willOpenInNewTab={false}
+                        willOpenInNewTab={true}
                       >
                         <Button
                           as="a"
@@ -257,14 +257,14 @@ exports[`The \`CookieAlert\` component if \`isUserOnMobile\` is false should ret
                           floated="left"
                           href="/"
                           onClick={[Function]}
-                          target="_self"
+                          target="_blank"
                         >
                           <a
                             className="ui basic left floated button"
                             href="/"
                             onClick={[Function]}
                             role="button"
-                            target="_self"
+                            target="_blank"
                           >
                             A link
                           </a>
@@ -364,7 +364,7 @@ exports[`The \`CookieAlert\` component if \`isUserOnMobile\` is true should retu
               href="/"
               isPositionedRight={false}
               onClick={[Function]}
-              willOpenInNewTab={false}
+              willOpenInNewTab={true}
             >
               A link
             </Link>
@@ -438,7 +438,7 @@ exports[`The \`CookieAlert\` component if \`isUserOnMobile\` is true should retu
                       class="ui basic left floated button"
                       href="/"
                       role="button"
-                      target="_self"
+                      target="_blank"
                     >
                       A link
                     </a>
@@ -484,7 +484,7 @@ exports[`The \`CookieAlert\` component if \`isUserOnMobile\` is true should retu
                       class="ui basic left floated button"
                       href="/"
                       role="button"
-                      target="_self"
+                      target="_blank"
                     >
                       A link
                     </a>

--- a/src/components/general-widgets/CookieAlert/component.js
+++ b/src/components/general-widgets/CookieAlert/component.js
@@ -32,7 +32,9 @@ const Component = ({
         >
           <Divider />
           <Paragraph>{text}</Paragraph>
-          <Link href={linkUrl}>{linkText}</Link>
+          <Link href={linkUrl} willOpenInNewTab>
+            {linkText}
+          </Link>
           <Divider />
           <Button onClick={onAccept}>{buttonText}</Button> <Divider />
         </FlexContainer>

--- a/src/components/general-widgets/CookieAlert/utils/__snapshots__/getFormMarkup.spec.js.snap
+++ b/src/components/general-widgets/CookieAlert/utils/__snapshots__/getFormMarkup.spec.js.snap
@@ -21,7 +21,7 @@ exports[`\`getFormMarkup\` should render the right structure 1`] = `
     href="Bup"
     isPositionedRight={false}
     onClick={[Function]}
-    willOpenInNewTab={false}
+    willOpenInNewTab={true}
   >
     Bip
   </Link>

--- a/src/components/general-widgets/CookieAlert/utils/getFormMarkup.js
+++ b/src/components/general-widgets/CookieAlert/utils/getFormMarkup.js
@@ -21,6 +21,8 @@ export const getFormMarkup = (
 ) => (
   <Form onSubmit={onAccept} submitButtonText={buttonText}>
     <Paragraph>{text}</Paragraph>
-    <Link href={linkUrl}>{linkText}</Link>
+    <Link href={linkUrl} willOpenInNewTab>
+      {linkText}
+    </Link>
   </Form>
 );

--- a/src/components/general-widgets/FeaturedProperties/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/FeaturedProperties/__snapshots__/component.spec.js.snap
@@ -70,16 +70,19 @@ exports[`<FeaturedProperties /> by default should render the right structure 1`]
                 propertyName="The Cat House"
                 propertyType="Bed and breakfast"
                 propertyUrl="/"
+                propertyUrlTarget="_self"
                 ratingNumber={4.8}
               >
                 <Card
                   className="has-featured"
                   href="/"
+                  target="_self"
                 >
                   <a
                     className="ui card has-featured"
                     href="/"
                     onClick={[Function]}
+                    target="_self"
                   >
                     <ResponsiveImage
                       alternativeText="Image Widget"
@@ -373,16 +376,19 @@ exports[`<FeaturedProperties /> by default should render the right structure 1`]
                 propertyName="The Cat House"
                 propertyType="Bed and breakfast"
                 propertyUrl="/"
+                propertyUrlTarget="_self"
                 ratingNumber={4.8}
               >
                 <Card
                   className="has-featured"
                   href="/"
+                  target="_self"
                 >
                   <a
                     className="ui card has-featured"
                     href="/"
                     onClick={[Function]}
+                    target="_self"
                   >
                     <ResponsiveImage
                       alternativeText="Image Widget"
@@ -757,16 +763,19 @@ exports[`<FeaturedProperties /> if \`props.headingText\` is passed should render
                 propertyName="The Cat House"
                 propertyType="Bed and breakfast"
                 propertyUrl="/"
+                propertyUrlTarget="_self"
                 ratingNumber={4.8}
               >
                 <Card
                   className="has-featured"
                   href="/"
+                  target="_self"
                 >
                   <a
                     className="ui card has-featured"
                     href="/"
                     onClick={[Function]}
+                    target="_self"
                   >
                     <ResponsiveImage
                       alternativeText="Image Widget"
@@ -1060,16 +1069,19 @@ exports[`<FeaturedProperties /> if \`props.headingText\` is passed should render
                 propertyName="The Cat House"
                 propertyType="Bed and breakfast"
                 propertyUrl="/"
+                propertyUrlTarget="_self"
                 ratingNumber={4.8}
               >
                 <Card
                   className="has-featured"
                   href="/"
+                  target="_self"
                 >
                   <a
                     className="ui card has-featured"
                     href="/"
                     onClick={[Function]}
+                    target="_self"
                   >
                     <ResponsiveImage
                       alternativeText="Image Widget"
@@ -1386,16 +1398,19 @@ exports[`<FeaturedProperties /> if \`props.isShowingPlaceholder\` === true and \
                 propertyName=""
                 propertyType=""
                 propertyUrl=""
+                propertyUrlTarget="_self"
                 ratingNumber={0}
               >
                 <Card
                   className="has-featured"
                   href=""
+                  target="_self"
                 >
                   <div
                     className="ui card has-featured"
                     href=""
                     onClick={[Function]}
+                    target="_self"
                   >
                     <BlockPlaceholder
                       isFluid={false}
@@ -1506,16 +1521,19 @@ exports[`<FeaturedProperties /> if \`props.isShowingPlaceholder\` === true and \
                 propertyName=""
                 propertyType=""
                 propertyUrl=""
+                propertyUrlTarget="_self"
                 ratingNumber={0}
               >
                 <Card
                   className="has-featured"
                   href=""
+                  target="_self"
                 >
                   <div
                     className="ui card has-featured"
                     href=""
                     onClick={[Function]}
+                    target="_self"
                   >
                     <BlockPlaceholder
                       isFluid={false}
@@ -1626,16 +1644,19 @@ exports[`<FeaturedProperties /> if \`props.isShowingPlaceholder\` === true and \
                 propertyName=""
                 propertyType=""
                 propertyUrl=""
+                propertyUrlTarget="_self"
                 ratingNumber={0}
               >
                 <Card
                   className="has-featured"
                   href=""
+                  target="_self"
                 >
                   <div
                     className="ui card has-featured"
                     href=""
                     onClick={[Function]}
+                    target="_self"
                   >
                     <BlockPlaceholder
                       isFluid={false}

--- a/src/components/general-widgets/FeaturedProperty/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/FeaturedProperty/__snapshots__/component.spec.js.snap
@@ -4,6 +4,7 @@ exports[`<FeaturedProperty /> if \`props.isShowingPlaceholder\` is passed should
 <Card
   className="has-featured"
   href="/"
+  target="_self"
 >
   <BlockPlaceholder
     isFluid={false}
@@ -43,6 +44,7 @@ exports[`<FeaturedProperty /> should render the right structure 1`] = `
 <Card
   className="has-featured"
   href="/"
+  target="_self"
 >
   <ResponsiveImage
     alternativeText="Image Widget"

--- a/src/components/general-widgets/FeaturedProperty/component.js
+++ b/src/components/general-widgets/FeaturedProperty/component.js
@@ -29,8 +29,9 @@ export const Component = ({
   propertyType,
   propertyUrl,
   ratingNumber,
+  propertyUrlTarget,
 }) => (
-  <Card className="has-featured" href={propertyUrl}>
+  <Card className="has-featured" href={propertyUrl} target={propertyUrlTarget}>
     {isShowingPlaceholder ? (
       getCardPlaceholderMarkup()
     ) : (
@@ -71,6 +72,7 @@ Component.defaultProps = {
   imageSrcSet: undefined,
   isShowingPlaceholder: false,
   placeholderImageUrl: undefined,
+  propertyUrlTarget: '_self',
 };
 
 Component.propTypes = {
@@ -100,6 +102,8 @@ Component.propTypes = {
   propertyType: PropTypes.string.isRequired,
   /** URL pointing to a page with details of the property. */
   propertyUrl: PropTypes.string.isRequired,
+  /** Specifies where to display the linked featured property URL. See [MDN docs `<a />` for more](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-target). */
+  propertyUrlTarget: PropTypes.string,
   /** The numeral rating for the property, out of 5 */
   ratingNumber: PropTypes.number.isRequired,
 };

--- a/src/components/general-widgets/FeaturedRoomType/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/FeaturedRoomType/__snapshots__/component.spec.js.snap
@@ -4,6 +4,7 @@ exports[`<FeaturedRoomType /> if \`props.isShowingPlaceholder\` is \`true\` shou
 <Card
   className="has-featured"
   href="/"
+  target="_self"
 >
   <BlockPlaceholder
     isFluid={false}
@@ -43,6 +44,7 @@ exports[`<FeaturedRoomType /> should render the right structure 1`] = `
 <Card
   className="has-featured"
   href="/"
+  target="_self"
 >
   <ResponsiveImage
     alternativeText="this alt tag"

--- a/src/components/general-widgets/FeaturedRoomType/component.js
+++ b/src/components/general-widgets/FeaturedRoomType/component.js
@@ -27,8 +27,9 @@ export const Component = ({
   placeholderImageUrl,
   roomTypeName,
   roomTypeUrl,
+  roomTypeUrlTarget,
 }) => (
-  <Card className="has-featured" href={roomTypeUrl}>
+  <Card className="has-featured" href={roomTypeUrl} target={roomTypeUrlTarget}>
     {isShowingPlaceholder ? (
       getCardPlaceholderMarkup()
     ) : (
@@ -69,6 +70,7 @@ Component.defaultProps = {
   imageSrcSet: undefined,
   placeholderImageUrl: undefined,
   isShowingPlaceholder: false,
+  roomTypeUrlTarget: '_self',
 };
 
 Component.propTypes = {
@@ -100,4 +102,6 @@ Component.propTypes = {
   roomTypeName: PropTypes.string.isRequired,
   /** URL pointing to a page with details of the room. */
   roomTypeUrl: PropTypes.string.isRequired,
+  /** Specifies where to display the linked featured room type URL. See [MDN docs `<a />` for more](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-target). */
+  roomTypeUrlTarget: PropTypes.string,
 };

--- a/src/components/general-widgets/FeaturedRoomTypes/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/FeaturedRoomTypes/__snapshots__/component.spec.js.snap
@@ -70,15 +70,18 @@ exports[`<FeaturedRoomTypes /> by default should render the right structure 1`] 
                 ratingNumber={4.8}
                 roomTypeName="The Cat House"
                 roomTypeUrl="/"
+                roomTypeUrlTarget="_self"
               >
                 <Card
                   className="has-featured"
                   href="/"
+                  target="_self"
                 >
                   <a
                     className="ui card has-featured"
                     href="/"
                     onClick={[Function]}
+                    target="_self"
                   >
                     <ResponsiveImage
                       alternativeText="Image Widget"
@@ -214,15 +217,18 @@ exports[`<FeaturedRoomTypes /> by default should render the right structure 1`] 
                 ratingNumber={4.8}
                 roomTypeName="The Cat House"
                 roomTypeUrl="/"
+                roomTypeUrlTarget="_self"
               >
                 <Card
                   className="has-featured"
                   href="/"
+                  target="_self"
                 >
                   <a
                     className="ui card has-featured"
                     href="/"
                     onClick={[Function]}
+                    target="_self"
                   >
                     <ResponsiveImage
                       alternativeText="Image Widget"
@@ -380,15 +386,18 @@ exports[`<FeaturedRoomTypes /> if \`props.featuredRoomTypes\` length === 0 and \
                 nightPrice=""
                 roomTypeName=""
                 roomTypeUrl=""
+                roomTypeUrlTarget="_self"
               >
                 <Card
                   className="has-featured"
                   href=""
+                  target="_self"
                 >
                   <div
                     className="ui card has-featured"
                     href=""
                     onClick={[Function]}
+                    target="_self"
                   >
                     <BlockPlaceholder
                       isFluid={false}
@@ -500,15 +509,18 @@ exports[`<FeaturedRoomTypes /> if \`props.featuredRoomTypes\` length === 0 and \
                 nightPrice=""
                 roomTypeName=""
                 roomTypeUrl=""
+                roomTypeUrlTarget="_self"
               >
                 <Card
                   className="has-featured"
                   href=""
+                  target="_self"
                 >
                   <div
                     className="ui card has-featured"
                     href=""
                     onClick={[Function]}
+                    target="_self"
                   >
                     <BlockPlaceholder
                       isFluid={false}
@@ -620,15 +632,18 @@ exports[`<FeaturedRoomTypes /> if \`props.featuredRoomTypes\` length === 0 and \
                 nightPrice=""
                 roomTypeName=""
                 roomTypeUrl=""
+                roomTypeUrlTarget="_self"
               >
                 <Card
                   className="has-featured"
                   href=""
+                  target="_self"
                 >
                   <div
                     className="ui card has-featured"
                     href=""
                     onClick={[Function]}
+                    target="_self"
                   >
                     <BlockPlaceholder
                       isFluid={false}
@@ -820,15 +835,18 @@ exports[`<FeaturedRoomTypes /> if \`props.headingText\` is passed should render 
                 ratingNumber={4.8}
                 roomTypeName="The Cat House"
                 roomTypeUrl="/"
+                roomTypeUrlTarget="_self"
               >
                 <Card
                   className="has-featured"
                   href="/"
+                  target="_self"
                 >
                   <a
                     className="ui card has-featured"
                     href="/"
                     onClick={[Function]}
+                    target="_self"
                   >
                     <ResponsiveImage
                       alternativeText="Image Widget"
@@ -964,15 +982,18 @@ exports[`<FeaturedRoomTypes /> if \`props.headingText\` is passed should render 
                 ratingNumber={4.8}
                 roomTypeName="The Cat House"
                 roomTypeUrl="/"
+                roomTypeUrlTarget="_self"
               >
                 <Card
                   className="has-featured"
                   href="/"
+                  target="_self"
                 >
                   <a
                     className="ui card has-featured"
                     href="/"
                     onClick={[Function]}
+                    target="_self"
                   >
                     <ResponsiveImage
                       alternativeText="Image Widget"

--- a/src/components/general-widgets/HomepageHero/component.js
+++ b/src/components/general-widgets/HomepageHero/component.js
@@ -183,9 +183,12 @@ Component.propTypes = {
       subItems: PropTypes.arrayOf(
         PropTypes.shape({
           href: PropTypes.string.isRequired,
+          target: PropTypes.string,
           text: PropTypes.string.isRequired,
         })
       ),
+      /** Specifies where to display the linked header navigation items URL. See [MDN docs `<a />` for more](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-target). */
+      target: PropTypes.string,
       /** The visible text for an item. */
       text: PropTypes.string.isRequired,
     })

--- a/src/components/property-page-widgets/PropertyPageHero/component.js
+++ b/src/components/property-page-widgets/PropertyPageHero/component.js
@@ -95,9 +95,12 @@ Component.propTypes = {
       subItems: PropTypes.arrayOf(
         PropTypes.shape({
           href: PropTypes.string.isRequired,
+          target: PropTypes.string,
           text: PropTypes.string.isRequired,
         })
       ),
+      /** Specifies where to display the linked header navigation items URL. See [MDN docs `<a />` for more](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-target). */
+      target: PropTypes.string,
       /** The visible text for an item. */
       text: PropTypes.string.isRequired,
     })


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1913)

### What **one** thing does this PR do?
Menu items now have the option to open in a new tab.

### Any other notes
- `CookieAlert` more info link now opens in a new tab as requested.

Showing examples of working implementation for `Submenu`, `Header`, `FeaturedProperty`, `FeaturedRoomType` and `CookieAlert` as the rest are just pass throughs.

#### Submenu
![kapture 2019-02-25 at 17 27 15](https://user-images.githubusercontent.com/10498995/53352199-a3208700-3922-11e9-8f23-efb7cafdffd3.gif)

#### Header
![kapture 2019-02-25 at 17 29 51](https://user-images.githubusercontent.com/10498995/53352426-05798780-3923-11e9-826f-ba5b4c5cb2d1.gif)
![kapture 2019-02-25 at 17 32 53](https://user-images.githubusercontent.com/10498995/53352620-699c4b80-3923-11e9-9168-284152db5dc0.gif)

#### FeaturedProperty
![kapture 2019-02-25 at 17 42 00](https://user-images.githubusercontent.com/10498995/53353295-af0d4880-3924-11e9-876e-58c14bf48e43.gif)

#### FeaturedRoomType
![kapture 2019-02-25 at 17 42 49](https://user-images.githubusercontent.com/10498995/53353340-cba98080-3924-11e9-9048-92c6bc7ec16a.gif)

#### CookieAlert
![kapture 2019-02-25 at 17 41 09](https://user-images.githubusercontent.com/10498995/53353222-8dac5c80-3924-11e9-8b61-72f43f6fb6ed.gif)
