### PR TITLE
TE-1904 Persist search value with a cookie

### DIFF
--- a/src/components/general-widgets/CallMeBack/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/CallMeBack/__snapshots__/component.spec.js.snap
@@ -460,6 +460,7 @@ exports[`<CallMeBack /> if there is no \`props.propertyOptions\` should have the
                         <Dropdown
                           error={false}
                           icon="clock"
+                          initialValue={null}
                           isDisabled={false}
                           isSearchable={false}
                           isValid={false}
@@ -533,7 +534,6 @@ exports[`<CallMeBack /> if there is no \`props.propertyOptions\` should have the
                               additionPosition="top"
                               closeOnBlur={true}
                               deburr={false}
-                              defaultValue={null}
                               disabled={false}
                               icon={
                                 <Icon
@@ -593,6 +593,7 @@ exports[`<CallMeBack /> if there is no \`props.propertyOptions\` should have the
                               selectOnNavigation={true}
                               selection={true}
                               upward={false}
+                              value={null}
                               wrapSelection={true}
                             >
                               <div
@@ -1440,6 +1441,7 @@ exports[`<CallMeBack /> should have the correct structure 1`] = `
                         <Dropdown
                           error={false}
                           icon="clock"
+                          initialValue={null}
                           isDisabled={false}
                           isSearchable={false}
                           isValid={false}
@@ -1513,7 +1515,6 @@ exports[`<CallMeBack /> should have the correct structure 1`] = `
                               additionPosition="top"
                               closeOnBlur={true}
                               deburr={false}
-                              defaultValue={null}
                               disabled={false}
                               icon={
                                 <Icon
@@ -1573,6 +1574,7 @@ exports[`<CallMeBack /> should have the correct structure 1`] = `
                               selectOnNavigation={true}
                               selection={true}
                               upward={false}
+                              value={null}
                               wrapSelection={true}
                             >
                               <div
@@ -1849,6 +1851,7 @@ exports[`<CallMeBack /> should have the correct structure 1`] = `
                     <Dropdown
                       error={false}
                       icon={null}
+                      initialValue={null}
                       isDisabled={false}
                       isSearchable={false}
                       isValid={false}
@@ -1887,7 +1890,6 @@ exports[`<CallMeBack /> should have the correct structure 1`] = `
                           additionPosition="top"
                           closeOnBlur={true}
                           deburr={false}
-                          defaultValue={null}
                           disabled={false}
                           icon={
                             <Icon
@@ -1939,6 +1941,7 @@ exports[`<CallMeBack /> should have the correct structure 1`] = `
                           selectOnNavigation={true}
                           selection={true}
                           upward={false}
+                          value={null}
                           wrapSelection={true}
                         >
                           <div

--- a/src/components/general-widgets/Contact/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/Contact/__snapshots__/component.spec.js.snap
@@ -643,6 +643,7 @@ exports[`<Contact /> if \`propertyOptions\` and \`roomOptions\` are passed shoul
                         <Dropdown
                           error={false}
                           icon={null}
+                          initialValue={null}
                           isDisabled={false}
                           isSearchable={false}
                           isValid={false}
@@ -681,7 +682,6 @@ exports[`<Contact /> if \`propertyOptions\` and \`roomOptions\` are passed shoul
                               additionPosition="top"
                               closeOnBlur={true}
                               deburr={false}
-                              defaultValue={null}
                               disabled={false}
                               icon={
                                 <Icon
@@ -733,6 +733,7 @@ exports[`<Contact /> if \`propertyOptions\` and \`roomOptions\` are passed shoul
                               selectOnNavigation={true}
                               selection={true}
                               upward={false}
+                              value={null}
                               wrapSelection={true}
                             >
                               <div
@@ -941,6 +942,7 @@ exports[`<Contact /> if \`propertyOptions\` and \`roomOptions\` are passed shoul
                         <Dropdown
                           error={false}
                           icon={null}
+                          initialValue={null}
                           isDisabled={false}
                           isSearchable={false}
                           isValid={false}
@@ -975,7 +977,6 @@ exports[`<Contact /> if \`propertyOptions\` and \`roomOptions\` are passed shoul
                               additionPosition="top"
                               closeOnBlur={true}
                               deburr={false}
-                              defaultValue={null}
                               disabled={false}
                               icon={
                                 <Icon
@@ -1023,6 +1024,7 @@ exports[`<Contact /> if \`propertyOptions\` and \`roomOptions\` are passed shoul
                               selectOnNavigation={true}
                               selection={true}
                               upward={false}
+                              value={null}
                               wrapSelection={true}
                             >
                               <div
@@ -1862,6 +1864,7 @@ exports[`<Contact /> if \`props.propertyOptions\` is passed should have the corr
                         <Dropdown
                           error={false}
                           icon={null}
+                          initialValue={null}
                           isDisabled={false}
                           isSearchable={false}
                           isValid={false}
@@ -1900,7 +1903,6 @@ exports[`<Contact /> if \`props.propertyOptions\` is passed should have the corr
                               additionPosition="top"
                               closeOnBlur={true}
                               deburr={false}
-                              defaultValue={null}
                               disabled={false}
                               icon={
                                 <Icon
@@ -1952,6 +1954,7 @@ exports[`<Contact /> if \`props.propertyOptions\` is passed should have the corr
                               selectOnNavigation={true}
                               selection={true}
                               upward={false}
+                              value={null}
                               wrapSelection={true}
                             >
                               <div
@@ -2820,6 +2823,7 @@ exports[`<Contact /> if \`props.roomOptions\` is passed should have the correct 
                         <Dropdown
                           error={false}
                           icon={null}
+                          initialValue={null}
                           isDisabled={false}
                           isSearchable={false}
                           isValid={false}
@@ -2854,7 +2858,6 @@ exports[`<Contact /> if \`props.roomOptions\` is passed should have the correct 
                               additionPosition="top"
                               closeOnBlur={true}
                               deburr={false}
-                              defaultValue={null}
                               disabled={false}
                               icon={
                                 <Icon
@@ -2902,6 +2905,7 @@ exports[`<Contact /> if \`props.roomOptions\` is passed should have the correct 
                               selectOnNavigation={true}
                               selection={true}
                               upward={false}
+                              value={null}
                               wrapSelection={true}
                             >
                               <div

--- a/src/components/general-widgets/HomepageHero/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/HomepageHero/__snapshots__/component.spec.js.snap
@@ -446,7 +446,9 @@ exports[`HomepageHero should render the right structure 1`] = `
                                 >
                                   <SearchBar
                                     className="show-on-tablet show-on-computer show-on-widescreen"
+                                    datesInputInitialValue={null}
                                     getIsDayBlocked={[Function]}
+                                    guestsInputInitialValue={null}
                                     guestsOptions={
                                       Array [
                                         Object {
@@ -458,6 +460,7 @@ exports[`HomepageHero should render the right structure 1`] = `
                                     isDisplayedAsModal={false}
                                     isFixed={false}
                                     isShowingSummary={false}
+                                    locationInputInitialValue={null}
                                     locationOptions={
                                       Array [
                                         Object {
@@ -503,6 +506,7 @@ exports[`HomepageHero should render the right structure 1`] = `
                                                   <Dropdown
                                                     error={false}
                                                     icon="map pin"
+                                                    initialValue={null}
                                                     isDisabled={false}
                                                     isSearchable={false}
                                                     isValid={false}
@@ -556,7 +560,6 @@ exports[`HomepageHero should render the right structure 1`] = `
                                                         additionPosition="top"
                                                         closeOnBlur={true}
                                                         deburr={false}
-                                                        defaultValue={null}
                                                         disabled={false}
                                                         icon={
                                                           <Icon
@@ -596,6 +599,7 @@ exports[`HomepageHero should render the right structure 1`] = `
                                                         selectOnNavigation={true}
                                                         selection={true}
                                                         upward={true}
+                                                        value={null}
                                                         wrapSelection={true}
                                                       >
                                                         <div
@@ -705,6 +709,7 @@ exports[`HomepageHero should render the right structure 1`] = `
                                                   <WithResponsive(DateRangePicker)
                                                     endDatePlaceholderText="Check-out"
                                                     getIsDayBlocked={[Function]}
+                                                    initialValue={null}
                                                     name="dates"
                                                     onChange={[Function]}
                                                     startDatePlaceholderText="Check-in"
@@ -714,6 +719,7 @@ exports[`HomepageHero should render the right structure 1`] = `
                                                       as={[Function]}
                                                       endDatePlaceholderText="Check-out"
                                                       getIsDayBlocked={[Function]}
+                                                      initialValue={null}
                                                       isUserOnMobile={false}
                                                       name="dates"
                                                       onChange={[Function]}
@@ -727,6 +733,7 @@ exports[`HomepageHero should render the right structure 1`] = `
                                                         endDatePlaceholderText="Check-out"
                                                         error={false}
                                                         getIsDayBlocked={[Function]}
+                                                        initialValue={null}
                                                         isUserOnMobile={false}
                                                         isValid={false}
                                                         localeCode="en"
@@ -741,7 +748,7 @@ exports[`HomepageHero should render the right structure 1`] = `
                                                           adaptOnChangeEvent={[Function]}
                                                           error={false}
                                                           icon={null}
-                                                          initialValue=""
+                                                          initialValue={null}
                                                           inputOnChangeFunctionName="onDatesChange"
                                                           isFocused={false}
                                                           isValid={false}
@@ -859,6 +866,7 @@ exports[`HomepageHero should render the right structure 1`] = `
                                                   <Dropdown
                                                     error={false}
                                                     icon="users"
+                                                    initialValue={null}
                                                     isDisabled={false}
                                                     isSearchable={false}
                                                     isValid={false}
@@ -912,7 +920,6 @@ exports[`HomepageHero should render the right structure 1`] = `
                                                         additionPosition="top"
                                                         closeOnBlur={true}
                                                         deburr={false}
-                                                        defaultValue={null}
                                                         disabled={false}
                                                         icon={
                                                           <Icon
@@ -952,6 +959,7 @@ exports[`HomepageHero should render the right structure 1`] = `
                                                         selectOnNavigation={true}
                                                         selection={true}
                                                         upward={true}
+                                                        value={null}
                                                         wrapSelection={true}
                                                       >
                                                         <div
@@ -1083,7 +1091,9 @@ exports[`HomepageHero should render the right structure 1`] = `
                                   >
                                     <SearchBar
                                       className={null}
+                                      datesInputInitialValue={null}
                                       getIsDayBlocked={[Function]}
+                                      guestsInputInitialValue={null}
                                       guestsOptions={
                                         Array [
                                           Object {
@@ -1095,6 +1105,7 @@ exports[`HomepageHero should render the right structure 1`] = `
                                       isDisplayedAsModal={true}
                                       isFixed={false}
                                       isShowingSummary={false}
+                                      locationInputInitialValue={null}
                                       locationOptions={
                                         Array [
                                           Object {

--- a/src/components/general-widgets/HomepageHero/component.js
+++ b/src/components/general-widgets/HomepageHero/component.js
@@ -236,7 +236,11 @@ Component.propTypes = {
    */
   searchBarGetIsDayBlocked: PropTypes.func,
   /** The initial value for the guests input of the search bar. */
-  searchBarGuestsInputInitialValue: PropTypes.string,
+  searchBarGuestsInputInitialValue: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.number,
+    PropTypes.string,
+  ]),
   /** The options which the user can select in the guests fields of the search bar. */
   searchBarGuestsOptions: PropTypes.arrayOf(
     PropTypes.shape({

--- a/src/components/general-widgets/SearchBar/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/SearchBar/__snapshots__/component.spec.js.snap
@@ -99,6 +99,7 @@ exports[`<SearchBar /> by default should render the right structure 1`] = `
                 <Dropdown
                   error={false}
                   icon="map pin"
+                  initialValue={null}
                   isDisabled={false}
                   isSearchable={false}
                   isValid={false}
@@ -164,7 +165,6 @@ exports[`<SearchBar /> by default should render the right structure 1`] = `
                       additionPosition="top"
                       closeOnBlur={true}
                       deburr={false}
-                      defaultValue={null}
                       disabled={false}
                       icon={
                         <Icon
@@ -216,6 +216,7 @@ exports[`<SearchBar /> by default should render the right structure 1`] = `
                       selectOnNavigation={true}
                       selection={true}
                       upward={false}
+                      value={null}
                       wrapSelection={true}
                     >
                       <div
@@ -583,6 +584,7 @@ exports[`<SearchBar /> by default should render the right structure 1`] = `
                 <Dropdown
                   error={false}
                   icon="users"
+                  initialValue={null}
                   isDisabled={false}
                   isSearchable={false}
                   isValid={false}
@@ -648,7 +650,6 @@ exports[`<SearchBar /> by default should render the right structure 1`] = `
                       additionPosition="top"
                       closeOnBlur={true}
                       deburr={false}
-                      defaultValue={null}
                       disabled={false}
                       icon={
                         <Icon
@@ -700,6 +701,7 @@ exports[`<SearchBar /> by default should render the right structure 1`] = `
                       selectOnNavigation={true}
                       selection={true}
                       upward={false}
+                      value={null}
                       wrapSelection={true}
                     >
                       <div
@@ -1129,6 +1131,7 @@ exports[`<SearchBar /> if \`props.isFixed\` is true should render the right stru
                                         <Dropdown
                                           error={false}
                                           icon="map pin"
+                                          initialValue={null}
                                           isDisabled={false}
                                           isSearchable={false}
                                           isValid={false}
@@ -1194,7 +1197,6 @@ exports[`<SearchBar /> if \`props.isFixed\` is true should render the right stru
                                               additionPosition="top"
                                               closeOnBlur={true}
                                               deburr={false}
-                                              defaultValue={null}
                                               disabled={false}
                                               icon={
                                                 <Icon
@@ -1246,6 +1248,7 @@ exports[`<SearchBar /> if \`props.isFixed\` is true should render the right stru
                                               selectOnNavigation={true}
                                               selection={true}
                                               upward={true}
+                                              value={null}
                                               wrapSelection={true}
                                             >
                                               <div
@@ -1613,6 +1616,7 @@ exports[`<SearchBar /> if \`props.isFixed\` is true should render the right stru
                                         <Dropdown
                                           error={false}
                                           icon="users"
+                                          initialValue={null}
                                           isDisabled={false}
                                           isSearchable={false}
                                           isValid={false}
@@ -1678,7 +1682,6 @@ exports[`<SearchBar /> if \`props.isFixed\` is true should render the right stru
                                               additionPosition="top"
                                               closeOnBlur={true}
                                               deburr={false}
-                                              defaultValue={null}
                                               disabled={false}
                                               icon={
                                                 <Icon
@@ -1730,6 +1733,7 @@ exports[`<SearchBar /> if \`props.isFixed\` is true should render the right stru
                                               selectOnNavigation={true}
                                               selection={true}
                                               upward={true}
+                                              value={null}
                                               wrapSelection={true}
                                             >
                                               <div
@@ -2161,6 +2165,7 @@ exports[`<SearchBar /> if \`props.isShowingSummary\` is true should render the r
                 <Dropdown
                   error={false}
                   icon="map pin"
+                  initialValue={null}
                   isDisabled={false}
                   isSearchable={false}
                   isValid={false}
@@ -2226,7 +2231,6 @@ exports[`<SearchBar /> if \`props.isShowingSummary\` is true should render the r
                       additionPosition="top"
                       closeOnBlur={true}
                       deburr={false}
-                      defaultValue={null}
                       disabled={false}
                       icon={
                         <Icon
@@ -2278,6 +2282,7 @@ exports[`<SearchBar /> if \`props.isShowingSummary\` is true should render the r
                       selectOnNavigation={true}
                       selection={true}
                       upward={false}
+                      value={null}
                       wrapSelection={true}
                     >
                       <div
@@ -2645,6 +2650,7 @@ exports[`<SearchBar /> if \`props.isShowingSummary\` is true should render the r
                 <Dropdown
                   error={false}
                   icon="users"
+                  initialValue={null}
                   isDisabled={false}
                   isSearchable={false}
                   isValid={false}
@@ -2710,7 +2716,6 @@ exports[`<SearchBar /> if \`props.isShowingSummary\` is true should render the r
                       additionPosition="top"
                       closeOnBlur={true}
                       deburr={false}
-                      defaultValue={null}
                       disabled={false}
                       icon={
                         <Icon
@@ -2762,6 +2767,7 @@ exports[`<SearchBar /> if \`props.isShowingSummary\` is true should render the r
                       selectOnNavigation={true}
                       selection={true}
                       upward={false}
+                      value={null}
                       wrapSelection={true}
                     >
                       <div
@@ -3276,6 +3282,7 @@ exports[`<SearchBar /> if \`props.locationOptions\` is not passed should render 
                 <Dropdown
                   error={false}
                   icon="users"
+                  initialValue={null}
                   isDisabled={false}
                   isSearchable={false}
                   isValid={false}
@@ -3341,7 +3348,6 @@ exports[`<SearchBar /> if \`props.locationOptions\` is not passed should render 
                       additionPosition="top"
                       closeOnBlur={true}
                       deburr={false}
-                      defaultValue={null}
                       disabled={false}
                       icon={
                         <Icon
@@ -3393,6 +3399,7 @@ exports[`<SearchBar /> if \`props.locationOptions\` is not passed should render 
                       selectOnNavigation={true}
                       selection={true}
                       upward={false}
+                      value={null}
                       wrapSelection={true}
                     >
                       <div
@@ -3752,6 +3759,7 @@ exports[`<SearchBar /> if \`props.searchButton\` is passed should render the rig
                 <Dropdown
                   error={false}
                   icon="map pin"
+                  initialValue={null}
                   isDisabled={false}
                   isSearchable={false}
                   isValid={false}
@@ -3817,7 +3825,6 @@ exports[`<SearchBar /> if \`props.searchButton\` is passed should render the rig
                       additionPosition="top"
                       closeOnBlur={true}
                       deburr={false}
-                      defaultValue={null}
                       disabled={false}
                       icon={
                         <Icon
@@ -3869,6 +3876,7 @@ exports[`<SearchBar /> if \`props.searchButton\` is passed should render the rig
                       selectOnNavigation={true}
                       selection={true}
                       upward={false}
+                      value={null}
                       wrapSelection={true}
                     >
                       <div
@@ -4236,6 +4244,7 @@ exports[`<SearchBar /> if \`props.searchButton\` is passed should render the rig
                 <Dropdown
                   error={false}
                   icon="users"
+                  initialValue={null}
                   isDisabled={false}
                   isSearchable={false}
                   isValid={false}
@@ -4301,7 +4310,6 @@ exports[`<SearchBar /> if \`props.searchButton\` is passed should render the rig
                       additionPosition="top"
                       closeOnBlur={true}
                       deburr={false}
-                      defaultValue={null}
                       disabled={false}
                       icon={
                         <Icon
@@ -4353,6 +4361,7 @@ exports[`<SearchBar /> if \`props.searchButton\` is passed should render the rig
                       selectOnNavigation={true}
                       selection={true}
                       upward={false}
+                      value={null}
                       wrapSelection={true}
                     >
                       <div

--- a/src/components/general-widgets/SearchBar/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/SearchBar/__snapshots__/component.spec.js.snap
@@ -4,7 +4,9 @@ exports[`<SearchBar /> by default should render the right structure 1`] = `
 <SearchBar
   className={null}
   dateRangePickerLocaleCode="ko"
+  datesInputInitialValue={null}
   getIsDayBlocked={[Function]}
+  guestsInputInitialValue={null}
   guestsOptions={
     Array [
       Object {
@@ -28,6 +30,7 @@ exports[`<SearchBar /> by default should render the right structure 1`] = `
   isDisplayedAsModal={false}
   isFixed={false}
   isShowingSummary={false}
+  locationInputInitialValue={null}
   locationOptions={
     Array [
       Object {
@@ -421,6 +424,7 @@ exports[`<SearchBar /> by default should render the right structure 1`] = `
                 <WithResponsive(DateRangePicker)
                   endDatePlaceholderText="Check-out"
                   getIsDayBlocked={[Function]}
+                  initialValue={null}
                   localeCode="ko"
                   name="dates"
                   onChange={[Function]}
@@ -431,6 +435,7 @@ exports[`<SearchBar /> by default should render the right structure 1`] = `
                     as={[Function]}
                     endDatePlaceholderText="Check-out"
                     getIsDayBlocked={[Function]}
+                    initialValue={null}
                     isUserOnMobile={false}
                     localeCode="ko"
                     name="dates"
@@ -445,6 +450,7 @@ exports[`<SearchBar /> by default should render the right structure 1`] = `
                       endDatePlaceholderText="Check-out"
                       error={false}
                       getIsDayBlocked={[Function]}
+                      initialValue={null}
                       isUserOnMobile={false}
                       isValid={false}
                       localeCode="ko"
@@ -459,7 +465,7 @@ exports[`<SearchBar /> by default should render the right structure 1`] = `
                         adaptOnChangeEvent={[Function]}
                         error={false}
                         icon={null}
-                        initialValue=""
+                        initialValue={null}
                         inputOnChangeFunctionName="onDatesChange"
                         isFocused={false}
                         isValid={false}
@@ -975,7 +981,9 @@ exports[`<SearchBar /> if \`props.isFixed\` is true should render the right stru
 <SearchBar
   className={null}
   dateRangePickerLocaleCode="ko"
+  datesInputInitialValue={null}
   getIsDayBlocked={[Function]}
+  guestsInputInitialValue={null}
   guestsOptions={
     Array [
       Object {
@@ -999,6 +1007,7 @@ exports[`<SearchBar /> if \`props.isFixed\` is true should render the right stru
   isDisplayedAsModal={false}
   isFixed={true}
   isShowingSummary={false}
+  locationInputInitialValue={null}
   locationOptions={
     Array [
       Object {
@@ -1445,6 +1454,7 @@ exports[`<SearchBar /> if \`props.isFixed\` is true should render the right stru
                                         <WithResponsive(DateRangePicker)
                                           endDatePlaceholderText="Check-out"
                                           getIsDayBlocked={[Function]}
+                                          initialValue={null}
                                           localeCode="ko"
                                           name="dates"
                                           onChange={[Function]}
@@ -1455,6 +1465,7 @@ exports[`<SearchBar /> if \`props.isFixed\` is true should render the right stru
                                             as={[Function]}
                                             endDatePlaceholderText="Check-out"
                                             getIsDayBlocked={[Function]}
+                                            initialValue={null}
                                             isUserOnMobile={false}
                                             localeCode="ko"
                                             name="dates"
@@ -1469,6 +1480,7 @@ exports[`<SearchBar /> if \`props.isFixed\` is true should render the right stru
                                               endDatePlaceholderText="Check-out"
                                               error={false}
                                               getIsDayBlocked={[Function]}
+                                              initialValue={null}
                                               isUserOnMobile={false}
                                               isValid={false}
                                               localeCode="ko"
@@ -1483,7 +1495,7 @@ exports[`<SearchBar /> if \`props.isFixed\` is true should render the right stru
                                                 adaptOnChangeEvent={[Function]}
                                                 error={false}
                                                 icon={null}
-                                                initialValue=""
+                                                initialValue={null}
                                                 inputOnChangeFunctionName="onDatesChange"
                                                 isFocused={false}
                                                 isValid={false}
@@ -2009,7 +2021,9 @@ exports[`<SearchBar /> if \`props.isShowingSummary\` is true should render the r
 <SearchBar
   className={null}
   dateRangePickerLocaleCode="ko"
+  datesInputInitialValue={null}
   getIsDayBlocked={[Function]}
+  guestsInputInitialValue={null}
   guestsOptions={
     Array [
       Object {
@@ -2033,6 +2047,7 @@ exports[`<SearchBar /> if \`props.isShowingSummary\` is true should render the r
   isDisplayedAsModal={false}
   isFixed={false}
   isShowingSummary={true}
+  locationInputInitialValue={null}
   locationOptions={
     Array [
       Object {
@@ -2471,6 +2486,7 @@ exports[`<SearchBar /> if \`props.isShowingSummary\` is true should render the r
                 <WithResponsive(DateRangePicker)
                   endDatePlaceholderText="Check-out"
                   getIsDayBlocked={[Function]}
+                  initialValue={null}
                   localeCode="ko"
                   name="dates"
                   onChange={[Function]}
@@ -2481,6 +2497,7 @@ exports[`<SearchBar /> if \`props.isShowingSummary\` is true should render the r
                     as={[Function]}
                     endDatePlaceholderText="Check-out"
                     getIsDayBlocked={[Function]}
+                    initialValue={null}
                     isUserOnMobile={false}
                     localeCode="ko"
                     name="dates"
@@ -2495,6 +2512,7 @@ exports[`<SearchBar /> if \`props.isShowingSummary\` is true should render the r
                       endDatePlaceholderText="Check-out"
                       error={false}
                       getIsDayBlocked={[Function]}
+                      initialValue={null}
                       isUserOnMobile={false}
                       isValid={false}
                       localeCode="ko"
@@ -2509,7 +2527,7 @@ exports[`<SearchBar /> if \`props.isShowingSummary\` is true should render the r
                         adaptOnChangeEvent={[Function]}
                         error={false}
                         icon={null}
-                        initialValue=""
+                        initialValue={null}
                         inputOnChangeFunctionName="onDatesChange"
                         isFocused={false}
                         isValid={false}
@@ -3023,7 +3041,9 @@ exports[`<SearchBar /> if \`props.locationOptions\` is not passed should render 
 <SearchBar
   className={null}
   dateRangePickerLocaleCode="ko"
+  datesInputInitialValue={null}
   getIsDayBlocked={[Function]}
+  guestsInputInitialValue={null}
   guestsOptions={
     Array [
       Object {
@@ -3047,6 +3067,7 @@ exports[`<SearchBar /> if \`props.locationOptions\` is not passed should render 
   isDisplayedAsModal={false}
   isFixed={false}
   isShowingSummary={false}
+  locationInputInitialValue={null}
   locationOptions={null}
   modalHeadingText="Check our availability"
   modalSummaryElement={null}
@@ -3096,6 +3117,7 @@ exports[`<SearchBar /> if \`props.locationOptions\` is not passed should render 
                 <WithResponsive(DateRangePicker)
                   endDatePlaceholderText="Check-out"
                   getIsDayBlocked={[Function]}
+                  initialValue={null}
                   localeCode="ko"
                   name="dates"
                   onChange={[Function]}
@@ -3106,6 +3128,7 @@ exports[`<SearchBar /> if \`props.locationOptions\` is not passed should render 
                     as={[Function]}
                     endDatePlaceholderText="Check-out"
                     getIsDayBlocked={[Function]}
+                    initialValue={null}
                     isUserOnMobile={false}
                     localeCode="ko"
                     name="dates"
@@ -3120,6 +3143,7 @@ exports[`<SearchBar /> if \`props.locationOptions\` is not passed should render 
                       endDatePlaceholderText="Check-out"
                       error={false}
                       getIsDayBlocked={[Function]}
+                      initialValue={null}
                       isUserOnMobile={false}
                       isValid={false}
                       localeCode="ko"
@@ -3134,7 +3158,7 @@ exports[`<SearchBar /> if \`props.locationOptions\` is not passed should render 
                         adaptOnChangeEvent={[Function]}
                         error={false}
                         icon={null}
-                        initialValue=""
+                        initialValue={null}
                         inputOnChangeFunctionName="onDatesChange"
                         isFocused={false}
                         isValid={false}
@@ -3648,7 +3672,9 @@ exports[`<SearchBar /> if \`props.searchButton\` is passed should render the rig
 <SearchBar
   className={null}
   dateRangePickerLocaleCode="ko"
+  datesInputInitialValue={null}
   getIsDayBlocked={[Function]}
+  guestsInputInitialValue={null}
   guestsOptions={
     Array [
       Object {
@@ -3672,6 +3698,7 @@ exports[`<SearchBar /> if \`props.searchButton\` is passed should render the rig
   isDisplayedAsModal={false}
   isFixed={false}
   isShowingSummary={false}
+  locationInputInitialValue={null}
   locationOptions={
     Array [
       Object {
@@ -4050,6 +4077,7 @@ exports[`<SearchBar /> if \`props.searchButton\` is passed should render the rig
                 <WithResponsive(DateRangePicker)
                   endDatePlaceholderText="Check-out"
                   getIsDayBlocked={[Function]}
+                  initialValue={null}
                   localeCode="ko"
                   name="dates"
                   onChange={[Function]}
@@ -4060,6 +4088,7 @@ exports[`<SearchBar /> if \`props.searchButton\` is passed should render the rig
                     as={[Function]}
                     endDatePlaceholderText="Check-out"
                     getIsDayBlocked={[Function]}
+                    initialValue={null}
                     isUserOnMobile={false}
                     localeCode="ko"
                     name="dates"
@@ -4074,6 +4103,7 @@ exports[`<SearchBar /> if \`props.searchButton\` is passed should render the rig
                       endDatePlaceholderText="Check-out"
                       error={false}
                       getIsDayBlocked={[Function]}
+                      initialValue={null}
                       isUserOnMobile={false}
                       isValid={false}
                       localeCode="ko"
@@ -4088,7 +4118,7 @@ exports[`<SearchBar /> if \`props.searchButton\` is passed should render the rig
                         adaptOnChangeEvent={[Function]}
                         error={false}
                         icon={null}
-                        initialValue=""
+                        initialValue={null}
                         inputOnChangeFunctionName="onDatesChange"
                         isFocused={false}
                         isValid={false}

--- a/src/components/general-widgets/SearchBar/component.js
+++ b/src/components/general-widgets/SearchBar/component.js
@@ -20,7 +20,11 @@ import { getSearchBarModal } from './utils/getSearchBarModal';
  */
 // eslint-disable-next-line jsdoc/require-jsdoc
 export class Component extends PureComponent {
-  state = {};
+  state = {
+    dates: this.props.datesInputInitialValue,
+    guests: this.props.guestsInputInitialValue,
+    location: this.props.locationInputInitialValue,
+  };
 
   componentDidUpdate(previousProps, previousState) {
     !isEqual(previousState, this.state) && this.props.onChangeInput(this.state);
@@ -111,15 +115,15 @@ Component.displayName = 'SearchBar';
 
 Component.defaultProps = {
   className: null,
-  datesInputInitialValue: undefined,
+  datesInputInitialValue: null,
   dateRangePickerLocaleCode: undefined,
   getIsDayBlocked: Function.prototype,
-  guestsInputInitialValue: undefined,
+  guestsInputInitialValue: null,
   isDisplayedAsModal: false,
   isFixed: false,
   isModalOpen: undefined,
   isShowingSummary: false,
-  locationInputInitialValue: undefined,
+  locationInputInitialValue: null,
   locationOptions: null,
   modalHeadingText: CHECK_OUR_AVAILABILITY,
   modalSummaryElement: null,

--- a/src/components/general-widgets/SearchBar/component.spec.js
+++ b/src/components/general-widgets/SearchBar/component.spec.js
@@ -111,7 +111,9 @@ describe('<SearchBar />', () => {
       input.simulate('change', name, value);
 
       expect(onChangeInput).toHaveBeenCalledWith({
-        [name]: value,
+        dates: null,
+        guests: null,
+        location: '🍰',
       });
     });
   });

--- a/src/components/general-widgets/SearchBar/utils/__snapshots__/getFormFieldMarkup.spec.js.snap
+++ b/src/components/general-widgets/SearchBar/utils/__snapshots__/getFormFieldMarkup.spec.js.snap
@@ -26,6 +26,7 @@ exports[`getFormFieldMarkup if \`props.locationOptions\` size is greater than 0 
     <Dropdown
       error={false}
       icon="map pin"
+      initialValue={null}
       isDisabled={false}
       isSearchable={false}
       isValid={false}
@@ -62,6 +63,7 @@ exports[`getFormFieldMarkup if \`props.locationOptions\` size is greater than 0 
     <Dropdown
       error={false}
       icon="users"
+      initialValue={null}
       isDisabled={false}
       isSearchable={false}
       isValid={false}
@@ -120,6 +122,7 @@ exports[`getFormFieldMarkup should render the right structure\` 1`] = `
     <Dropdown
       error={false}
       icon="users"
+      initialValue={null}
       isDisabled={false}
       isSearchable={false}
       isValid={false}

--- a/src/components/inputs/Dropdown/component.js
+++ b/src/components/inputs/Dropdown/component.js
@@ -13,7 +13,6 @@ import { ErrorMessage } from '../ErrorMessage';
 
 import { getIsOpenAfterChange } from './utils/getIsOpenAfterChange';
 import { adaptOptions } from './utils/adaptOptions';
-import { getDefaultValue } from './utils/getDefaultValue';
 import { getHasImages } from './utils/getHasImages';
 import { isValueValid } from './utils/isValueValid';
 
@@ -89,12 +88,6 @@ export class Component extends PureComponent {
         {isValid && <Icon color="green" name={ICON_NAMES.CHECKMARK} />}
         {!hasImages && icon && <Icon name={icon} />}
         <Dropdown
-          defaultValue={getDefaultValue(
-            adaptedOptions,
-            hasImages,
-            !!label,
-            value
-          )}
           disabled={isDisabled || !adaptedOptions.length}
           icon={<Icon name={ICON_NAMES.CARET_DOWN} />}
           noResultsMessage={noResultsText}
@@ -133,7 +126,7 @@ Component.defaultProps = {
   options: [],
   value: undefined,
   willOpenAbove: false,
-  initialValue: undefined,
+  initialValue: null,
 };
 
 Component.propTypes = {

--- a/src/components/inputs/Dropdown/component.spec.js
+++ b/src/components/inputs/Dropdown/component.spec.js
@@ -120,7 +120,6 @@ describe('<Dropdown />', () => {
       const wrapper = getSemanticDropdown();
 
       expectComponentToHaveProps(wrapper, {
-        defaultValue: null,
         icon: <Icon name={ICON_NAMES.CARET_DOWN} />,
         noResultsMessage: NO_RESULTS,
         onBlur: expect.any(Function),
@@ -285,7 +284,7 @@ describe('<Dropdown />', () => {
           .instance()
           .componentDidUpdate({}, { value: 'some changed value' });
 
-        expect(onChange).not.toHaveBeenCalled();
+        expect(onChange).toHaveBeenCalledWith('', undefined);
       });
     });
 
@@ -316,7 +315,7 @@ describe('<Dropdown />', () => {
 
       expect(actual).toEqual({
         isOpen: false,
-        value: undefined,
+        value: null,
       });
     });
   });
@@ -367,7 +366,7 @@ describe('<Dropdown />', () => {
 
       expect(actual).toEqual({
         isOpen: true,
-        value: undefined,
+        value: null,
       });
     });
   });
@@ -382,7 +381,7 @@ describe('<Dropdown />', () => {
 
       expect(actual).toEqual({
         isOpen: true,
-        value: undefined,
+        value: null,
       });
     });
   });

--- a/src/components/property-page-widgets/Availability/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Availability/__snapshots__/component.spec.js.snap
@@ -366,6 +366,7 @@ exports[`<Availability /> the wrapped component if \`size(props.roomOptionsWithI
             <Dropdown
               error={false}
               icon="map pin"
+              initialValue={null}
               isDisabled={false}
               isSearchable={false}
               isValid={false}

--- a/src/components/property-page-widgets/PropertyPageSearchBar/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/PropertyPageSearchBar/__snapshots__/component.spec.js.snap
@@ -80,7 +80,9 @@ exports[`<PropertyPageSearchBar /> if \`isShowingPlaceholder\` === true should h
       >
         <SearchBar
           className={null}
+          datesInputInitialValue={null}
           getIsDayBlocked={[Function]}
+          guestsInputInitialValue={null}
           guestsOptions={
             Array [
               Object {
@@ -104,6 +106,7 @@ exports[`<PropertyPageSearchBar /> if \`isShowingPlaceholder\` === true should h
           isDisplayedAsModal={false}
           isFixed={true}
           isShowingSummary={false}
+          locationInputInitialValue={null}
           locationOptions={null}
           modalHeadingText="Check our availability"
           modalSummaryElement={null}
@@ -326,6 +329,7 @@ exports[`<PropertyPageSearchBar /> if \`isShowingPlaceholder\` === true should h
                                                 <WithResponsive(DateRangePicker)
                                                   endDatePlaceholderText="Check-out"
                                                   getIsDayBlocked={[Function]}
+                                                  initialValue={null}
                                                   name="dates"
                                                   onChange={[Function]}
                                                   startDatePlaceholderText="Check-in"
@@ -335,6 +339,7 @@ exports[`<PropertyPageSearchBar /> if \`isShowingPlaceholder\` === true should h
                                                     as={[Function]}
                                                     endDatePlaceholderText="Check-out"
                                                     getIsDayBlocked={[Function]}
+                                                    initialValue={null}
                                                     isUserOnMobile={false}
                                                     name="dates"
                                                     onChange={[Function]}
@@ -348,6 +353,7 @@ exports[`<PropertyPageSearchBar /> if \`isShowingPlaceholder\` === true should h
                                                       endDatePlaceholderText="Check-out"
                                                       error={false}
                                                       getIsDayBlocked={[Function]}
+                                                      initialValue={null}
                                                       isUserOnMobile={false}
                                                       isValid={false}
                                                       localeCode="en"
@@ -362,7 +368,7 @@ exports[`<PropertyPageSearchBar /> if \`isShowingPlaceholder\` === true should h
                                                         adaptOnChangeEvent={[Function]}
                                                         error={false}
                                                         icon={null}
-                                                        initialValue=""
+                                                        initialValue={null}
                                                         inputOnChangeFunctionName="onDatesChange"
                                                         isFocused={false}
                                                         isValid={false}
@@ -480,6 +486,7 @@ exports[`<PropertyPageSearchBar /> if \`isShowingPlaceholder\` === true should h
                                                 <Dropdown
                                                   error={false}
                                                   icon="users"
+                                                  initialValue={null}
                                                   isDisabled={false}
                                                   isSearchable={false}
                                                   isValid={false}
@@ -545,7 +552,6 @@ exports[`<PropertyPageSearchBar /> if \`isShowingPlaceholder\` === true should h
                                                       additionPosition="top"
                                                       closeOnBlur={true}
                                                       deburr={false}
-                                                      defaultValue={null}
                                                       disabled={false}
                                                       icon={
                                                         <Icon
@@ -597,6 +603,7 @@ exports[`<PropertyPageSearchBar /> if \`isShowingPlaceholder\` === true should h
                                                       selectOnNavigation={true}
                                                       selection={true}
                                                       upward={true}
+                                                      value={null}
                                                       wrapSelection={true}
                                                     >
                                                       <div
@@ -870,7 +877,9 @@ exports[`<PropertyPageSearchBar /> if \`isShowingPlaceholder\` === true should h
       >
         <SearchBar
           className={null}
+          datesInputInitialValue={null}
           getIsDayBlocked={[Function]}
+          guestsInputInitialValue={null}
           guestsOptions={
             Array [
               Object {
@@ -894,6 +903,7 @@ exports[`<PropertyPageSearchBar /> if \`isShowingPlaceholder\` === true should h
           isDisplayedAsModal={true}
           isFixed={true}
           isShowingSummary={false}
+          locationInputInitialValue={null}
           locationOptions={null}
           modalHeadingText="Check our availability"
           modalSummaryElement={
@@ -1289,7 +1299,9 @@ exports[`<PropertyPageSearchBar /> should have the right structure 1`] = `
       >
         <SearchBar
           className={null}
+          datesInputInitialValue={null}
           getIsDayBlocked={[Function]}
+          guestsInputInitialValue={null}
           guestsOptions={
             Array [
               Object {
@@ -1313,6 +1325,7 @@ exports[`<PropertyPageSearchBar /> should have the right structure 1`] = `
           isDisplayedAsModal={false}
           isFixed={true}
           isShowingSummary={false}
+          locationInputInitialValue={null}
           locationOptions={null}
           modalHeadingText="Check our availability"
           modalSummaryElement={null}
@@ -1693,6 +1706,7 @@ exports[`<PropertyPageSearchBar /> should have the right structure 1`] = `
                                                 <WithResponsive(DateRangePicker)
                                                   endDatePlaceholderText="Check-out"
                                                   getIsDayBlocked={[Function]}
+                                                  initialValue={null}
                                                   name="dates"
                                                   onChange={[Function]}
                                                   startDatePlaceholderText="Check-in"
@@ -1702,6 +1716,7 @@ exports[`<PropertyPageSearchBar /> should have the right structure 1`] = `
                                                     as={[Function]}
                                                     endDatePlaceholderText="Check-out"
                                                     getIsDayBlocked={[Function]}
+                                                    initialValue={null}
                                                     isUserOnMobile={false}
                                                     name="dates"
                                                     onChange={[Function]}
@@ -1715,6 +1730,7 @@ exports[`<PropertyPageSearchBar /> should have the right structure 1`] = `
                                                       endDatePlaceholderText="Check-out"
                                                       error={false}
                                                       getIsDayBlocked={[Function]}
+                                                      initialValue={null}
                                                       isUserOnMobile={false}
                                                       isValid={false}
                                                       localeCode="en"
@@ -1729,7 +1745,7 @@ exports[`<PropertyPageSearchBar /> should have the right structure 1`] = `
                                                         adaptOnChangeEvent={[Function]}
                                                         error={false}
                                                         icon={null}
-                                                        initialValue=""
+                                                        initialValue={null}
                                                         inputOnChangeFunctionName="onDatesChange"
                                                         isFocused={false}
                                                         isValid={false}
@@ -1847,6 +1863,7 @@ exports[`<PropertyPageSearchBar /> should have the right structure 1`] = `
                                                 <Dropdown
                                                   error={false}
                                                   icon="users"
+                                                  initialValue={null}
                                                   isDisabled={false}
                                                   isSearchable={false}
                                                   isValid={false}
@@ -1912,7 +1929,6 @@ exports[`<PropertyPageSearchBar /> should have the right structure 1`] = `
                                                       additionPosition="top"
                                                       closeOnBlur={true}
                                                       deburr={false}
-                                                      defaultValue={null}
                                                       disabled={false}
                                                       icon={
                                                         <Icon
@@ -1964,6 +1980,7 @@ exports[`<PropertyPageSearchBar /> should have the right structure 1`] = `
                                                       selectOnNavigation={true}
                                                       selection={true}
                                                       upward={true}
+                                                      value={null}
                                                       wrapSelection={true}
                                                     >
                                                       <div
@@ -2237,7 +2254,9 @@ exports[`<PropertyPageSearchBar /> should have the right structure 1`] = `
       >
         <SearchBar
           className={null}
+          datesInputInitialValue={null}
           getIsDayBlocked={[Function]}
+          guestsInputInitialValue={null}
           guestsOptions={
             Array [
               Object {
@@ -2261,6 +2280,7 @@ exports[`<PropertyPageSearchBar /> should have the right structure 1`] = `
           isDisplayedAsModal={true}
           isFixed={true}
           isShowingSummary={false}
+          locationInputInitialValue={null}
           locationOptions={null}
           modalHeadingText="Check our availability"
           modalSummaryElement={

--- a/src/components/property-page-widgets/PropertyPageSearchBar/component.js
+++ b/src/components/property-page-widgets/PropertyPageSearchBar/component.js
@@ -116,7 +116,11 @@ Component.propTypes = {
    */
   getIsDayBlocked: PropTypes.func,
   /** The initial value for the guests input of the search bar. */
-  guestsInputInitialValue: PropTypes.string,
+  guestsInputInitialValue: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.number,
+    PropTypes.string,
+  ]),
   /** The options that the user can select in the guests field. */
   guestsOptions: PropTypes.arrayOf(
     PropTypes.shape({

--- a/src/components/property-page-widgets/Rates/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Rates/__snapshots__/component.spec.js.snap
@@ -87,6 +87,7 @@ exports[`<Rates /> by default should have the right structure 1`] = `
       <Dropdown
         error={false}
         icon={null}
+        initialValue={null}
         isDisabled={false}
         isSearchable={true}
         isValid={false}
@@ -121,7 +122,6 @@ exports[`<Rates /> by default should have the right structure 1`] = `
             additionPosition="top"
             closeOnBlur={true}
             deburr={false}
-            defaultValue="eur"
             disabled={false}
             icon={
               <Icon
@@ -169,6 +169,7 @@ exports[`<Rates /> by default should have the right structure 1`] = `
             selectOnNavigation={true}
             selection={true}
             upward={false}
+            value={null}
             wrapSelection={true}
           >
             <div
@@ -214,9 +215,7 @@ exports[`<Rates /> by default should have the right structure 1`] = `
                 aria-live="polite"
                 className="text"
                 role="alert"
-              >
-                EUR €
-              </div>
+              />
               <Icon
                 color={null}
                 hasBorder={false}
@@ -255,7 +254,7 @@ exports[`<Rates /> by default should have the right structure 1`] = `
                   role="listbox"
                 >
                   <DropdownItem
-                    active={true}
+                    active={false}
                     key="eur"
                     onClick={[Function]}
                     selected={true}
@@ -268,9 +267,9 @@ exports[`<Rates /> by default should have the right structure 1`] = `
                     value="eur"
                   >
                     <div
-                      aria-checked={true}
+                      aria-checked={false}
                       aria-selected={true}
-                      className="active selected item"
+                      className="selected item"
                       onClick={[Function]}
                       role="option"
                       style={
@@ -1555,6 +1554,7 @@ exports[`<Rates /> by default should have the right structure 1`] = `
             <Dropdown
               error={false}
               icon={null}
+              initialValue={null}
               isDisabled={false}
               isSearchable={true}
               isValid={false}
@@ -1627,6 +1627,7 @@ exports[`<Rates /> by default should have the right structure 1`] = `
                           <Dropdown
                             error={false}
                             icon={null}
+                            initialValue={null}
                             isDisabled={false}
                             isSearchable={true}
                             isValid={false}
@@ -1661,7 +1662,6 @@ exports[`<Rates /> by default should have the right structure 1`] = `
                                 additionPosition="top"
                                 closeOnBlur={true}
                                 deburr={false}
-                                defaultValue="eur"
                                 disabled={false}
                                 icon={
                                   <Icon
@@ -1709,6 +1709,7 @@ exports[`<Rates /> by default should have the right structure 1`] = `
                                 selectOnNavigation={true}
                                 selection={true}
                                 upward={false}
+                                value={null}
                                 wrapSelection={true}
                               >
                                 <div
@@ -1754,9 +1755,7 @@ exports[`<Rates /> by default should have the right structure 1`] = `
                                     aria-live="polite"
                                     className="text"
                                     role="alert"
-                                  >
-                                    EUR €
-                                  </div>
+                                  />
                                   <Icon
                                     color={null}
                                     hasBorder={false}
@@ -1795,7 +1794,7 @@ exports[`<Rates /> by default should have the right structure 1`] = `
                                       role="listbox"
                                     >
                                       <DropdownItem
-                                        active={true}
+                                        active={false}
                                         key="eur"
                                         onClick={[Function]}
                                         selected={true}
@@ -1808,9 +1807,9 @@ exports[`<Rates /> by default should have the right structure 1`] = `
                                         value="eur"
                                       >
                                         <div
-                                          aria-checked={true}
+                                          aria-checked={false}
                                           aria-selected={true}
-                                          className="active selected item"
+                                          className="selected item"
                                           onClick={[Function]}
                                           role="option"
                                           style={
@@ -3194,6 +3193,7 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
       <Dropdown
         error={false}
         icon={null}
+        initialValue={null}
         isDisabled={false}
         isSearchable={false}
         isValid={false}
@@ -3236,7 +3236,6 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
             additionPosition="top"
             closeOnBlur={true}
             deburr={false}
-            defaultValue="🎅"
             disabled={false}
             icon={
               <Icon
@@ -3332,6 +3331,7 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
             selectOnNavigation={true}
             selection={true}
             upward={false}
+            value={null}
             wrapSelection={true}
           >
             <div
@@ -3350,20 +3350,7 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
                 aria-live="polite"
                 className="text"
                 role="alert"
-              >
-                <img
-                  alt="🎅"
-                  className="ui image"
-                  key="img🎅0"
-                  src="🎅"
-                />
-                <span
-                  className="text"
-                  key="spa🎅0"
-                >
-                  🎅
-                </span>
-              </div>
+              />
               <Icon
                 color={null}
                 hasBorder={false}
@@ -3400,7 +3387,7 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
                   className="menu transition"
                 >
                   <DropdownItem
-                    active={true}
+                    active={false}
                     key="🎅"
                     onClick={[Function]}
                     selected={true}
@@ -3426,9 +3413,9 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
                     value="🎅"
                   >
                     <div
-                      aria-checked={true}
+                      aria-checked={false}
                       aria-selected={true}
-                      className="active selected item"
+                      className="selected item"
                       onClick={[Function]}
                       role="option"
                       style={
@@ -3660,6 +3647,7 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
       <Dropdown
         error={false}
         icon={null}
+        initialValue={null}
         isDisabled={false}
         isSearchable={true}
         isValid={false}
@@ -3694,7 +3682,6 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
             additionPosition="top"
             closeOnBlur={true}
             deburr={false}
-            defaultValue="eur"
             disabled={false}
             icon={
               <Icon
@@ -3742,6 +3729,7 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
             selectOnNavigation={true}
             selection={true}
             upward={false}
+            value={null}
             wrapSelection={true}
           >
             <div
@@ -3787,9 +3775,7 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
                 aria-live="polite"
                 className="text"
                 role="alert"
-              >
-                EUR €
-              </div>
+              />
               <Icon
                 color={null}
                 hasBorder={false}
@@ -3828,7 +3814,7 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
                   role="listbox"
                 >
                   <DropdownItem
-                    active={true}
+                    active={false}
                     key="eur"
                     onClick={[Function]}
                     selected={true}
@@ -3841,9 +3827,9 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
                     value="eur"
                   >
                     <div
-                      aria-checked={true}
+                      aria-checked={false}
                       aria-selected={true}
-                      className="active selected item"
+                      className="selected item"
                       onClick={[Function]}
                       role="option"
                       style={
@@ -5128,6 +5114,7 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
             <Dropdown
               error={false}
               icon={null}
+              initialValue={null}
               isDisabled={false}
               isSearchable={true}
               isValid={false}
@@ -5200,6 +5187,7 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
                           <Dropdown
                             error={false}
                             icon={null}
+                            initialValue={null}
                             isDisabled={false}
                             isSearchable={true}
                             isValid={false}
@@ -5234,7 +5222,6 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
                                 additionPosition="top"
                                 closeOnBlur={true}
                                 deburr={false}
-                                defaultValue="eur"
                                 disabled={false}
                                 icon={
                                   <Icon
@@ -5282,6 +5269,7 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
                                 selectOnNavigation={true}
                                 selection={true}
                                 upward={false}
+                                value={null}
                                 wrapSelection={true}
                               >
                                 <div
@@ -5327,9 +5315,7 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
                                     aria-live="polite"
                                     className="text"
                                     role="alert"
-                                  >
-                                    EUR €
-                                  </div>
+                                  />
                                   <Icon
                                     color={null}
                                     hasBorder={false}
@@ -5368,7 +5354,7 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
                                       role="listbox"
                                     >
                                       <DropdownItem
-                                        active={true}
+                                        active={false}
                                         key="eur"
                                         onClick={[Function]}
                                         selected={true}
@@ -5381,9 +5367,9 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
                                         value="eur"
                                       >
                                         <div
-                                          aria-checked={true}
+                                          aria-checked={false}
                                           aria-selected={true}
-                                          className="active selected item"
+                                          className="selected item"
                                           onClick={[Function]}
                                           role="option"
                                           style={

--- a/src/components/property-page-widgets/Rates/utils/__snapshots__/getRoomTypeDropdownMarkup.spec.js.snap
+++ b/src/components/property-page-widgets/Rates/utils/__snapshots__/getRoomTypeDropdownMarkup.spec.js.snap
@@ -37,6 +37,7 @@ Array [
       <Dropdown
         error={false}
         icon={null}
+        initialValue={null}
         isDisabled={false}
         isSearchable={false}
         isValid={false}


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1904)

### What are the 3 things this PR does?

- Removes unnecessary `defaultValue` from `Dropdown`.
- Adds initial values for `SearchBar` state inputs.
- Fixes `HomepageHero` and `PropertySearchBar` guest input PropTypes.