### PR TITLE
TE-2083 DateRangePicker: change styles for blocked and unblocked days

### DIFF
--- a/src/styles/semantic/definitions/third-party-components/react-dates-datepicker.less
+++ b/src/styles/semantic/definitions/third-party-components/react-dates-datepicker.less
@@ -144,6 +144,16 @@
       &.CalendarDay__hovered_span {
         background: @pickerDayHoveredBackground;
         color: inherit;
+
+        &.CalendarDay__blocked_calendar {
+          background: @pickerDayHoveredBackground;
+          color: inherit;
+
+          &:hover {
+            background: @pickerDayBlockedBackground;
+            color: @pickerDayBlockedFontColor;
+          }
+        }
       }
 
       &.CalendarDay__selected {
@@ -167,8 +177,8 @@
       }
     }
 
-    tr:not(:first-child) td.CalendarDay {
-      border-top: @pickerTableCellBorder;
+    tr td.CalendarDay {
+      border: @pickerTableCellBorder;
     }
   }
 }


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-2083)

### What **one** thing does this PR do?
Implements the requested styles for `DateRangePicker`; blocked and unblocked dates on hover. 

### Additional Notes
The following bug was solved in this PR:

#### Before
![Screenshot 2019-03-25 at 16 49 37](https://user-images.githubusercontent.com/33876435/54937364-90e73800-4f24-11e9-8ea6-f63ea26612c2.png)

#### After
![Screenshot 2019-03-25 at 17 38 26](https://user-images.githubusercontent.com/33876435/54937508-d146b600-4f24-11e9-9b34-a345489d7b9d.png)


### Current behaviour
![daterangepicker](https://user-images.githubusercontent.com/33876435/54937741-45815980-4f25-11e9-9315-c4a29349bcad.gif)





