### PR TITLE
TE-1941 Review component: Change the order for reviewerLocation and reviewerName

### DIFF
--- a/src/components/general-widgets/Review/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/Review/__snapshots__/component.spec.js.snap
@@ -274,7 +274,7 @@ exports[`<Review /> if \`props.reviewResponse\` is passed should render the righ
                                   <span
                                     className="ui sub header"
                                   >
-                                    someLocation (someName)
+                                    someName (someLocation)
                                   </span>
                                 </Subheading>
                               </div>
@@ -703,7 +703,7 @@ exports[`<Review /> should render the right structure 1`] = `
                                   <span
                                     className="ui sub header"
                                   >
-                                    someLocation (someName)
+                                    someName (someLocation)
                                   </span>
                                 </Subheading>
                               </div>

--- a/src/components/general-widgets/Review/utils/getReviewerNameAndLocationString.js
+++ b/src/components/general-widgets/Review/utils/getReviewerNameAndLocationString.js
@@ -6,4 +6,4 @@
 export const getReviewerNameAndLocationString = (
   reviewerLocation,
   reviewerName
-) => `${reviewerName} (${reviewerLocation})`;
+) => `${reviewerLocation} (${reviewerName})`;

--- a/src/components/general-widgets/Review/utils/getReviewerNameAndLocationString.spec.js
+++ b/src/components/general-widgets/Review/utils/getReviewerNameAndLocationString.spec.js
@@ -1,7 +1,7 @@
 import { getReviewerNameAndLocationString } from './getReviewerNameAndLocationString';
 
 describe('getReviewerNameAndLocationString', () => {
-  it('should return a string composed from the `reviewerName` and `reviewerLocation` arguments', () => {
+  it('should return a string composed from the`reviewerLocation` and `reviewerName` arguments', () => {
     const reviewerLocation = 'someLabel';
     const reviewerName = '🚣';
     const actual = getReviewerNameAndLocationString(
@@ -9,6 +9,6 @@ describe('getReviewerNameAndLocationString', () => {
       reviewerName
     );
 
-    expect(actual).toBe(`${reviewerName} (${reviewerLocation})`);
+    expect(actual).toBe(`${reviewerLocation} (${reviewerName})`);
   });
 });

--- a/src/components/property-page-widgets/Reviews/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Reviews/__snapshots__/component.spec.js.snap
@@ -2866,7 +2866,7 @@ exports[`<Reviews /> should render the right structure 1`] = `
                                                       <span
                                                         className="ui sub header"
                                                       >
-                                                        Lithuania (Magellan)
+                                                        Magellan (Lithuania)
                                                       </span>
                                                     </Subheading>
                                                   </div>
@@ -3334,7 +3334,7 @@ exports[`<Reviews /> should render the right structure 1`] = `
                                                       <span
                                                         className="ui sub header"
                                                       >
-                                                        Lithuania (Magellan)
+                                                        Magellan (Lithuania)
                                                       </span>
                                                     </Subheading>
                                                   </div>


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1941)

### What **one** thing does this PR do?
Swaps  the order of `reviewerLocation` and `reviewerName`

### Any other notes
<img width="542" alt="screenshot 2019-03-01 at 12 13 34" src="https://user-images.githubusercontent.com/33876435/53634886-c6498000-3c1b-11e9-8bc3-6b8a94ca60e4.png">
