### PR TITLE
TE-1991 Remove underline from cards wrapped by <a> on Safari

### DIFF
--- a/src/styles/semantic/themes/livingstone/views/card.overrides
+++ b/src/styles/semantic/themes/livingstone/views/card.overrides
@@ -116,7 +116,7 @@
 
   /* Link */
   a& {
-    text-decoration-line: none;
+    text-decoration: none;
   }
 
   /* Raised */


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1991)

### What **one** thing does this PR do?
Removes the underline from all text in a card that is wrapped by an `<a>`.

### Any other notes
The issue was caused by the `text-decoration-line` property which isn't supported by ie 11 or older versions of safari. `text-decoration: none;` didn't seem to cause any regression.

![image](https://user-images.githubusercontent.com/10498995/54191054-6d000d00-44b5-11e9-8984-36de12e018b8.png)
