### PR TITLE
TE-1996 `SearchBar`: expose `props.datesInputOnFocusChange`

### DIFF
--- a/src/components/general-widgets/Contact/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/Contact/__snapshots__/component.spec.js.snap
@@ -452,6 +452,7 @@ exports[`<Contact /> if \`propertyOptions\` and \`roomOptions\` are passed shoul
                           name="dates"
                           onBlur={[Function]}
                           onChange={[Function]}
+                          onFocusChange={[Function]}
                           startDatePlaceholderText="Arrival"
                           willOpenAbove={false}
                           windowInnerWidth={1024}
@@ -1673,6 +1674,7 @@ exports[`<Contact /> if \`props.propertyOptions\` is passed should have the corr
                           name="dates"
                           onBlur={[Function]}
                           onChange={[Function]}
+                          onFocusChange={[Function]}
                           startDatePlaceholderText="Arrival"
                           willOpenAbove={false}
                           windowInnerWidth={1024}
@@ -2632,6 +2634,7 @@ exports[`<Contact /> if \`props.roomOptions\` is passed should have the correct 
                           name="dates"
                           onBlur={[Function]}
                           onChange={[Function]}
+                          onFocusChange={[Function]}
                           startDatePlaceholderText="Arrival"
                           willOpenAbove={false}
                           windowInnerWidth={1024}
@@ -3535,6 +3538,7 @@ exports[`<Contact /> should have the correct structure 1`] = `
                           name="dates"
                           onBlur={[Function]}
                           onChange={[Function]}
+                          onFocusChange={[Function]}
                           startDatePlaceholderText="Arrival"
                           willOpenAbove={false}
                           windowInnerWidth={1024}

--- a/src/components/general-widgets/HomepageHero/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/HomepageHero/__snapshots__/component.spec.js.snap
@@ -26,6 +26,7 @@ exports[`HomepageHero should render the right structure 1`] = `
   }
   headingText="heading text"
   placeholderBackgroundImageUrl={null}
+  searchBarDatesInputOnFocusChange={[Function]}
   searchBarGetIsDayBlocked={[Function]}
   searchBarGuestsOptions={
     Array [
@@ -418,6 +419,7 @@ exports[`HomepageHero should render the right structure 1`] = `
                                     Object {
                                       "dateRangePickerLocaleCode": undefined,
                                       "datesInputInitialValue": undefined,
+                                      "datesInputOnFocusChange": [Function],
                                       "getIsDayBlocked": [Function],
                                       "guestsInputInitialValue": undefined,
                                       "guestsOptions": Array [
@@ -447,6 +449,7 @@ exports[`HomepageHero should render the right structure 1`] = `
                                   <SearchBar
                                     className="show-on-tablet show-on-computer show-on-widescreen"
                                     datesInputInitialValue={null}
+                                    datesInputOnFocusChange={[Function]}
                                     getIsDayBlocked={[Function]}
                                     guestsInputInitialValue={null}
                                     guestsOptions={
@@ -712,6 +715,7 @@ exports[`HomepageHero should render the right structure 1`] = `
                                                     initialValue={null}
                                                     name="dates"
                                                     onChange={[Function]}
+                                                    onFocusChange={[Function]}
                                                     startDatePlaceholderText="Check-in"
                                                     willOpenAbove={true}
                                                   >
@@ -723,6 +727,7 @@ exports[`HomepageHero should render the right structure 1`] = `
                                                       isUserOnMobile={false}
                                                       name="dates"
                                                       onChange={[Function]}
+                                                      onFocusChange={[Function]}
                                                       onUpdate={[Function]}
                                                       startDatePlaceholderText="Check-in"
                                                       willOpenAbove={true}
@@ -740,6 +745,7 @@ exports[`HomepageHero should render the right structure 1`] = `
                                                         name="dates"
                                                         onBlur={[Function]}
                                                         onChange={[Function]}
+                                                        onFocusChange={[Function]}
                                                         startDatePlaceholderText="Check-in"
                                                         willOpenAbove={true}
                                                         windowInnerWidth={1024}
@@ -1092,6 +1098,7 @@ exports[`HomepageHero should render the right structure 1`] = `
                                     <SearchBar
                                       className={null}
                                       datesInputInitialValue={null}
+                                      datesInputOnFocusChange={[Function]}
                                       getIsDayBlocked={[Function]}
                                       guestsInputInitialValue={null}
                                       guestsOptions={

--- a/src/components/general-widgets/HomepageHero/component.js
+++ b/src/components/general-widgets/HomepageHero/component.js
@@ -33,6 +33,7 @@ export const Component = ({
   placeholderBackgroundImageUrl,
   searchBarDateRangePickerLocaleCode,
   searchBarDatesInputInitialValue,
+  searchBarDatesInputOnFocusChange,
   searchBarGetIsDayBlocked,
   searchBarGuestsInputInitialValue,
   searchBarGuestsOptions,
@@ -42,98 +43,96 @@ export const Component = ({
   searchBarOnChangeInput,
   searchBarOnSubmit,
   searchBarSearchButton,
-}) => (
-  <Hero
-    activeNavigationItemIndex={activeNavigationItemIndex}
-    backgroundImageHeight={backgroundImageHeight}
-    backgroundImageSizes={backgroundImageSizes}
-    backgroundImageSrcSet={backgroundImageSrcSet}
-    backgroundImageUrl={backgroundImageUrl}
-    backgroundImageWidth={backgroundImageWidth}
-    headerLogoHref={headerLogoHref}
-    headerLogoSizes={headerLogoSizes}
-    headerLogoSrc={headerLogoSrc}
-    headerLogoSrcSet={headerLogoSrcSet}
-    headerLogoText={headerLogoText}
-    headerNavigationItems={headerNavigationItems}
-    headerPrimaryCTA={headerPrimaryCTA}
-    placeholderBackgroundImageUrl={placeholderBackgroundImageUrl}
-  >
-    <FlexContainer
-      alignItems="center"
-      flexDirection="column"
-      justifyContent="space-evenly"
+}) => {
+  const searchBarSharedProps = {
+    dateRangePickerLocaleCode: searchBarDateRangePickerLocaleCode,
+    datesInputInitialValue: searchBarDatesInputInitialValue,
+    datesInputOnFocusChange: searchBarDatesInputOnFocusChange,
+    getIsDayBlocked: searchBarGetIsDayBlocked,
+    guestsInputInitialValue: searchBarGuestsInputInitialValue,
+    guestsOptions: searchBarGuestsOptions,
+    locationInputInitialValue: searchBarLocationInputInitialValue,
+    locationOptions: searchBarLocationOptions,
+    onChangeInput: searchBarOnChangeInput,
+    onSubmit: searchBarOnSubmit,
+    searchButton: searchBarSearchButton,
+  };
+
+  return (
+    <Hero
+      activeNavigationItemIndex={activeNavigationItemIndex}
+      backgroundImageHeight={backgroundImageHeight}
+      backgroundImageSizes={backgroundImageSizes}
+      backgroundImageSrcSet={backgroundImageSrcSet}
+      backgroundImageUrl={backgroundImageUrl}
+      backgroundImageWidth={backgroundImageWidth}
+      headerLogoHref={headerLogoHref}
+      headerLogoSizes={headerLogoSizes}
+      headerLogoSrc={headerLogoSrc}
+      headerLogoSrcSet={headerLogoSrcSet}
+      headerLogoText={headerLogoText}
+      headerNavigationItems={headerNavigationItems}
+      headerPrimaryCTA={headerPrimaryCTA}
+      placeholderBackgroundImageUrl={placeholderBackgroundImageUrl}
     >
-      <HorizontalGutters>
-        <ShowOn
-          computer
-          parent={Heading}
-          parentProps={{
-            isColorInverted: true,
-            size: 'huge',
-            textAlign: 'center',
-          }}
-          tablet
-          widescreen
-        >
-          {headingText}
-        </ShowOn>
-        <ShowOn
-          mobile
-          parent={Heading}
-          parentProps={{
-            isColorInverted: true,
-            size: 'large',
-            textAlign: 'center',
-          }}
-        >
-          {headingText}
-        </ShowOn>
-      </HorizontalGutters>
-      <HorizontalGutters>
-        <Grid areColumnsCentered>
-          <GridRow horizontalAlignContent="center">
-            <ShowOn
-              computer
-              parent={SearchBar}
-              parentProps={{
-                datesInputInitialValue: searchBarDatesInputInitialValue,
-                dateRangePickerLocaleCode: searchBarDateRangePickerLocaleCode,
-                getIsDayBlocked: searchBarGetIsDayBlocked,
-                guestsInputInitialValue: searchBarGuestsInputInitialValue,
-                guestsOptions: searchBarGuestsOptions,
-                locationInputInitialValue: searchBarLocationInputInitialValue,
-                locationOptions: searchBarLocationOptions,
-                onChangeInput: searchBarOnChangeInput,
-                onSubmit: searchBarOnSubmit,
-                searchButton: searchBarSearchButton,
-                willDropdownsOpenAbove: true,
-              }}
-              tablet
-              widescreen
-            />
-            <ShowOn mobile>
-              <SearchBar
-                dateRangePickerLocaleCode={searchBarDateRangePickerLocaleCode}
-                datesInputInitialValue={searchBarDatesInputInitialValue}
-                getIsDayBlocked={searchBarGetIsDayBlocked}
-                guestsInputInitialValue={searchBarGuestsInputInitialValue}
-                guestsOptions={searchBarGuestsOptions}
-                isDisplayedAsModal
-                locationInputInitialValue={searchBarLocationInputInitialValue}
-                locationOptions={searchBarLocationOptions}
-                modalHeadingText={searchBarModalHeadingText}
-                onChangeInput={searchBarOnChangeInput}
-                onSubmit={searchBarOnSubmit}
-                searchButton={searchBarSearchButton}
+      <FlexContainer
+        alignItems="center"
+        flexDirection="column"
+        justifyContent="space-evenly"
+      >
+        <HorizontalGutters>
+          <ShowOn
+            computer
+            parent={Heading}
+            parentProps={{
+              isColorInverted: true,
+              size: 'huge',
+              textAlign: 'center',
+            }}
+            tablet
+            widescreen
+          >
+            {headingText}
+          </ShowOn>
+          <ShowOn
+            mobile
+            parent={Heading}
+            parentProps={{
+              isColorInverted: true,
+              size: 'large',
+              textAlign: 'center',
+            }}
+          >
+            {headingText}
+          </ShowOn>
+        </HorizontalGutters>
+        <HorizontalGutters>
+          <Grid areColumnsCentered>
+            <GridRow horizontalAlignContent="center">
+              <ShowOn
+                computer
+                parent={SearchBar}
+                parentProps={{
+                  ...searchBarSharedProps,
+                  willDropdownsOpenAbove: true,
+                }}
+                tablet
+                widescreen
               />
-            </ShowOn>
-          </GridRow>
-        </Grid>
-      </HorizontalGutters>
-    </FlexContainer>
-  </Hero>
-);
+              <ShowOn mobile>
+                <SearchBar
+                  {...searchBarSharedProps}
+                  isDisplayedAsModal
+                  modalHeadingText={searchBarModalHeadingText}
+                />
+              </ShowOn>
+            </GridRow>
+          </Grid>
+        </HorizontalGutters>
+      </FlexContainer>
+    </Hero>
+  );
+};
 
 Component.displayName = 'HomepageHero';
 
@@ -154,6 +153,7 @@ Component.defaultProps = {
   searchBarLocationInputInitialValue: undefined,
   placeholderBackgroundImageUrl: null,
   searchBarDateRangePickerLocaleCode: undefined,
+  searchBarDatesInputOnFocusChange: Function.prototype,
   searchBarGetIsDayBlocked: undefined,
   searchBarLocationOptions: undefined,
   searchBarModalHeadingText: CHECK_OUR_AVAILABILITY,
@@ -228,6 +228,12 @@ Component.propTypes = {
     endDate: PropTypes.object,
     startDate: PropTypes.object,
   }),
+  /**
+   * A function called when the focus state of the dates input in the search bar changes.
+   * @param {String} inputName
+   */
+  // eslint-disable-next-line react/no-unused-prop-types
+  searchBarDatesInputOnFocusChange: PropTypes.func,
   /**
    * A function called for each day to be displayed in the DateRangePicker.
    * Returning true blocks that day in the date range picker.

--- a/src/components/general-widgets/SearchBar/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/SearchBar/__snapshots__/component.spec.js.snap
@@ -5,6 +5,7 @@ exports[`<SearchBar /> by default should render the right structure 1`] = `
   className={null}
   dateRangePickerLocaleCode="ko"
   datesInputInitialValue={null}
+  datesInputOnFocusChange={[Function]}
   getIsDayBlocked={[Function]}
   guestsInputInitialValue={null}
   guestsOptions={
@@ -429,6 +430,7 @@ exports[`<SearchBar /> by default should render the right structure 1`] = `
                   localeCode="ko"
                   name="dates"
                   onChange={[Function]}
+                  onFocusChange={[Function]}
                   startDatePlaceholderText="Check-in"
                   willOpenAbove={false}
                 >
@@ -441,6 +443,7 @@ exports[`<SearchBar /> by default should render the right structure 1`] = `
                     localeCode="ko"
                     name="dates"
                     onChange={[Function]}
+                    onFocusChange={[Function]}
                     onUpdate={[Function]}
                     startDatePlaceholderText="Check-in"
                     willOpenAbove={false}
@@ -458,6 +461,7 @@ exports[`<SearchBar /> by default should render the right structure 1`] = `
                       name="dates"
                       onBlur={[Function]}
                       onChange={[Function]}
+                      onFocusChange={[Function]}
                       startDatePlaceholderText="Check-in"
                       willOpenAbove={false}
                       windowInnerWidth={1024}
@@ -984,6 +988,7 @@ exports[`<SearchBar /> if \`props.isFixed\` is true should render the right stru
   className={null}
   dateRangePickerLocaleCode="ko"
   datesInputInitialValue={null}
+  datesInputOnFocusChange={[Function]}
   getIsDayBlocked={[Function]}
   guestsInputInitialValue={null}
   guestsOptions={
@@ -1461,6 +1466,7 @@ exports[`<SearchBar /> if \`props.isFixed\` is true should render the right stru
                                           localeCode="ko"
                                           name="dates"
                                           onChange={[Function]}
+                                          onFocusChange={[Function]}
                                           startDatePlaceholderText="Check-in"
                                           willOpenAbove={true}
                                         >
@@ -1473,6 +1479,7 @@ exports[`<SearchBar /> if \`props.isFixed\` is true should render the right stru
                                             localeCode="ko"
                                             name="dates"
                                             onChange={[Function]}
+                                            onFocusChange={[Function]}
                                             onUpdate={[Function]}
                                             startDatePlaceholderText="Check-in"
                                             willOpenAbove={true}
@@ -1490,6 +1497,7 @@ exports[`<SearchBar /> if \`props.isFixed\` is true should render the right stru
                                               name="dates"
                                               onBlur={[Function]}
                                               onChange={[Function]}
+                                              onFocusChange={[Function]}
                                               startDatePlaceholderText="Check-in"
                                               willOpenAbove={true}
                                               windowInnerWidth={1024}
@@ -2026,6 +2034,7 @@ exports[`<SearchBar /> if \`props.isShowingSummary\` is true should render the r
   className={null}
   dateRangePickerLocaleCode="ko"
   datesInputInitialValue={null}
+  datesInputOnFocusChange={[Function]}
   getIsDayBlocked={[Function]}
   guestsInputInitialValue={null}
   guestsOptions={
@@ -2495,6 +2504,7 @@ exports[`<SearchBar /> if \`props.isShowingSummary\` is true should render the r
                   localeCode="ko"
                   name="dates"
                   onChange={[Function]}
+                  onFocusChange={[Function]}
                   startDatePlaceholderText="Check-in"
                   willOpenAbove={false}
                 >
@@ -2507,6 +2517,7 @@ exports[`<SearchBar /> if \`props.isShowingSummary\` is true should render the r
                     localeCode="ko"
                     name="dates"
                     onChange={[Function]}
+                    onFocusChange={[Function]}
                     onUpdate={[Function]}
                     startDatePlaceholderText="Check-in"
                     willOpenAbove={false}
@@ -2524,6 +2535,7 @@ exports[`<SearchBar /> if \`props.isShowingSummary\` is true should render the r
                       name="dates"
                       onBlur={[Function]}
                       onChange={[Function]}
+                      onFocusChange={[Function]}
                       startDatePlaceholderText="Check-in"
                       willOpenAbove={false}
                       windowInnerWidth={1024}
@@ -3048,6 +3060,7 @@ exports[`<SearchBar /> if \`props.locationOptions\` is not passed should render 
   className={null}
   dateRangePickerLocaleCode="ko"
   datesInputInitialValue={null}
+  datesInputOnFocusChange={[Function]}
   getIsDayBlocked={[Function]}
   guestsInputInitialValue={null}
   guestsOptions={
@@ -3127,6 +3140,7 @@ exports[`<SearchBar /> if \`props.locationOptions\` is not passed should render 
                   localeCode="ko"
                   name="dates"
                   onChange={[Function]}
+                  onFocusChange={[Function]}
                   startDatePlaceholderText="Check-in"
                   willOpenAbove={false}
                 >
@@ -3139,6 +3153,7 @@ exports[`<SearchBar /> if \`props.locationOptions\` is not passed should render 
                     localeCode="ko"
                     name="dates"
                     onChange={[Function]}
+                    onFocusChange={[Function]}
                     onUpdate={[Function]}
                     startDatePlaceholderText="Check-in"
                     willOpenAbove={false}
@@ -3156,6 +3171,7 @@ exports[`<SearchBar /> if \`props.locationOptions\` is not passed should render 
                       name="dates"
                       onBlur={[Function]}
                       onChange={[Function]}
+                      onFocusChange={[Function]}
                       startDatePlaceholderText="Check-in"
                       willOpenAbove={false}
                       windowInnerWidth={1024}
@@ -3680,6 +3696,7 @@ exports[`<SearchBar /> if \`props.searchButton\` is passed should render the rig
   className={null}
   dateRangePickerLocaleCode="ko"
   datesInputInitialValue={null}
+  datesInputOnFocusChange={[Function]}
   getIsDayBlocked={[Function]}
   guestsInputInitialValue={null}
   guestsOptions={
@@ -4089,6 +4106,7 @@ exports[`<SearchBar /> if \`props.searchButton\` is passed should render the rig
                   localeCode="ko"
                   name="dates"
                   onChange={[Function]}
+                  onFocusChange={[Function]}
                   startDatePlaceholderText="Check-in"
                   willOpenAbove={false}
                 >
@@ -4101,6 +4119,7 @@ exports[`<SearchBar /> if \`props.searchButton\` is passed should render the rig
                     localeCode="ko"
                     name="dates"
                     onChange={[Function]}
+                    onFocusChange={[Function]}
                     onUpdate={[Function]}
                     startDatePlaceholderText="Check-in"
                     willOpenAbove={false}
@@ -4118,6 +4137,7 @@ exports[`<SearchBar /> if \`props.searchButton\` is passed should render the rig
                       name="dates"
                       onBlur={[Function]}
                       onChange={[Function]}
+                      onFocusChange={[Function]}
                       startDatePlaceholderText="Check-in"
                       willOpenAbove={false}
                       windowInnerWidth={1024}

--- a/src/components/general-widgets/SearchBar/component.js
+++ b/src/components/general-widgets/SearchBar/component.js
@@ -41,11 +41,8 @@ export class Component extends PureComponent {
   render = () => {
     const {
       className,
-      datesInputInitialValue,
-      guestsInputInitialValue,
       isDisplayedAsModal,
       isFixed,
-      locationInputInitialValue,
       summaryElement,
       willDropdownsOpenAbove,
     } = this.props;
@@ -71,9 +68,6 @@ export class Component extends PureComponent {
                           this.props,
                           this.persistInputChange,
                           false,
-                          datesInputInitialValue,
-                          guestsInputInitialValue,
-                          locationInputInitialValue,
                           true
                         )}
                       </Form.Group>
@@ -99,9 +93,6 @@ export class Component extends PureComponent {
               this.props,
               this.persistInputChange,
               false,
-              datesInputInitialValue,
-              guestsInputInitialValue,
-              locationInputInitialValue,
               willDropdownsOpenAbove
             )}
           </Form.Group>
@@ -116,6 +107,7 @@ Component.displayName = 'SearchBar';
 Component.defaultProps = {
   className: null,
   datesInputInitialValue: null,
+  datesInputOnFocusChange: Function.prototype,
   dateRangePickerLocaleCode: undefined,
   getIsDayBlocked: Function.prototype,
   guestsInputInitialValue: null,
@@ -154,6 +146,12 @@ Component.propTypes = {
     endDate: PropTypes.object,
     startDate: PropTypes.object,
   }),
+  /**
+   * A function called when the focus state of the dates input changes.
+   * @param {String} inputName
+   */
+  // eslint-disable-next-line react/no-unused-prop-types
+  datesInputOnFocusChange: PropTypes.func,
   /**
    * A function called for each day to be displayed in the DateRangePicker. Returning true blocks that day in the date range picker.
    * @param   {Moment}  day - The day to test.

--- a/src/components/general-widgets/SearchBar/utils/__snapshots__/getFormFieldMarkup.spec.js.snap
+++ b/src/components/general-widgets/SearchBar/utils/__snapshots__/getFormFieldMarkup.spec.js.snap
@@ -42,7 +42,7 @@ exports[`getFormFieldMarkup if \`props.locationOptions\` size is greater than 0 
           },
         ]
       }
-      willOpenAbove={false}
+      willOpenAbove={true}
     />
   </FormField>
   <FormField
@@ -51,10 +51,10 @@ exports[`getFormFieldMarkup if \`props.locationOptions\` size is greater than 0 
     <WithResponsive(DateRangePicker)
       endDatePlaceholderText="Check-out"
       getIsDayBlocked={[Function]}
-      initialValue={true}
       name="dates"
       onChange={[Function]}
       startDatePlaceholderText="Check-in"
+      willOpenAbove={true}
     />
   </FormField>
   <FormField
@@ -73,7 +73,7 @@ exports[`getFormFieldMarkup if \`props.locationOptions\` size is greater than 0 
       onBlur={[Function]}
       onChange={[Function]}
       options={Array []}
-      willOpenAbove={false}
+      willOpenAbove={true}
     />
   </FormField>
   <FormField
@@ -110,10 +110,10 @@ exports[`getFormFieldMarkup should render the right structure\` 1`] = `
     <WithResponsive(DateRangePicker)
       endDatePlaceholderText="Check-out"
       getIsDayBlocked={[Function]}
-      initialValue={true}
       name="dates"
       onChange={[Function]}
       startDatePlaceholderText="Check-in"
+      willOpenAbove={true}
     />
   </FormField>
   <FormField
@@ -132,7 +132,7 @@ exports[`getFormFieldMarkup should render the right structure\` 1`] = `
       onBlur={[Function]}
       onChange={[Function]}
       options={Array []}
-      willOpenAbove={false}
+      willOpenAbove={true}
     />
   </FormField>
   <FormField

--- a/src/components/general-widgets/SearchBar/utils/getFormFieldMarkup.js
+++ b/src/components/general-widgets/SearchBar/utils/getFormFieldMarkup.js
@@ -10,33 +10,35 @@ import { DateRangePicker } from 'inputs/DateRangePicker';
 /**
  * @param  {Object}   props
  * @param  {string}   props.dateRangePickerLocaleCode
- * @param  {boolean}  props.isShowingSummary
+ * @param  {Object}   props.datesInputInitialValue
+ * @param  {Function} props.datesInputOnFocusChange
  * @param  {Function} props.getIsDayBlocked
- * @param  {Object[]} props.locationOptions
  * @param  {Object[]} props.guestsOptions
+ * @param  {string}   props.guestsInputInitialValue
+ * @param  {boolean}  props.isShowingSummary
+ * @param  {string}   props.locationInputInitialValue
+ * @param  {Object[]} props.locationOptions
  * @param  {Node}     props.searchButton
- * @param  {Function} onDatePickerChange
+ * @param  {Function} persistInputChange
  * @param  {boolean}  areColumnsStacked
- * @param  {Object}   datesInputInitialValue
- * @param  {string}   guestsInputInitialValue
- * @param  {string}   locationInputInitialValue
  * @param  {boolean}  willDropdownsOpenAbove
  * @return {Object}
  */
 export const getFormFieldMarkup = (
   {
     dateRangePickerLocaleCode,
-    isShowingSummary,
+    datesInputInitialValue,
+    datesInputOnFocusChange,
     getIsDayBlocked,
-    locationOptions,
+    guestsInputInitialValue,
     guestsOptions,
+    isShowingSummary,
+    locationInputInitialValue,
+    locationOptions,
     searchButton,
   },
-  onDatePickerChange,
+  persistInputChange,
   areColumnsStacked,
-  datesInputInitialValue,
-  guestsInputInitialValue,
-  locationInputInitialValue,
   willDropdownsOpenAbove
 ) => {
   const defaultColumnWidth = areColumnsStacked ? 'twelve' : 'three';
@@ -61,7 +63,7 @@ export const getFormFieldMarkup = (
             initialValue={locationInputInitialValue}
             label="Location"
             name="location"
-            onChange={onDatePickerChange}
+            onChange={persistInputChange}
             options={locationOptions}
             willOpenAbove={willDropdownsOpenAbove}
           />
@@ -74,7 +76,8 @@ export const getFormFieldMarkup = (
           initialValue={datesInputInitialValue}
           localeCode={dateRangePickerLocaleCode}
           name="dates"
-          onChange={onDatePickerChange}
+          onChange={persistInputChange}
+          onFocusChange={datesInputOnFocusChange}
           startDatePlaceholderText="Check-in"
           willOpenAbove={willDropdownsOpenAbove}
         />
@@ -85,7 +88,7 @@ export const getFormFieldMarkup = (
           initialValue={guestsInputInitialValue}
           label="Guests"
           name="guests"
-          onChange={onDatePickerChange}
+          onChange={persistInputChange}
           options={guestsOptions}
           willOpenAbove={willDropdownsOpenAbove}
         />

--- a/src/components/inputs/DateRangePicker/__snapshots__/component.spec.js.snap
+++ b/src/components/inputs/DateRangePicker/__snapshots__/component.spec.js.snap
@@ -19,6 +19,7 @@ exports[`<DateRangePicker /> should render the right structure 1`] = `
       name=""
       onBlur={[Function]}
       onChange={[Function]}
+      onFocusChange={[Function]}
       startDatePlaceholderText=""
       willOpenAbove={false}
       windowInnerWidth={1024}

--- a/src/components/inputs/DateRangePicker/component.js
+++ b/src/components/inputs/DateRangePicker/component.js
@@ -38,9 +38,10 @@ class Component extends PureComponent {
   componentDidUpdate = (prevProps, prevState) => {
     const { focusedInput: prevFocusedInput } = prevState;
     const { focusedInput } = this.state;
-    const { onBlur } = this.props;
+    const { onBlur, onFocusChange } = this.props;
 
     isBlurEvent(prevFocusedInput, focusedInput) && onBlur();
+    prevFocusedInput !== focusedInput && onFocusChange(focusedInput);
   };
 
   handleFocusChange = focusedInput => {
@@ -132,6 +133,7 @@ Component.defaultProps = {
   name: '',
   onBlur: Function.prototype,
   onChange: Function.prototype,
+  onFocusChange: Function.prototype,
   startDatePlaceholderText: '',
   value: undefined,
   willOpenAbove: false,
@@ -175,6 +177,11 @@ Component.propTypes = {
    * @param {Moment} value.startDate
    */
   onChange: PropTypes.func,
+  /**
+   * A function called when the focus state of the date range picker changes.
+   * @param {String} inputName
+   */
+  onFocusChange: PropTypes.func,
   /** The visible placeholder text for the start date input. */
   startDatePlaceholderText: PropTypes.string,
   /** The current value of the input where it is consumed as a controlled component. */

--- a/src/components/inputs/DateRangePicker/component.spec.js
+++ b/src/components/inputs/DateRangePicker/component.spec.js
@@ -154,8 +154,8 @@ describe('<DateRangePicker />', () => {
       });
     });
 
-    describe('if there is a no blur event', () => {
-      it('should note call `props.onBlur`', () => {
+    describe('if there is no blur event', () => {
+      it('should not call `props.onBlur`', () => {
         const onBlur = jest.fn();
         const dateRangePicker = getWrappedDateRangePicker({ onBlur });
 
@@ -166,6 +166,57 @@ describe('<DateRangePicker />', () => {
         dateRangePicker.setState(state);
 
         expect(onBlur).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('if the focused input has changed', () => {
+      it('should call `props.onFocusChange` with the right arguments', () => {
+        const onFocusChange = jest.fn();
+        const dateRangePicker = getWrappedDateRangePicker({ onFocusChange });
+
+        const testCases = [
+          { previousFocusedInput: null, focusedInput: 'startDate' },
+          { previousFocusedInput: null, focusedInput: 'endDate' },
+          { previousFocusedInput: 'startDate', focusedInput: null },
+          { previousFocusedInput: 'startDate', focusedInput: 'endDate' },
+          { previousFocusedInput: 'endDate', focusedInput: null },
+          { previousFocusedInput: 'endDate', focusedInput: 'startDate' },
+        ];
+
+        testCases.forEach(({ previousFocusedInput, focusedInput }) => {
+          const prevState = { focusedInput: previousFocusedInput };
+          const state = { focusedInput };
+
+          dateRangePicker.setState(prevState);
+          onFocusChange.mockClear();
+          dateRangePicker.setState(state);
+
+          expect(onFocusChange).toHaveBeenCalledWith(focusedInput);
+        });
+      });
+    });
+
+    describe('if the focused input has not changed', () => {
+      it('should not call `props.onFocusChange`', () => {
+        const onFocusChange = jest.fn();
+        const dateRangePicker = getWrappedDateRangePicker({ onFocusChange });
+
+        const testCases = [
+          { previousFocusedInput: null, focusedInput: null },
+          { previousFocusedInput: 'startDate', focusedInput: 'startDate' },
+          { previousFocusedInput: 'endDate', focusedInput: 'endDate' },
+        ];
+
+        testCases.forEach(({ previousFocusedInput, focusedInput }) => {
+          const prevState = { focusedInput: previousFocusedInput };
+          const state = { focusedInput };
+
+          dateRangePicker.setState(prevState);
+          onFocusChange.mockClear();
+          dateRangePicker.setState(state);
+
+          expect(onFocusChange).not.toHaveBeenCalled();
+        });
       });
     });
   });

--- a/src/components/property-page-widgets/PropertyPageSearchBar/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/PropertyPageSearchBar/__snapshots__/component.spec.js.snap
@@ -2,6 +2,7 @@
 
 exports[`<PropertyPageSearchBar /> if \`isShowingPlaceholder\` === true should have the right structure 1`] = `
 <PropertyPageSearchBar
+  datesInputOnFocusChange={[Function]}
   getIsDayBlocked={[Function]}
   guestsOptions={
     Array [
@@ -81,6 +82,7 @@ exports[`<PropertyPageSearchBar /> if \`isShowingPlaceholder\` === true should h
         <SearchBar
           className={null}
           datesInputInitialValue={null}
+          datesInputOnFocusChange={[Function]}
           getIsDayBlocked={[Function]}
           guestsInputInitialValue={null}
           guestsOptions={
@@ -332,6 +334,7 @@ exports[`<PropertyPageSearchBar /> if \`isShowingPlaceholder\` === true should h
                                                   initialValue={null}
                                                   name="dates"
                                                   onChange={[Function]}
+                                                  onFocusChange={[Function]}
                                                   startDatePlaceholderText="Check-in"
                                                   willOpenAbove={true}
                                                 >
@@ -343,6 +346,7 @@ exports[`<PropertyPageSearchBar /> if \`isShowingPlaceholder\` === true should h
                                                     isUserOnMobile={false}
                                                     name="dates"
                                                     onChange={[Function]}
+                                                    onFocusChange={[Function]}
                                                     onUpdate={[Function]}
                                                     startDatePlaceholderText="Check-in"
                                                     willOpenAbove={true}
@@ -360,6 +364,7 @@ exports[`<PropertyPageSearchBar /> if \`isShowingPlaceholder\` === true should h
                                                       name="dates"
                                                       onBlur={[Function]}
                                                       onChange={[Function]}
+                                                      onFocusChange={[Function]}
                                                       startDatePlaceholderText="Check-in"
                                                       willOpenAbove={true}
                                                       windowInnerWidth={1024}
@@ -878,6 +883,7 @@ exports[`<PropertyPageSearchBar /> if \`isShowingPlaceholder\` === true should h
         <SearchBar
           className={null}
           datesInputInitialValue={null}
+          datesInputOnFocusChange={[Function]}
           getIsDayBlocked={[Function]}
           guestsInputInitialValue={null}
           guestsOptions={
@@ -1221,6 +1227,7 @@ exports[`<PropertyPageSearchBar /> if \`isShowingPlaceholder\` === true should h
 
 exports[`<PropertyPageSearchBar /> should have the right structure 1`] = `
 <PropertyPageSearchBar
+  datesInputOnFocusChange={[Function]}
   getIsDayBlocked={[Function]}
   guestsOptions={
     Array [
@@ -1300,6 +1307,7 @@ exports[`<PropertyPageSearchBar /> should have the right structure 1`] = `
         <SearchBar
           className={null}
           datesInputInitialValue={null}
+          datesInputOnFocusChange={[Function]}
           getIsDayBlocked={[Function]}
           guestsInputInitialValue={null}
           guestsOptions={
@@ -1709,6 +1717,7 @@ exports[`<PropertyPageSearchBar /> should have the right structure 1`] = `
                                                   initialValue={null}
                                                   name="dates"
                                                   onChange={[Function]}
+                                                  onFocusChange={[Function]}
                                                   startDatePlaceholderText="Check-in"
                                                   willOpenAbove={true}
                                                 >
@@ -1720,6 +1729,7 @@ exports[`<PropertyPageSearchBar /> should have the right structure 1`] = `
                                                     isUserOnMobile={false}
                                                     name="dates"
                                                     onChange={[Function]}
+                                                    onFocusChange={[Function]}
                                                     onUpdate={[Function]}
                                                     startDatePlaceholderText="Check-in"
                                                     willOpenAbove={true}
@@ -1737,6 +1747,7 @@ exports[`<PropertyPageSearchBar /> should have the right structure 1`] = `
                                                       name="dates"
                                                       onBlur={[Function]}
                                                       onChange={[Function]}
+                                                      onFocusChange={[Function]}
                                                       startDatePlaceholderText="Check-in"
                                                       willOpenAbove={true}
                                                       windowInnerWidth={1024}
@@ -2255,6 +2266,7 @@ exports[`<PropertyPageSearchBar /> should have the right structure 1`] = `
         <SearchBar
           className={null}
           datesInputInitialValue={null}
+          datesInputOnFocusChange={[Function]}
           getIsDayBlocked={[Function]}
           guestsInputInitialValue={null}
           guestsOptions={

--- a/src/components/property-page-widgets/PropertyPageSearchBar/component.js
+++ b/src/components/property-page-widgets/PropertyPageSearchBar/component.js
@@ -16,6 +16,7 @@ import { getSummaryMarkup } from './utils/getSummaryMarkup';
 export const Component = ({
   dateRangePickerLocaleCode,
   datesInputInitialValue,
+  datesInputOnFocusChange,
   getIsDayBlocked,
   guestsInputInitialValue,
   guestsOptions,
@@ -28,6 +29,24 @@ export const Component = ({
   summaryPropertyName,
   summaryRatingNumber,
 }) => {
+  const sharedProps = {
+    dateRangePickerLocaleCode,
+    datesInputInitialValue,
+    datesInputOnFocusChange,
+    getIsDayBlocked,
+    guestsInputInitialValue,
+    guestsOptions,
+    dateRangePickerLocaleCode,
+    datesInputInitialValue,
+    datesInputOnFocusChange,
+    getIsDayBlocked,
+    guestsInputInitialValue,
+    guestsOptions,
+    isFixed: true,
+    onChangeInput,
+    onSubmit,
+    searchButton,
+  };
   const summaryProps = {
     locationName: summaryLocationName,
     nightPrice: summaryNightPrice,
@@ -40,15 +59,7 @@ export const Component = ({
     <div className="property-page-searchbar">
       <ShowOn computer widescreen>
         <SearchBar
-          dateRangePickerLocaleCode={dateRangePickerLocaleCode}
-          datesInputInitialValue={datesInputInitialValue}
-          getIsDayBlocked={getIsDayBlocked}
-          guestsInputInitialValue={guestsInputInitialValue}
-          guestsOptions={guestsOptions}
-          isFixed
-          onChangeInput={onChangeInput}
-          onSubmit={onSubmit}
-          searchButton={searchButton}
+          {...sharedProps}
           summaryElement={getSummaryMarkup({
             areOnlyNightPriceAndRatingDisplayed: false,
             ...summaryProps,
@@ -57,20 +68,12 @@ export const Component = ({
       </ShowOn>
       <ShowOn mobile tablet>
         <SearchBar
-          dateRangePickerLocaleCode={dateRangePickerLocaleCode}
-          datesInputInitialValue={datesInputInitialValue}
-          getIsDayBlocked={getIsDayBlocked}
-          guestsInputInitialValue={guestsInputInitialValue}
-          guestsOptions={guestsOptions}
+          {...sharedProps}
           isDisplayedAsModal
-          isFixed
           modalSummaryElement={getSummaryMarkup({
             areOnlyNightPriceAndRatingDisplayed: false,
             ...summaryProps,
           })}
-          onChangeInput={onChangeInput}
-          onSubmit={onSubmit}
-          searchButton={searchButton}
           summaryElement={getSummaryMarkup({
             areOnlyNightPriceAndRatingDisplayed: true,
             ...summaryProps,
@@ -85,6 +88,7 @@ Component.displayName = 'PropertyPageSearchBar';
 
 Component.defaultProps = {
   datesInputInitialValue: undefined,
+  datesInputOnFocusChange: Function.prototype,
   dateRangePickerLocaleCode: undefined,
   getIsDayBlocked: undefined,
   guestsInputInitialValue: undefined,
@@ -109,6 +113,11 @@ Component.propTypes = {
     endDate: PropTypes.object,
     startDate: PropTypes.object,
   }),
+  /**
+   * A function called when the focus state of the dates input changes.
+   * @param {String} inputName
+   */
+  datesInputOnFocusChange: PropTypes.func,
   /**
    * A function called for each day to be displayed in the DateRangePicker. Returning true blocks that day in the date range picker.
    * @param   {Moment}  day - The day to test.


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-1996)

### What **one** thing does this PR do?
Exposes a functional prop called when `DateRangePicker` focus state changes.

#### Example when consumed in `HomepageHero`...
![Kapture 2019-03-13 at 17 53 42](https://user-images.githubusercontent.com/8591501/54298785-b6398500-45b9-11e9-9736-a0865e061156.gif)

