### PR TITLE
TE-2084 `DateRangePicker`: expose `props.focusedInput`

### DIFF
--- a/src/components/general-widgets/HomepageHero/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/HomepageHero/__snapshots__/component.spec.js.snap
@@ -428,6 +428,7 @@ exports[`HomepageHero should render the right structure 1`] = `
                                   parentProps={
                                     Object {
                                       "dateRangePickerLocaleCode": undefined,
+                                      "datesInputFocusedInput": undefined,
                                       "datesInputOnFocusChange": [Function],
                                       "datesInputValue": undefined,
                                       "getIsDayBlocked": [Function],

--- a/src/components/general-widgets/HomepageHero/component.js
+++ b/src/components/general-widgets/HomepageHero/component.js
@@ -32,8 +32,9 @@ export const Component = ({
   headingText,
   placeholderBackgroundImageUrl,
   searchBarDateRangePickerLocaleCode,
-  searchBarDatesInputValue,
+  searchBarDatesInputFocusedInput,
   searchBarDatesInputOnFocusChange,
+  searchBarDatesInputValue,
   searchBarGetIsDayBlocked,
   searchBarGuestsInputValue,
   searchBarGuestsOptions,
@@ -46,8 +47,9 @@ export const Component = ({
 }) => {
   const searchBarSharedProps = {
     dateRangePickerLocaleCode: searchBarDateRangePickerLocaleCode,
-    datesInputValue: searchBarDatesInputValue,
+    datesInputFocusedInput: searchBarDatesInputFocusedInput,
     datesInputOnFocusChange: searchBarDatesInputOnFocusChange,
+    datesInputValue: searchBarDatesInputValue,
     getIsDayBlocked: searchBarGetIsDayBlocked,
     guestsInputValue: searchBarGuestsInputValue,
     guestsOptions: searchBarGuestsOptions,
@@ -153,6 +155,7 @@ Component.defaultProps = {
   searchBarLocationInputValue: undefined,
   placeholderBackgroundImageUrl: null,
   searchBarDateRangePickerLocaleCode: undefined,
+  searchBarDatesInputFocusedInput: undefined,
   searchBarDatesInputOnFocusChange: Function.prototype,
   searchBarGetIsDayBlocked: undefined,
   searchBarLocationOptions: undefined,
@@ -223,11 +226,16 @@ Component.propTypes = {
   placeholderBackgroundImageUrl: PropTypes.string,
   /** The ISO 639-1 locale code which changes the format and language of days of the week and the months of the year in the search bars date range picker. */
   searchBarDateRangePickerLocaleCode: PropTypes.string,
+  /** The field of the dates input which is currently focused. Used when consuming `PropertyPageSearchBar` as a controlled component. */
+  searchBarDatesInputFocusedInput: PropTypes.oneOf([
+    null,
+    'startDate',
+    'endDate',
+  ]),
   /**
    * A function called when the focus state of the dates input in the search bar changes.
    * @param {String} inputName
    */
-  // eslint-disable-next-line react/no-unused-prop-types
   searchBarDatesInputOnFocusChange: PropTypes.func,
   /** The value for the dates input of the search bar. Used when consuming `HomepageHero` as a controlled component. */
   searchBarDatesInputValue: PropTypes.shape({

--- a/src/components/general-widgets/SearchBar/component.js
+++ b/src/components/general-widgets/SearchBar/component.js
@@ -107,9 +107,10 @@ Component.displayName = 'SearchBar';
 
 Component.defaultProps = {
   className: null,
-  datesInputValue: undefined,
-  datesInputOnFocusChange: Function.prototype,
   dateRangePickerLocaleCode: undefined,
+  datesInputFocusedInput: undefined,
+  datesInputOnFocusChange: Function.prototype,
+  datesInputValue: undefined,
   getIsDayBlocked: Function.prototype,
   guestsInputValue: undefined,
   isDisplayedAsModal: false,
@@ -142,6 +143,9 @@ Component.propTypes = {
   /** The ISO 639-1 locale code which changes the format and language of days of the week and the months of the year in the date range picker. */
   // eslint-disable-next-line react/no-unused-prop-types
   dateRangePickerLocaleCode: PropTypes.string,
+  /** The field of the dates input which is currently focused. Used when consuming `SearchBar` as a controlled component. */
+  // eslint-disable-next-line react/no-unused-prop-types
+  datesInputFocusedInput: PropTypes.oneOf([null, 'startDate', 'endDate']),
   /**
    * A function called when the focus state of the dates input changes.
    * @param {String} inputName

--- a/src/components/general-widgets/SearchBar/utils/getFormFieldMarkup.js
+++ b/src/components/general-widgets/SearchBar/utils/getFormFieldMarkup.js
@@ -27,6 +27,7 @@ import { DateRangePicker } from 'inputs/DateRangePicker';
 export const getFormFieldMarkup = (
   {
     dateRangePickerLocaleCode,
+    datesInputFocusedInput,
     datesInputValue,
     datesInputOnFocusChange,
     getIsDayBlocked,
@@ -72,6 +73,7 @@ export const getFormFieldMarkup = (
       <Form.Field width={datePickerColumnWidth}>
         <DateRangePicker
           endDatePlaceholderText="Check-out"
+          focusedInput={datesInputFocusedInput}
           getIsDayBlocked={getIsDayBlocked}
           localeCode={dateRangePickerLocaleCode}
           name="dates"

--- a/src/components/inputs/DateRangePicker/__snapshots__/component.spec.js.snap
+++ b/src/components/inputs/DateRangePicker/__snapshots__/component.spec.js.snap
@@ -1,5 +1,146 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<DateRangePicker /> if \`props.focusedInput\` is passed should render the right structure 1`] = `
+<WithResponsive(DateRangePicker)
+  focusedInput="startDate"
+>
+  <Responsive
+    as={[Function]}
+    focusedInput="startDate"
+    isUserOnMobile={false}
+    onUpdate={[Function]}
+    windowInnerWidth={1024}
+  >
+    <DateRangePicker
+      displayFormat="DD/MM/YYYY"
+      endDatePlaceholderText=""
+      error={false}
+      focusedInput="startDate"
+      getIsDayBlocked={[Function]}
+      isUserOnMobile={false}
+      isValid={false}
+      localeCode="en"
+      name=""
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocusChange={[Function]}
+      startDatePlaceholderText=""
+      willOpenAbove={false}
+      windowInnerWidth={1024}
+    >
+      <InputController
+        adaptOnChangeEvent={[Function]}
+        error={false}
+        icon={null}
+        initialValue=""
+        inputOnChangeFunctionName="onDatesChange"
+        isFocused={true}
+        isValid={false}
+        label={null}
+        mapValueToProps={[Function]}
+        name=""
+        onChange={[Function]}
+      >
+        <Input
+          className="focus"
+          iconPosition={null}
+          type="text"
+        >
+          <div
+            className="ui input focus"
+          >
+            <DateRangePicker
+              customArrowIcon={
+                <Icon
+                  color={null}
+                  hasBorder={false}
+                  isButton={false}
+                  isCircular={false}
+                  isColorInverted={false}
+                  isDisabled={false}
+                  isLabelLeft={false}
+                  labelText={null}
+                  labelWeight={null}
+                  name="arrow right"
+                  path={null}
+                  size={null}
+                />
+              }
+              customInputIcon={
+                <Icon
+                  color={null}
+                  hasBorder={false}
+                  isButton={false}
+                  isCircular={false}
+                  isColorInverted={false}
+                  isDisabled={false}
+                  isLabelLeft={false}
+                  labelText={null}
+                  labelWeight={null}
+                  name="calendar"
+                  path={null}
+                  size={null}
+                />
+              }
+              daySize={52}
+              displayFormat="DD/MM/YYYY"
+              endDate={null}
+              endDateId="end_date_id_7"
+              endDatePlaceholderText=""
+              focusedInput="startDate"
+              hideKeyboardShortcutsPanel={true}
+              isDayBlocked={[Function]}
+              key=".1"
+              navNext={
+                <Icon
+                  color={null}
+                  hasBorder={false}
+                  isButton={false}
+                  isCircular={false}
+                  isColorInverted={false}
+                  isDisabled={false}
+                  isLabelLeft={false}
+                  labelText={null}
+                  labelWeight={null}
+                  name="arrow right"
+                  path={null}
+                  size={null}
+                />
+              }
+              navPrev={
+                <Icon
+                  color={null}
+                  hasBorder={false}
+                  isButton={false}
+                  isCircular={false}
+                  isColorInverted={false}
+                  isDisabled={false}
+                  isLabelLeft={false}
+                  labelText={null}
+                  labelWeight={null}
+                  name="arrow left"
+                  path={null}
+                  size={null}
+                />
+              }
+              onDatesChange={[Function]}
+              onFocusChange={[Function]}
+              openDirection="down"
+              startDate={null}
+              startDateId="start_date_id_8"
+              startDatePlaceholderText=""
+              withPortal={false}
+            >
+              <div />
+            </DateRangePicker>
+          </div>
+        </Input>
+      </InputController>
+    </DateRangePicker>
+  </Responsive>
+</WithResponsive(DateRangePicker)>
+`;
+
 exports[`<DateRangePicker /> should render the right structure 1`] = `
 <WithResponsive(DateRangePicker)>
   <Responsive

--- a/src/components/inputs/DateRangePicker/component.js
+++ b/src/components/inputs/DateRangePicker/component.js
@@ -16,6 +16,7 @@ import { getWindowHeight } from 'utils/get-window-height';
 import { isDisplayedAsModal } from 'utils/is-displayed-as-modal';
 
 import { mapValueToProps } from './utils/mapValueToProps';
+import { getFocusedInput } from './utils/getFocusedInput';
 import { getNumberOfMonths } from './utils/getNumberOfMonths';
 import { MAXIMUM_SCREEN_WIDTH_FOR_TWO_MONTH_CALENDAR } from './constants';
 
@@ -63,6 +64,7 @@ class Component extends PureComponent {
       displayFormat,
       endDatePlaceholderText,
       error,
+      focusedInput: controlledFocusedInput,
       getIsDayBlocked,
       initialValue,
       isValid,
@@ -73,7 +75,11 @@ class Component extends PureComponent {
       willOpenAbove,
       windowInnerWidth,
     } = this.props;
-    const { focusedInput } = this.state;
+    const { focusedInput: uncontrolledFocusedInput } = this.state;
+    const focusedInput = getFocusedInput(
+      controlledFocusedInput,
+      uncontrolledFocusedInput
+    );
 
     return (
       <InputController
@@ -126,6 +132,7 @@ Component.defaultProps = {
   displayFormat: 'DD/MM/YYYY',
   endDatePlaceholderText: '',
   error: false,
+  focusedInput: undefined,
   getIsDayBlocked: Function.prototype,
   initialValue: undefined,
   isValid: false,
@@ -147,6 +154,8 @@ Component.propTypes = {
   endDatePlaceholderText: PropTypes.string,
   /** Is the date range picker in an error state. A string is displayed as an error message. */
   error: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+  /** The input field which is currently focused where the input is consumed as a controlled component. */
+  focusedInput: PropTypes.oneOf([null, 'startDate', 'endDate']),
   /**
    * A function called for each day to be displayed. Returning true blocks that day in the date range picker.
    * @param   {Moment}  day - The day to test.

--- a/src/components/inputs/DateRangePicker/component.spec.js
+++ b/src/components/inputs/DateRangePicker/component.spec.js
@@ -17,6 +17,7 @@ import { mount, shallow } from 'enzyme';
 import moment from 'moment';
 import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
 import { debounce } from 'lodash';
+
 import { getWindowHeight } from 'utils/get-window-height';
 
 import { ComponentWithResponsive as DateRangePicker } from './component';

--- a/src/components/inputs/DateRangePicker/component.spec.js
+++ b/src/components/inputs/DateRangePicker/component.spec.js
@@ -17,7 +17,6 @@ import { mount, shallow } from 'enzyme';
 import moment from 'moment';
 import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
 import { debounce } from 'lodash';
-
 import { getWindowHeight } from 'utils/get-window-height';
 
 import { ComponentWithResponsive as DateRangePicker } from './component';
@@ -25,7 +24,8 @@ import { ComponentWithResponsive as DateRangePicker } from './component';
 const STARTING_WINDOW_HEIGHT = 900;
 const NEXT_WINDOW_HEIGHT = 800;
 
-const getDateRangePicker = () => mount(<DateRangePicker />);
+const getDateRangePicker = extraProps =>
+  mount(<DateRangePicker {...extraProps} />);
 const getWrappedDateRangePicker = props => {
   const Child = shallow(<DateRangePicker />).prop('as');
 
@@ -43,6 +43,14 @@ describe('<DateRangePicker />', () => {
     const wrapper = getDateRangePicker();
 
     expect(wrapper).toMatchSnapshot();
+  });
+
+  describe('if `props.focusedInput` is passed', () => {
+    it('should render the right structure', () => {
+      const wrapper = getDateRangePicker({ focusedInput: 'startDate' });
+
+      expect(wrapper).toMatchSnapshot();
+    });
   });
 
   describe('`componentDidMount`', () => {

--- a/src/components/inputs/DateRangePicker/utils/getFocusedInput.js
+++ b/src/components/inputs/DateRangePicker/utils/getFocusedInput.js
@@ -1,0 +1,13 @@
+/**
+ * @typedef {Object} null
+ * @param   {string|null|undefined} controlledFocusedInput
+ * @param   {string|null} uncontrolledFocusedInput
+ * @return  {string|null}
+ */
+export const getFocusedInput = (
+  controlledFocusedInput,
+  uncontrolledFocusedInput
+) =>
+  typeof controlledFocusedInput === 'undefined'
+    ? uncontrolledFocusedInput
+    : controlledFocusedInput;

--- a/src/components/inputs/DateRangePicker/utils/getFocusedInput.spec.js
+++ b/src/components/inputs/DateRangePicker/utils/getFocusedInput.spec.js
@@ -1,0 +1,24 @@
+import { getFocusedInput } from './getFocusedInput';
+
+describe('getFocusedInput', () => {
+  describe('if `controlledFocusedInput` is `undefined`', () => {
+    it('should return `uncontrolledFocusedInput`', () => {
+      const uncontrolledFocusedInput = 'summin';
+      const actual = getFocusedInput(undefined, uncontrolledFocusedInput);
+
+      expect(actual).toBe(uncontrolledFocusedInput);
+    });
+  });
+
+  describe('if `controlledFocusedInput` is a string or null', () => {
+    it('should return `controlledFocusedInput`', () => {
+      const testCases = [null, 'worms'];
+
+      testCases.forEach(controlledFocusedInput => {
+        const actual = getFocusedInput(controlledFocusedInput, 'summin');
+
+        expect(actual).toBe(controlledFocusedInput);
+      });
+    });
+  });
+});

--- a/src/components/property-page-widgets/PropertyPageSearchBar/component.js
+++ b/src/components/property-page-widgets/PropertyPageSearchBar/component.js
@@ -14,8 +14,9 @@ import { getSummaryMarkup } from './utils/getSummaryMarkup';
 // eslint-disable-next-line jsdoc/require-jsdoc
 export const Component = ({
   dateRangePickerLocaleCode,
-  datesInputValue,
+  datesInputFocusedInput,
   datesInputOnFocusChange,
+  datesInputValue,
   getIsDayBlocked,
   guestsInputValue,
   guestsOptions,
@@ -31,8 +32,9 @@ export const Component = ({
 }) => {
   const sharedProps = {
     dateRangePickerLocaleCode,
-    datesInputValue,
+    datesInputFocusedInput,
     datesInputOnFocusChange,
+    datesInputValue,
     getIsDayBlocked,
     guestsInputValue,
     guestsOptions,
@@ -88,9 +90,10 @@ export const Component = ({
 Component.displayName = 'PropertyPageSearchBar';
 
 Component.defaultProps = {
-  datesInputValue: undefined,
-  datesInputOnFocusChange: Function.prototype,
   dateRangePickerLocaleCode: undefined,
+  datesInputFocusedInput: undefined,
+  datesInputOnFocusChange: Function.prototype,
+  datesInputValue: undefined,
   getIsDayBlocked: undefined,
   guestsInputValue: undefined,
   isShowingPlaceholder: false,
@@ -110,6 +113,8 @@ Component.propTypes = {
   /** The ISO 639-1 locale code which changes the format and language of days of the week and the months of the year in the date range picker. */
   // eslint-disable-next-line react/no-unused-prop-types
   dateRangePickerLocaleCode: PropTypes.string,
+  /** The field of the dates input which is currently focused. Used when consuming `PropertyPageSearchBar` as a controlled component. */
+  datesInputFocusedInput: PropTypes.oneOf([null, 'startDate', 'endDate']),
   /**
    * A function called when the focus state of the dates input changes.
    * @param {String} inputName


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-X)

### What **one** thing does this PR do?
`DateRangePicker`: expose `props.focusedInput`. This allows controlling components to control the timing of the change of focused input and in turn the timing of the call of `props.getIsDayBlocked`

#### Working example in `HomepageHero`
![Screenshot 2019-03-29 at 11 26 39](https://user-images.githubusercontent.com/8591501/55227032-b458fe00-5216-11e9-8891-409b7e697988.png)


