### PR TITLE
TE-1908 Modal header image regression

### DIFF
--- a/src/styles/semantic/themes/livingstone/modules/modal.overrides
+++ b/src/styles/semantic/themes/livingstone/modules/modal.overrides
@@ -65,14 +65,6 @@
     margin: 0 !important;
   }
 
-  > .content > .link.item {
-    display: inline-block;
-
-    > img:only-of-type {
-      max-height: @modalLogoMaxHeight;
-    }
-  }
-
   > .header {
     font-size: inherit;
 
@@ -81,6 +73,13 @@
       .header {
         margin-bottom: @headerWithHeadingAndRatingMarginBottom;
         padding: 0;
+      }
+    }
+
+    .ui.container > .link.item {
+
+      > img:only-of-type {
+        max-height: @modalLogoMaxHeight;
       }
     }
   }


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1908)

### What **one** thing does this PR do?
Fixes the regression caused by https://github.com/lodgify/lodgify-ui/pull/564.
Header image is restricted to a maximum height.

### Any other notes
![Screenshot 2019-03-12 at 12 44 42](https://user-images.githubusercontent.com/10498995/54197690-e6ebc280-44c4-11e9-90ab-54aadff8b74c.png)
![Screenshot 2019-03-12 at 12 44 51](https://user-images.githubusercontent.com/10498995/54197691-e6ebc280-44c4-11e9-8e65-defa4fd2c323.png)
