### PR TITLE
TE-1856 Remove `.isRequired` from `Footer.props.phoneNumber`

### DIFF
--- a/src/components/collections/Footer/component.js
+++ b/src/components/collections/Footer/component.js
@@ -122,6 +122,7 @@ Component.defaultProps = {
   currencyValue: null,
   languageOptions: [],
   languageValue: null,
+  phoneNumber: null,
   socialMediaLinks: [],
 };
 
@@ -198,7 +199,7 @@ Component.propTypes = {
    */
   onChangeLanguage: PropTypes.func.isRequired,
   /** The phone number to display */
-  phoneNumber: PropTypes.string.isRequired,
+  phoneNumber: PropTypes.string,
   /** The address of the property */
   propertyAddress: PropTypes.string.isRequired,
   /** The links to social media accounts to display. */


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1856)

### What **one** thing does this PR do?
Remove `.isRequired` from `Footer.props.phoneNumber`

### Any other notes
The other changed required in the ticket has already been solved in some other PR.
