### PR TITLE
TE-1940 Expose header logo href

### DIFF
--- a/src/components/collections/Header/__snapshots__/component.spec.js.snap
+++ b/src/components/collections/Header/__snapshots__/component.spec.js.snap
@@ -5,6 +5,7 @@ exports[`<Header /> by default should render the right structure 1`] = `
   activeNavigationItemIndex={null}
   dateRangePickerLocaleCode="ko"
   isBackgroundFilled={false}
+  logoHref="/"
   logoSrc={null}
   logoText="someLogoText"
   navigationItems={
@@ -445,6 +446,7 @@ exports[`<Header /> if \`isMenuHidden\` is \`true\` should render the right stru
   activeNavigationItemIndex={null}
   dateRangePickerLocaleCode="ko"
   isBackgroundFilled={false}
+  logoHref="/"
   logoSrc={null}
   logoText="someLogoText"
   navigationItems={
@@ -792,6 +794,7 @@ exports[`<Header /> if \`props.isBackgroundFilled\` is true should render the ri
   activeNavigationItemIndex={null}
   dateRangePickerLocaleCode="ko"
   isBackgroundFilled={true}
+  logoHref="/"
   logoSrc={null}
   logoText="someLogoText"
   navigationItems={

--- a/src/components/collections/Header/component.js
+++ b/src/components/collections/Header/component.js
@@ -57,6 +57,7 @@ export class Component extends PureComponent {
   render = () => {
     const {
       isBackgroundFilled,
+      logoHref,
       logoText,
       logoSrc,
       logoSizes,
@@ -73,7 +74,7 @@ export class Component extends PureComponent {
         ref={this.createHeaderRef}
       >
         <HorizontalGutters as={Menu} borderless text>
-          {getLogoMarkup(logoText, logoSrc, logoSizes, logoSrcSet)}
+          {getLogoMarkup(logoHref, logoText, logoSrc, logoSizes, logoSrcSet)}
           <Menu.Menu position="right">
             {isMenuHidden
               ? getHiddenMenuMarkup(this.props)
@@ -90,6 +91,7 @@ Component.displayName = 'Header';
 Component.defaultProps = {
   activeNavigationItemIndex: null,
   isBackgroundFilled: false,
+  logoHref: '/',
   logoSizes: undefined,
   logoSrc: null,
   logoSrcSet: undefined,
@@ -102,6 +104,8 @@ Component.propTypes = {
   activeNavigationItemIndex: PropTypes.number,
   /** Is the background filled with a color defined in CSS. */
   isBackgroundFilled: PropTypes.bool,
+  /** The href for the logo link. */
+  logoHref: PropTypes.string,
   /** A list of one or more strings separated by commas indicating a set of source sizes for the logo. See [the MDN docs for more information](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img). */
   logoSizes: PropTypes.string,
   /** The src url for the logo. */

--- a/src/components/collections/Header/component.spec.js
+++ b/src/components/collections/Header/component.spec.js
@@ -15,7 +15,6 @@ import { getMenuWidth } from './utils/getMenuWidth';
 import { getIsMenuHidden } from './utils/getIsMenuHidden';
 
 const logoText = 'someLogoText';
-
 const props = {
   logoText,
   navigationItems,

--- a/src/components/collections/Header/utils/__snapshots__/getHiddenMenuMarkup.spec.js.snap
+++ b/src/components/collections/Header/utils/__snapshots__/getHiddenMenuMarkup.spec.js.snap
@@ -98,7 +98,6 @@ Array [
           content={
             Array [
               <MenuItem
-                href="/"
                 link={true}
               >
                 <Image

--- a/src/components/collections/Header/utils/__snapshots__/getLogoMarkup.spec.js.snap
+++ b/src/components/collections/Header/utils/__snapshots__/getLogoMarkup.spec.js.snap
@@ -2,12 +2,12 @@
 
 exports[`getLogoMarkup by default should render the right structure 1`] = `
 <MenuItem
-  href="/"
+  href="someLogoHref"
   link={true}
 >
   <a
     className="link item"
-    href="/"
+    href="someLogoHref"
     onClick={[Function]}
   >
     <Heading
@@ -35,12 +35,12 @@ exports[`getLogoMarkup by default should render the right structure 1`] = `
 
 exports[`getLogoMarkup if \`logoSrc\`, \`logoSizes\` and \`logoSrcSet\` are passed should render the right structure 1`] = `
 <MenuItem
-  href="/"
+  href="someLogoHref"
   link={true}
 >
   <a
     className="link item"
-    href="/"
+    href="someLogoHref"
     onClick={[Function]}
   >
     <Image

--- a/src/components/collections/Header/utils/getHiddenMenuMarkup.js
+++ b/src/components/collections/Header/utils/getHiddenMenuMarkup.js
@@ -23,6 +23,7 @@ import { getLinkMarkup } from './getLinkMarkup';
 export const getHiddenMenuMarkup = ({
   /* eslint-disable react/prop-types */
   activeNavigationItemIndex,
+  logoHref,
   logoSizes,
   logoSrc,
   logoSrcSet,
@@ -41,7 +42,7 @@ export const getHiddenMenuMarkup = ({
     )}
     <Menu.Item className="no-underline">
       <Modal isFullscreen trigger={<Icon name={ICON_NAMES.BARS} />}>
-        {getLogoMarkup(logoText, logoSrc, logoSizes, logoSrcSet)}
+        {getLogoMarkup(logoHref, logoText, logoSrc, logoSizes, logoSrcSet)}
         <Menu text vertical>
           {navigationItems.map(
             ({ subItems, text, target: navigationItemTarget, href }, index) =>

--- a/src/components/collections/Header/utils/getLogoMarkup.js
+++ b/src/components/collections/Header/utils/getLogoMarkup.js
@@ -4,14 +4,21 @@ import { Menu, Image } from 'semantic-ui-react';
 import { Heading } from 'typography/Heading';
 
 /**
+ * @param  {string} logoHref
  * @param  {string} logoText
  * @param  {string} logoSrc
  * @param  {string} logoSizes
  * @param  {string} logoSrcSet
  * @return {Object}
  */
-export const getLogoMarkup = (logoText, logoSrc, logoSizes, logoSrcSet) => (
-  <Menu.Item href="/" link>
+export const getLogoMarkup = (
+  logoHref,
+  logoText,
+  logoSrc,
+  logoSizes,
+  logoSrcSet
+) => (
+  <Menu.Item href={logoHref} link>
     {logoSrc ? (
       <Image
         alt={logoText}

--- a/src/components/collections/Header/utils/getLogoMarkup.spec.js
+++ b/src/components/collections/Header/utils/getLogoMarkup.spec.js
@@ -2,13 +2,14 @@ import { mount } from 'enzyme';
 
 import { getLogoMarkup } from './getLogoMarkup';
 
+const logoHref = 'someLogoHref';
 const logoText = 'someLogoText';
 const logoSrc = 'someLogoSrc';
 const sizes = 'someSizes';
 const srcSet = 'someSrcSet';
 
 const getLogoMarkupAsComponent = (props = []) =>
-  mount(getLogoMarkup(logoText, ...props));
+  mount(getLogoMarkup(logoHref, logoText, ...props));
 
 describe('getLogoMarkup', () => {
   describe('by default', () => {

--- a/src/components/collections/Hero/__snapshots__/component.spec.js.snap
+++ b/src/components/collections/Hero/__snapshots__/component.spec.js.snap
@@ -117,6 +117,7 @@ exports[`<Hero /> by default should render the right structure 1`] = `
         <Header
           activeNavigationItemIndex={1}
           isBackgroundFilled={false}
+          logoHref="/"
           logoSizes="a load of logo sizes"
           logoSrc="https://darkgreen.com"
           logoSrcSet="a load of logo src sets"

--- a/src/components/collections/Hero/component.js
+++ b/src/components/collections/Hero/component.js
@@ -19,6 +19,7 @@ export const Component = ({
   backgroundImageWidth,
   bottomOffset,
   children,
+  headerLogoHref,
   headerLogoSizes,
   headerLogoSrc,
   headerLogoSrcSet,
@@ -39,6 +40,7 @@ export const Component = ({
   >
     <Header
       activeNavigationItemIndex={activeNavigationItemIndex}
+      logoHref={headerLogoHref}
       logoSizes={headerLogoSizes}
       logoSrc={headerLogoSrc}
       logoSrcSet={headerLogoSrcSet}
@@ -60,6 +62,7 @@ Component.defaultProps = {
   backgroundImageWidth: undefined,
   bottomOffset: DEFAULT_BOTTOM_OFFSET,
   children: null,
+  headerLogoHref: undefined,
   headerLogoSizes: undefined,
   headerLogoSrc: null,
   headerLogoSrcSet: undefined,
@@ -90,6 +93,8 @@ Component.propTypes = {
   bottomOffset: PropTypes.string,
   /** The children displayed between the header and the bottom of the hero. */
   children: PropTypes.node,
+  /** The href for the header logo link. */
+  headerLogoHref: PropTypes.string,
   /** A list of one or more strings separated by commas indicating a set of source sizes for the header logo. See [the MDN docs for more information](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img). */
   headerLogoSizes: PropTypes.string,
   /** The src url for the logo in the header. */

--- a/src/components/general-widgets/HomepageHero/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/HomepageHero/__snapshots__/component.spec.js.snap
@@ -149,6 +149,7 @@ exports[`HomepageHero should render the right structure 1`] = `
           <Header
             activeNavigationItemIndex={1}
             isBackgroundFilled={false}
+            logoHref="/"
             logoSizes="a load of logo sizes"
             logoSrc="src"
             logoSrcSet="a load of logo src sets"

--- a/src/components/general-widgets/HomepageHero/component.js
+++ b/src/components/general-widgets/HomepageHero/component.js
@@ -22,6 +22,7 @@ export const Component = ({
   backgroundImageSrcSet,
   backgroundImageUrl,
   backgroundImageWidth,
+  headerLogoHref,
   headerLogoSizes,
   headerLogoSrc,
   headerLogoSrcSet,
@@ -46,6 +47,7 @@ export const Component = ({
     backgroundImageSrcSet={backgroundImageSrcSet}
     backgroundImageUrl={backgroundImageUrl}
     backgroundImageWidth={backgroundImageWidth}
+    headerLogoHref={headerLogoHref}
     headerLogoSizes={headerLogoSizes}
     headerLogoSrc={headerLogoSrc}
     headerLogoSrcSet={headerLogoSrcSet}
@@ -132,6 +134,7 @@ Component.defaultProps = {
   backgroundImageSizes: undefined,
   backgroundImageSrcSet: undefined,
   backgroundImageWidth: undefined,
+  headerLogoHref: undefined,
   headerLogoSizes: undefined,
   headerLogoSrc: null,
   headerLogoSrcSet: undefined,
@@ -166,6 +169,8 @@ Component.propTypes = {
     PropTypes.string,
     PropTypes.number,
   ]),
+  /** The href for the header logo link. */
+  headerLogoHref: PropTypes.string,
   /** A list of one or more strings separated by commas indicating a set of source sizes for the header logo. See [the MDN docs for more information](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img). */
   headerLogoSizes: PropTypes.string,
   /** The src url for the logo in the header. */

--- a/src/components/property-page-widgets/PropertyPageHero/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/PropertyPageHero/__snapshots__/component.spec.js.snap
@@ -130,6 +130,7 @@ exports[`PropertyPageHero if there are fewer than two images should render the r
           <Header
             activeNavigationItemIndex={1}
             isBackgroundFilled={false}
+            logoHref="/"
             logoSizes="a load of logo sizes"
             logoSrc="src"
             logoSrcSet="a load of logo src sets"
@@ -408,6 +409,7 @@ exports[`PropertyPageHero should render the right structure 1`] = `
           <Header
             activeNavigationItemIndex={1}
             isBackgroundFilled={false}
+            logoHref="/"
             logoSizes="a load of logo sizes"
             logoSrc="src"
             logoSrcSet="a load of logo src sets"

--- a/src/components/property-page-widgets/PropertyPageHero/component.js
+++ b/src/components/property-page-widgets/PropertyPageHero/component.js
@@ -14,6 +14,7 @@ import { getGalleryMarkup } from './utils/getGalleryMarkup';
 // eslint-disable-next-line jsdoc/require-jsdoc
 const Component = ({
   activeNavigationItemIndex,
+  headerLogoHref,
   headerLogoSizes,
   headerLogoSrc,
   headerLogoSrcSet,
@@ -43,6 +44,7 @@ const Component = ({
       backgroundImageUrl={backgroundImageUrl}
       backgroundImageWidth={backgroundImageWidth}
       bottomOffset={BOTTOM_OFFSET}
+      headerLogoHref={headerLogoHref}
       headerLogoSizes={headerLogoSizes}
       headerLogoSrc={headerLogoSrc}
       headerLogoSrcSet={headerLogoSrcSet}
@@ -66,6 +68,7 @@ Component.displayName = 'PropertyPageHero';
 
 Component.defaultProps = {
   activeNavigationItemIndex: null,
+  headerLogoHref: undefined,
   headerLogoSizes: undefined,
   headerLogoSrc: null,
   headerLogoSrcSet: undefined,
@@ -78,6 +81,8 @@ Component.defaultProps = {
 Component.propTypes = {
   /** The index of the active navigation item. */
   activeNavigationItemIndex: PropTypes.number,
+  /** The href for the header logo link. */
+  headerLogoHref: PropTypes.string,
   /** A list of one or more strings separated by commas indicating a set of source sizes for the header logo. See [the MDN docs for more information](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img). */
   headerLogoSizes: PropTypes.string,
   /** The src url for the logo in the header. */


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1940)

### What **one** thing does this PR do?
Exposes `logoHref` and `headerLogoHref` prop in `Header`, `Hero`, `HomepageHero` and `PropertyPageHero` so that consumers can choose where the logo link takes someone on click.

