### PR TITLE
TE-1848 Remove terser from dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,6 @@
     "style-loader": "^0.20.2",
     "stylelint": "^9.7.0",
     "stylelint-config-standard": "^18.2.0",
-    "terser": "3.14.1",
     "webpack": "^4.19.0",
     "webpack-cli": "^3.0.0"
   },


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1848)

### What **one** thing does this PR do?
Removes Terser from dev dependencies as it's no longer needed as a work around for a problem within webpack.
