### PR TITLE
TE-2073 Header folder links are permanently outlined

### DIFF
--- a/src/components/collections/Header/component.js
+++ b/src/components/collections/Header/component.js
@@ -20,6 +20,7 @@ import { getStandardMenuMarkup } from './utils/getStandardMenuMarkup';
 // eslint-disable-next-line jsdoc/require-jsdoc
 export class Component extends PureComponent {
   state = {
+    activeNavigationItemIndex: null,
     isMenuHidden: false,
     isOpaque: false,
     navigationItemsWidth: null,
@@ -30,6 +31,7 @@ export class Component extends PureComponent {
     global.window.addEventListener('resize', debounce(this.handleResize, 150));
     this.handleResize();
     this.setState({
+      activeNavigationItemIndex: this.props.activeNavigationItemIndex,
       navigationItemsWidth: getNavigationItemsWidth(this.header),
       isOpaque: true,
     });
@@ -63,7 +65,7 @@ export class Component extends PureComponent {
       logoSizes,
       logoSrcSet,
     } = this.props;
-    const { isMenuHidden, isOpaque } = this.state;
+    const { activeNavigationItemIndex, isMenuHidden, isOpaque } = this.state;
 
     return (
       <header
@@ -77,8 +79,8 @@ export class Component extends PureComponent {
           {getLogoMarkup(logoHref, logoText, logoSrc, logoSizes, logoSrcSet)}
           <Menu.Menu position="right">
             {isMenuHidden
-              ? getHiddenMenuMarkup(this.props)
-              : getStandardMenuMarkup(this.props)}
+              ? getHiddenMenuMarkup(this.props, activeNavigationItemIndex)
+              : getStandardMenuMarkup(this.props, activeNavigationItemIndex)}
           </Menu.Menu>
         </HorizontalGutters>
       </header>

--- a/src/components/collections/Header/component.spec.js
+++ b/src/components/collections/Header/component.spec.js
@@ -96,6 +96,7 @@ describe('<Header />', () => {
       wrapper.instance().componentDidMount();
 
       expect(wrapper.instance().setState).toHaveBeenCalledWith({
+        activeNavigationItemIndex: null,
         navigationItemsWidth: NAVIGATION_ITEMS_WIDTH,
         isOpaque: true,
       });

--- a/src/components/collections/Header/utils/__snapshots__/getStandardMenuMarkup.spec.js.snap
+++ b/src/components/collections/Header/utils/__snapshots__/getStandardMenuMarkup.spec.js.snap
@@ -20,7 +20,7 @@ exports[`getStandardMenuMarkup by default should render the right structure 1`] 
     isMenuItem={true}
     isSearchable={false}
     isSimple={true}
-    isTriggerUnderlined={true}
+    isTriggerUnderlined={false}
     isTriggeredOnHover={true}
     items={
       Array [
@@ -53,7 +53,7 @@ exports[`getStandardMenuMarkup by default should render the right structure 1`] 
     <Dropdown
       additionLabel="Add "
       additionPosition="top"
-      className="underlined"
+      className=""
       closeOnBlur={true}
       deburr={false}
       icon={
@@ -117,7 +117,7 @@ exports[`getStandardMenuMarkup by default should render the right structure 1`] 
     >
       <div
         aria-expanded={false}
-        className="ui item simple scrolling top left pointing dropdown underlined"
+        className="ui item simple scrolling top left pointing dropdown"
         name={null}
         onBlur={[Function]}
         onChange={[Function]}
@@ -353,7 +353,7 @@ exports[`getStandardMenuMarkup if \`props.primaryCTA\` is passed should render t
     isMenuItem={true}
     isSearchable={false}
     isSimple={true}
-    isTriggerUnderlined={true}
+    isTriggerUnderlined={false}
     isTriggeredOnHover={true}
     items={
       Array [
@@ -386,7 +386,7 @@ exports[`getStandardMenuMarkup if \`props.primaryCTA\` is passed should render t
     <Dropdown
       additionLabel="Add "
       additionPosition="top"
-      className="underlined"
+      className=""
       closeOnBlur={true}
       deburr={false}
       icon={
@@ -450,7 +450,7 @@ exports[`getStandardMenuMarkup if \`props.primaryCTA\` is passed should render t
     >
       <div
         aria-expanded={false}
-        className="ui item simple scrolling top left pointing dropdown underlined"
+        className="ui item simple scrolling top left pointing dropdown"
         name={null}
         onBlur={[Function]}
         onChange={[Function]}

--- a/src/components/collections/Header/utils/getHiddenMenuMarkup.js
+++ b/src/components/collections/Header/utils/getHiddenMenuMarkup.js
@@ -13,26 +13,28 @@ import { getLinkMarkup } from './getLinkMarkup';
 
 /**
  * @param  {Object}   props
- * @param  {number}   props.activeNavigationItemIndex
  * @param  {string}   props.logoSizes
  * @param  {string}   props.logoSrc
  * @param  {string}   props.logoSrcSet
  * @param  {string}   props.logoText
  * @param  {Object[]} props.navigationItems
+ * @param  {number}   activeNavigationItemIndex
  * @return {Object}
  */
-export const getHiddenMenuMarkup = ({
-  /* eslint-disable react/prop-types */
-  activeNavigationItemIndex,
-  logoHref,
-  logoSizes,
-  logoSrc,
-  logoSrcSet,
-  logoText,
-  navigationItems,
-  primaryCTA,
-  /* eslint-enable react/prop-types */
-}) => (
+export const getHiddenMenuMarkup = (
+  {
+    /* eslint-disable react/prop-types */
+    logoHref,
+    logoSizes,
+    logoSrc,
+    logoSrcSet,
+    logoText,
+    navigationItems,
+    primaryCTA,
+    /* eslint-enable react/prop-types */
+  },
+  activeNavigationItemIndex
+) => (
   <Fragment>
     {primaryCTA && (
       <Menu.Item className="no-underline" link>

--- a/src/components/collections/Header/utils/getStandardMenuMarkup.js
+++ b/src/components/collections/Header/utils/getStandardMenuMarkup.js
@@ -11,18 +11,20 @@ import { getLinkMarkup } from './getLinkMarkup';
 
 /**
  * @param  {Object}   props
- * @param  {number}   props.activeNavigationItemIndex
  * @param  {Object[]} props.navigationItems
  * @param  {Object}   props.primaryCTA
+ * @param  {number}   activeNavigationItemIndex
  * @return {Object}
  */
-export const getStandardMenuMarkup = ({
-  /* eslint-disable react/prop-types */
-  activeNavigationItemIndex,
-  navigationItems,
-  primaryCTA,
-  /* eslint-enable react/prop-types */
-}) => (
+export const getStandardMenuMarkup = (
+  {
+    /* eslint-disable react/prop-types */
+    navigationItems,
+    primaryCTA,
+    /* eslint-enable react/prop-types */
+  },
+  activeNavigationItemIndex
+) => (
   <Fragment>
     {navigationItems.map(({ subItems, text, href, target }, index) =>
       size(subItems) > 0 ? (


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-2073)

### What **one** thing does this PR do?
Implements `activeNavigationItemIndex` to `Header` state.

### Behaviour
![balala](https://user-images.githubusercontent.com/33876435/55408185-c6f96d00-555f-11e9-9599-00f598b4a770.gif)
