### PR TITLE
TE-2032 Folder first child arrow icon does not respect its intended style.

### DIFF
--- a/src/styles/semantic/themes/livingstone/collections/menu.overrides
+++ b/src/styles/semantic/themes/livingstone/collections/menu.overrides
@@ -127,32 +127,29 @@
         padding-top: 0;
       }
 
-      &:not(:first-child) {
+      > .title {
+        padding: 0;
 
-        > .title {
-          padding: 0;
-
-          > .icon {
-            float: right;
-            margin: @verticalMenuInModalAccordionIconMargin;
-          }
+        > .icon {
+          float: right;
+          margin: @verticalMenuInModalAccordionIconMargin;
         }
+      }
 
-        > .content {
-          padding: 0;
+      > .content {
+        padding: 0;
 
-          > .item {
-            padding-left: @verticalMenuInModalSubItemPaddingLeft;
-            margin: 0;
-            padding-top: @verticalMenuInModalSubItemPaddingTop;
-            padding-bottom: @verticalMenuInModalSubItemPaddingBottom;
-          }
+        > .item {
+          padding-left: @verticalMenuInModalSubItemPaddingLeft;
+          margin: 0;
+          padding-top: @verticalMenuInModalSubItemPaddingTop;
+          padding-bottom: @verticalMenuInModalSubItemPaddingBottom;
         }
+      }
 
-        &.active {
-          border-bottom: @activeItemUnderlineBorder;
-          border-bottom-color: var(@themeActionColorIdentifier, @themeActionColorDefault);
-        }
+      &.active {
+        border-bottom: @activeItemUnderlineBorder;
+        border-bottom-color: var(@themeActionColorIdentifier, @themeActionColorDefault);
       }
     }
   }


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-2032)

### What **one** thing does this PR do?
Eliminates the style rules for the `first-child` of `Accordion` dropdowns. 

### Before
![Screenshot 2019-03-29 at 16 40 38](https://user-images.githubusercontent.com/33876435/55244581-bd12f980-5241-11e9-98ed-00a5be2d25ef.png)

### After
![Screenshot 2019-03-29 at 16 40 20](https://user-images.githubusercontent.com/33876435/55244602-c4d29e00-5241-11e9-8dbe-1fd7dead64df.png)

