### PR TITLE
TE-2158 CheckIn - CheckOut styles are overriden after the blocked dates are recalculated

### DIFF
--- a/src/styles/semantic/definitions/third-party-components/react-dates-datepicker.less
+++ b/src/styles/semantic/definitions/third-party-components/react-dates-datepicker.less
@@ -164,6 +164,15 @@
           background: @pickerDaySelectedBackground;
           color: inherit;
         }
+
+        &.CalendarDay__blocked_minimum_nights.CalendarDay__blocked_calendar {
+
+          &.CalendarDay__selected_start,
+          &.CalendarDay__selected_end {
+            background: @pickerDaySelectedBackground;
+            color: inherit;
+          }
+        }
       }
 
       &.CalendarDay__blocked_calendar,


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-2158)

### What **one** thing does this PR do?
Overrides the blocked date styles, when the date is also selected.

### Behaviour
<img width="1437" alt="Screenshot 2019-04-04 at 13 10 38" src="https://user-images.githubusercontent.com/33876435/55553725-46fb1080-56e1-11e9-883a-b1822ee8f985.png">
