### PR TITLE
TE-1915 Promotion: respect background image aspect ratio

### DIFF
--- a/src/styles/semantic/themes/livingstone/elements/segment.overrides
+++ b/src/styles/semantic/themes/livingstone/elements/segment.overrides
@@ -248,12 +248,22 @@
     }
 
     > figure.responsive-image {
-      z-index: @promotionBeforeLayerZIndex;
+      height: 100%;
+      left: 0;
       position: absolute;
       top: 0;
-      bottom: 0;
-      right: 0;
-      left: 0;
+      width: 100%;
+      z-index: @promotionBeforeLayerZIndex;
+
+      > img {
+        left: 50%;
+        max-width: none;
+        min-height: 100%;
+        position: absolute;
+        top: 50%;
+        transform: translate(-50%, -50%);
+        width: auto;
+      }
     }
 
     p,


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1915)

### What **one** thing does this PR do?
`Promotion`: respect background image aspect ratio

For these examples I am using the same image as https://npreview-mos-eisley.lodgifyintegration.com/en/1208320/promotion-widget ...

![screenshot 2019-03-04 at 12 29 39](https://user-images.githubusercontent.com/8591501/53730919-8aabf180-3e79-11e9-8026-b0beccb0a4f1.png)
![screenshot 2019-03-04 at 12 28 59](https://user-images.githubusercontent.com/8591501/53730920-8aabf180-3e79-11e9-910e-bd3b85be4403.png)
![screenshot 2019-03-04 at 12 28 36](https://user-images.githubusercontent.com/8591501/53730922-8b448800-3e79-11e9-8aa4-40f559fc007c.png)

