### PR TITLE
TE-1957 PropertyPageSearchBar placeholders

### DIFF
--- a/src/components/property-page-widgets/PropertyPageSearchBar/Readme.md
+++ b/src/components/property-page-widgets/PropertyPageSearchBar/Readme.md
@@ -26,7 +26,7 @@ const displayAsFixed = false;
 const { guestsOptions } = require('./mock-data/options');
 
 // Please set this to true to see the example
-const displayAsFixed = true;
+const displayAsFixed = false;
 
 <PropertyPageSearchBar
   isFixed={displayAsFixed}


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1957)

### What **one** thing does this PR do?
Docs should display the search bars as inline widgets not as fixed bars by default.
