### PR TITLE
TE-1943 Remove focus state from Rating components which are not an input

### DIFF
--- a/src/styles/semantic/themes/livingstone/modules/rating.overrides
+++ b/src/styles/semantic/themes/livingstone/modules/rating.overrides
@@ -10,8 +10,12 @@
   --------------------*/
 
   /* Standard */
-  .icon:before {
-    content: '\2605';
+  .icon {
+    outline-width: 0;
+
+    &:before {
+      content: '\2605';
+    }
   }
 
   /* Star */
@@ -25,4 +29,7 @@
   /*-------------------
         Variations
   --------------------*/
+  .modal & .icon {
+    outline-width: @inputRatingOutline;
+  }
 }

--- a/src/styles/semantic/themes/livingstone/modules/rating.variables
+++ b/src/styles/semantic/themes/livingstone/modules/rating.variables
@@ -28,3 +28,4 @@
 /*-------------------
       Variations
 --------------------*/
+@inputRatingOutline: 4px;


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1943)

### What **one** thing does this PR do?
Removes the focus outline for all `Rating` components that are not an input

### Any other notes
![kapture 2019-03-01 at 13 37 44](https://user-images.githubusercontent.com/33876435/53638914-13cbea00-3c28-11e9-9ecb-51c4dcd2d522.gif)

