### PR TITLE
TE-2139 PropertyPageHero: Accept gallery images with categories

### DIFF
--- a/src/components/property-page-widgets/PropertyPageHero/Readme.md
+++ b/src/components/property-page-widgets/PropertyPageHero/Readme.md
@@ -1,7 +1,7 @@
 ```jsx
 const logoSrc = require('./mock-data/livingstoneLogo.png');
-const { navigationItems } = require('./mock-data/mock-data');
-const images = [
+const { backgroundImageUrl, navigationItems } = require('./mock-data/mock-data');
+const galleryImages = [
   {
     imageUrl: 'https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max',
     label: 'Two Cats',
@@ -17,11 +17,12 @@ const images = [
 ];
 
 <PropertyPageHero
+  backgroundImageUrl={backgroundImageUrl}
   headerLogoSrc={logoSrc}
   headerLogoText="Livingstone Cottage"
   headerNavigationItems={navigationItems}
   headerPrimaryCTA={{ onClick: console.log, text: 'Book now'}}
-  images={images}
+  galleryImages={galleryImages}
   propertyName="Livingstone Cottage"
   ratingNumber={4.2}
 />
@@ -29,21 +30,21 @@ const images = [
 
 ### Variations
 
-#### With fewer than two images
+#### With fewer than two gallery images
 
-If there are fewer than two images, the gallery won't be displayed.
+If there are fewer than two gallery images, the gallery won't be displayed.
 
 ```jsx
 
 const logoSrc = require('./mock-data/livingstoneLogo.png');
-const { image, navigationItems } = require('./mock-data/mock-data');
-
+const { backgroundImageUrl, image, navigationItems } = require('./mock-data/mock-data');
 
 <PropertyPageHero
+  backgroundImageUrl={backgroundImageUrl}
   headerLogoSrc={logoSrc}
   headerLogoText="Livingstone Cottage"
   headerNavigationItems={navigationItems}
   headerPrimaryCTA={{ onClick: console.log, text: 'Book now'}}
-  images={image}
+  galleryImages={image}
 />
 ```

--- a/src/components/property-page-widgets/PropertyPageHero/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/PropertyPageHero/__snapshots__/component.spec.js.snap
@@ -1,8 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`PropertyPageHero if there are fewer than two images should render the right structure 1`] = `
+exports[`PropertyPageHero if there are fewer than two items in \`galleryImages\` should render the right structure 1`] = `
 <PropertyPageHero
   activeNavigationItemIndex={1}
+  backgroundImageUrl="some url"
+  galleryImages={
+    Array [
+      Object {
+        "imageUrl": "🚞",
+        "label": "Entrance",
+      },
+    ]
+  }
   headerLogoSizes="a load of logo sizes"
   headerLogoSrc="src"
   headerLogoSrcSet="a load of logo src sets"
@@ -21,22 +30,15 @@ exports[`PropertyPageHero if there are fewer than two images should render the r
       "text": "Book now",
     }
   }
-  images={
-    Array [
-      Object {
-        "imageUrl": "🚞",
-        "label": "Entrance",
-      },
-    ]
-  }
   isUserOnMobile={false}
+  placeholderBackgroundImageUrl={null}
   propertyName={null}
   ratingNumber={null}
   secondaryButtonText="🐸"
 >
   <Hero
     activeNavigationItemIndex={1}
-    backgroundImageUrl="🚞"
+    backgroundImageUrl="some url"
     bottomOffset="85px"
     headerLogoSizes="a load of logo sizes"
     headerLogoSrc="src"
@@ -62,7 +64,7 @@ exports[`PropertyPageHero if there are fewer than two images should render the r
     <FullBleed
       bottomOffset="85px"
       hasGradient={true}
-      imageUrl="🚞"
+      imageUrl="some url"
       placeholderImageUrl={null}
       sizes={null}
       srcSet={null}
@@ -85,7 +87,7 @@ exports[`PropertyPageHero if there are fewer than two images should render the r
           }
         >
           <withLazyLoad(ResponsiveImage)
-            imageUrl="🚞"
+            imageUrl="some url"
             isFluid={true}
             isLazyLoaded={false}
             placeholderImageUrl={null}
@@ -98,7 +100,7 @@ exports[`PropertyPageHero if there are fewer than two images should render the r
               imageHeight={null}
               imageNotFoundLabelText="Image not found!"
               imageTitle="Image Title"
-              imageUrl="🚞"
+              imageUrl="some url"
               imageWidth={null}
               isAvatar={false}
               isCircular={false}
@@ -119,7 +121,7 @@ exports[`PropertyPageHero if there are fewer than two images should render the r
                   fluid={true}
                   onLoad={[Function]}
                   sizes={null}
-                  src="🚞"
+                  src="some url"
                   srcSet={null}
                   title="Image Title"
                   ui={true}
@@ -129,7 +131,7 @@ exports[`PropertyPageHero if there are fewer than two images should render the r
                     className="ui fluid image"
                     onLoad={[Function]}
                     sizes={null}
-                    src="🚞"
+                    src="some url"
                     srcSet={null}
                     title="Image Title"
                   />
@@ -288,6 +290,19 @@ exports[`PropertyPageHero if there are fewer than two images should render the r
 exports[`PropertyPageHero should render the right structure 1`] = `
 <PropertyPageHero
   activeNavigationItemIndex={1}
+  backgroundImageUrl="some url"
+  galleryImages={
+    Array [
+      Object {
+        "imageUrl": "🚞",
+        "label": "Entrance",
+      },
+      Object {
+        "imageUrl": "🚞",
+        "label": "Kitchen",
+      },
+    ]
+  }
   headerLogoSizes="a load of logo sizes"
   headerLogoSrc="src"
   headerLogoSrcSet="a load of logo src sets"
@@ -306,26 +321,15 @@ exports[`PropertyPageHero should render the right structure 1`] = `
       "text": "Book now",
     }
   }
-  images={
-    Array [
-      Object {
-        "imageUrl": "🚞",
-        "label": "Entrance",
-      },
-      Object {
-        "imageUrl": "🚞",
-        "label": "Kitchen",
-      },
-    ]
-  }
   isUserOnMobile={false}
+  placeholderBackgroundImageUrl={null}
   propertyName={null}
   ratingNumber={null}
   secondaryButtonText="🐸"
 >
   <Hero
     activeNavigationItemIndex={1}
-    backgroundImageUrl="🚞"
+    backgroundImageUrl="some url"
     bottomOffset="85px"
     headerLogoSizes="a load of logo sizes"
     headerLogoSrc="src"
@@ -351,7 +355,7 @@ exports[`PropertyPageHero should render the right structure 1`] = `
     <FullBleed
       bottomOffset="85px"
       hasGradient={true}
-      imageUrl="🚞"
+      imageUrl="some url"
       placeholderImageUrl={null}
       sizes={null}
       srcSet={null}
@@ -374,7 +378,7 @@ exports[`PropertyPageHero should render the right structure 1`] = `
           }
         >
           <withLazyLoad(ResponsiveImage)
-            imageUrl="🚞"
+            imageUrl="some url"
             isFluid={true}
             isLazyLoaded={false}
             placeholderImageUrl={null}
@@ -387,7 +391,7 @@ exports[`PropertyPageHero should render the right structure 1`] = `
               imageHeight={null}
               imageNotFoundLabelText="Image not found!"
               imageTitle="Image Title"
-              imageUrl="🚞"
+              imageUrl="some url"
               imageWidth={null}
               isAvatar={false}
               isCircular={false}
@@ -408,7 +412,7 @@ exports[`PropertyPageHero should render the right structure 1`] = `
                   fluid={true}
                   onLoad={[Function]}
                   sizes={null}
-                  src="🚞"
+                  src="some url"
                   srcSet={null}
                   title="Image Title"
                   ui={true}
@@ -418,7 +422,7 @@ exports[`PropertyPageHero should render the right structure 1`] = `
                     className="ui fluid image"
                     onLoad={[Function]}
                     sizes={null}
-                    src="🚞"
+                    src="some url"
                     srcSet={null}
                     title="Image Title"
                   />

--- a/src/components/property-page-widgets/PropertyPageHero/component.js
+++ b/src/components/property-page-widgets/PropertyPageHero/component.js
@@ -14,6 +14,12 @@ import { getGalleryMarkup } from './utils/getGalleryMarkup';
 // eslint-disable-next-line jsdoc/require-jsdoc
 const Component = ({
   activeNavigationItemIndex,
+  backgroundImageHeight,
+  backgroundImageSizes,
+  backgroundImageSrcSet,
+  backgroundImageUrl,
+  backgroundImageWidth,
+  galleryImages,
   headerLogoHref,
   headerLogoSizes,
   headerLogoSrc,
@@ -21,58 +27,53 @@ const Component = ({
   headerLogoText,
   headerNavigationItems,
   headerPrimaryCTA,
-  images,
+  placeholderBackgroundImageUrl,
   propertyName,
   ratingNumber,
   secondaryButtonText,
-}) => {
-  const {
-    imageUrl: backgroundImageUrl,
-    sizes: backgroundImageSizes,
-    srcSet: backgroundImageSrcSet,
-    placeholderImageUrl,
-    imageWidth: backgroundImageHeight,
-    imageHeight: backgroundImageWidth,
-  } = images[0];
-
-  return (
-    <Hero
-      activeNavigationItemIndex={activeNavigationItemIndex}
-      backgroundImageHeight={backgroundImageHeight}
-      backgroundImageSizes={backgroundImageSizes}
-      backgroundImageSrcSet={backgroundImageSrcSet}
-      backgroundImageUrl={backgroundImageUrl}
-      backgroundImageWidth={backgroundImageWidth}
-      bottomOffset={BOTTOM_OFFSET}
-      headerLogoHref={headerLogoHref}
-      headerLogoSizes={headerLogoSizes}
-      headerLogoSrc={headerLogoSrc}
-      headerLogoSrcSet={headerLogoSrcSet}
-      headerLogoText={headerLogoText}
-      headerNavigationItems={headerNavigationItems}
-      headerPrimaryCTA={headerPrimaryCTA}
-      isFixedSearchBarDisplayed
-      placeholderBackgroundImageUrl={placeholderImageUrl}
-    >
-      {getGalleryMarkup(
-        images,
-        propertyName,
-        ratingNumber,
-        secondaryButtonText
-      )}
-    </Hero>
-  );
-};
+}) => (
+  <Hero
+    activeNavigationItemIndex={activeNavigationItemIndex}
+    backgroundImageHeight={backgroundImageHeight}
+    backgroundImageSizes={backgroundImageSizes}
+    backgroundImageSrcSet={backgroundImageSrcSet}
+    backgroundImageUrl={backgroundImageUrl}
+    backgroundImageWidth={backgroundImageWidth}
+    bottomOffset={BOTTOM_OFFSET}
+    headerLogoHref={headerLogoHref}
+    headerLogoSizes={headerLogoSizes}
+    headerLogoSrc={headerLogoSrc}
+    headerLogoSrcSet={headerLogoSrcSet}
+    headerLogoText={headerLogoText}
+    headerNavigationItems={headerNavigationItems}
+    headerPrimaryCTA={headerPrimaryCTA}
+    isFixedSearchBarDisplayed
+    placeholderBackgroundImageUrl={placeholderBackgroundImageUrl}
+  >
+    {getGalleryMarkup(
+      galleryImages,
+      propertyName,
+      ratingNumber,
+      secondaryButtonText
+    )}
+  </Hero>
+);
 
 Component.displayName = 'PropertyPageHero';
 
 Component.defaultProps = {
   activeNavigationItemIndex: null,
+  backgroundImageHeight: undefined,
+  backgroundImageSizes: undefined,
+  backgroundImageSrcSet: undefined,
+  backgroundImageWidth: undefined,
+  galleryImages: [],
   headerLogoHref: undefined,
   headerLogoSizes: undefined,
   headerLogoSrc: null,
   headerLogoSrcSet: undefined,
   headerPrimaryCTA: null,
+  placeholderBackgroundImageUrl: null,
   propertyName: null,
   ratingNumber: null,
   secondaryButtonText: VIEW_MORE_PICTURES,
@@ -81,6 +82,53 @@ Component.defaultProps = {
 Component.propTypes = {
   /** The index of the active navigation item. */
   activeNavigationItemIndex: PropTypes.number,
+  /** The natural height of the background image. */
+  backgroundImageHeight: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+  ]),
+  /** A list of one or more strings separated by commas indicating a set of source sizes for the image. See [the MDN docs for more information](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img). */
+  backgroundImageSizes: PropTypes.string,
+  /** A list of one or more strings separated by commas indicating a set of possible image sources for the user agent to use for the image. See [the MDN docs for more information](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img). */
+  backgroundImageSrcSet: PropTypes.string,
+  /** The source url of the hero's background image. */
+  backgroundImageUrl: PropTypes.string.isRequired,
+  /** The natural width of the background image. */
+  backgroundImageWidth: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+  ]),
+  /** The images to display in the gallery modal. */
+  galleryImages: PropTypes.arrayOf(
+    PropTypes.oneOfType([
+      PropTypes.shape({
+        /** The text to display above an isolated category of images. */
+        categoryText: PropTypes.string,
+      }),
+      PropTypes.shape({
+        /** Alternative text to show if the image can't be loaded by the browser */
+        alternativeText: PropTypes.string,
+        /** The natural height of the image. */
+        imageHeight: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+        /** The label text for the when the image is not found. */
+        imageNotFoundLabelText: PropTypes.string,
+        /** Title of the image to show when hovering it on desktop browsers */
+        imageTitle: PropTypes.string,
+        /** URL pointing to the image to display. */
+        imageUrl: PropTypes.string.isRequired,
+        /** The natural width of the image. */
+        imageWidth: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+        /** A visible label for the image. */
+        label: PropTypes.string.isRequired,
+        /** URL pointing to the placeholder image to display. */
+        placeholderImageUrl: PropTypes.string,
+        /** A list of one or more strings separated by commas indicating a set of source sizes. See [the MDN docs for more information](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img). */
+        sizes: PropTypes.string,
+        /** A list of one or more strings separated by commas indicating a set of possible image sources for the user agent to use. See [the MDN docs for more information](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img). */
+        srcSet: PropTypes.string,
+      }),
+    ])
+  ),
   /** The href for the header logo link. */
   headerLogoHref: PropTypes.string,
   /** A list of one or more strings separated by commas indicating a set of source sizes for the header logo. See [the MDN docs for more information](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img). */
@@ -117,37 +165,8 @@ Component.propTypes = {
     /** The  visible text for the call to action. */
     text: PropTypes.string.isRequired,
   }),
-  /** The images to display in the gallery modal. */
-  images: PropTypes.arrayOf(
-    PropTypes.oneOfType([
-      PropTypes.shape({
-        /** The text to display above an isolated category of images. */
-        categoryText: PropTypes.string,
-      }),
-      PropTypes.shape({
-        /** Alternative text to show if the image can't be loaded by the browser */
-        alternativeText: PropTypes.string,
-        /** The natural height of the image. */
-        imageHeight: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-        /** The label text for the when the image is not found. */
-        imageNotFoundLabelText: PropTypes.string,
-        /** Title of the image to show when hovering it on desktop browsers */
-        imageTitle: PropTypes.string,
-        /** URL pointing to the image to display. */
-        imageUrl: PropTypes.string.isRequired,
-        /** The natural width of the image. */
-        imageWidth: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-        /** A visible label for the image. */
-        label: PropTypes.string.isRequired,
-        /** URL pointing to the placeholder image to display. */
-        placeholderImageUrl: PropTypes.string,
-        /** A list of one or more strings separated by commas indicating a set of source sizes. See [the MDN docs for more information](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img). */
-        sizes: PropTypes.string,
-        /** A list of one or more strings separated by commas indicating a set of possible image sources for the user agent to use. See [the MDN docs for more information](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img). */
-        srcSet: PropTypes.string,
-      }),
-    ])
-  ).isRequired,
+  /** The background placeholder image url of the hero. */
+  placeholderBackgroundImageUrl: PropTypes.string,
   /** The name of the property to display in the gallery modal. */
   propertyName: PropTypes.string,
   /** The numeral rating for the property, out of 5 */

--- a/src/components/property-page-widgets/PropertyPageHero/component.spec.js
+++ b/src/components/property-page-widgets/PropertyPageHero/component.spec.js
@@ -20,13 +20,17 @@ const imageUrl = '🚞';
 
 const props = {
   activeNavigationItemIndex: 1,
+  backgroundImageUrl: 'some url',
   headerLogoSizes: 'a load of logo sizes',
   headerLogoSrc: 'src',
   headerLogoSrcSet: 'a load of logo src sets',
   headerLogoText: 'text',
   headerNavigationItems: [{ text: 'Home', href: '/' }],
   headerPrimaryCTA: { onClick: Function.prototype, text: 'Book now' },
-  images: [{ imageUrl, label: 'Entrance' }, { imageUrl, label: 'Kitchen' }],
+  galleryImages: [
+    { imageUrl, label: 'Entrance' },
+    { imageUrl, label: 'Kitchen' },
+  ],
   secondaryButtonText: '🐸',
 };
 
@@ -45,10 +49,10 @@ describe('PropertyPageHero', () => {
     expect(actual).toMatchSnapshot();
   });
 
-  describe('if there are fewer than two images', () => {
+  describe('if there are fewer than two items in `galleryImages`', () => {
     it('should render the right structure', () => {
       const actual = getWrappedPropertyPageHero({
-        images: [{ imageUrl, label: 'Entrance' }],
+        galleryImages: [{ imageUrl, label: 'Entrance' }],
       });
 
       expect(actual).toMatchSnapshot();


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-2139)

### What **one** thing does this PR do?
Decouples the background image from the gallery images in `PropertyPageHero` so we can deal with categorised gallery images better.

### Any other notes
The component API now matches that of `HomepageHero` so there is nothing controversial in the way this is laid out.
