### PR TITLE
TE-2098 header logo tagline

### DIFF
--- a/src/components/collections/Header/Readme.md
+++ b/src/components/collections/Header/Readme.md
@@ -40,6 +40,33 @@ const logoSrc = require('./mock-data/livingstoneLogo.png');
 </div>
 ```
 
+#### Logo sub text
+Sub text can be displayed underneath the logo or logo text.
+
+```jsx
+const { navigationItems } = require('./mock-data/navigationItems');
+const logoSrc = require('./mock-data/livingstoneLogo.png');
+
+<div>
+  <div style={{ backgroundColor: 'grey'}}>
+    <Header
+      logoSrc={logoSrc}
+      logoText="Livingstone Cottage"
+      logoSubText="A cottage built from living stones."
+      navigationItems={navigationItems}
+    />
+  </div>
+  <Divider />
+  <div style={{ backgroundColor: 'grey'}}>
+    <Header
+      logoText="Livingstone Cottage"
+      logoSubText="A cottage built from living stones."
+      navigationItems={navigationItems}
+    />
+  </div>
+</div>
+```
+
 #### Navigation items
 
 Navigation items can be links or groups of subitems.

--- a/src/components/collections/Header/__snapshots__/component.spec.js.snap
+++ b/src/components/collections/Header/__snapshots__/component.spec.js.snap
@@ -7,6 +7,7 @@ exports[`<Header /> by default should render the right structure 1`] = `
   isBackgroundFilled={false}
   logoHref="/"
   logoSrc={null}
+  logoSubText={null}
   logoText="someLogoText"
   navigationItems={
     Array [
@@ -68,6 +69,7 @@ exports[`<Header /> by default should render the right structure 1`] = `
             className="ui borderless ui text container menu"
           >
             <MenuItem
+              className=""
               href="/"
               link={true}
             >
@@ -76,25 +78,49 @@ exports[`<Header /> by default should render the right structure 1`] = `
                 href="/"
                 onClick={[Function]}
               >
-                <Heading
-                  className={null}
-                  isColorInverted={false}
-                  size="small"
-                  textAlign={null}
+                <FlexContainer
+                  alignContent={null}
+                  alignItems={null}
+                  flexDirection="column"
+                  flexWrap={null}
+                  justifyContent="center"
                 >
-                  <Header
-                    as="h4"
-                    className={null}
-                    inverted={false}
-                    textAlign={null}
+                  <div
+                    className="flex-container"
+                    style={
+                      Object {
+                        "alignContent": null,
+                        "alignItems": null,
+                        "display": "flex",
+                        "flexDirection": "column",
+                        "flexGrow": "1",
+                        "flexWrap": null,
+                        "height": "100%",
+                        "justifyContent": "center",
+                      }
+                    }
                   >
-                    <h4
-                      className="ui header"
+                    <Heading
+                      className={null}
+                      isColorInverted={false}
+                      size="small"
+                      textAlign={null}
                     >
-                      someLogoText
-                    </h4>
-                  </Header>
-                </Heading>
+                      <Header
+                        as="h4"
+                        className={null}
+                        inverted={false}
+                        textAlign={null}
+                      >
+                        <h4
+                          className="ui header"
+                        >
+                          someLogoText
+                        </h4>
+                      </Header>
+                    </Heading>
+                  </div>
+                </FlexContainer>
               </a>
             </MenuItem>
             <MenuMenu
@@ -448,6 +474,7 @@ exports[`<Header /> if \`isMenuHidden\` is \`true\` should render the right stru
   isBackgroundFilled={false}
   logoHref="/"
   logoSrc={null}
+  logoSubText={null}
   logoText="someLogoText"
   navigationItems={
     Array [
@@ -509,6 +536,7 @@ exports[`<Header /> if \`isMenuHidden\` is \`true\` should render the right stru
             className="ui borderless ui text container menu"
           >
             <MenuItem
+              className=""
               href="/"
               link={true}
             >
@@ -517,25 +545,49 @@ exports[`<Header /> if \`isMenuHidden\` is \`true\` should render the right stru
                 href="/"
                 onClick={[Function]}
               >
-                <Heading
-                  className={null}
-                  isColorInverted={false}
-                  size="small"
-                  textAlign={null}
+                <FlexContainer
+                  alignContent={null}
+                  alignItems={null}
+                  flexDirection="column"
+                  flexWrap={null}
+                  justifyContent="center"
                 >
-                  <Header
-                    as="h4"
-                    className={null}
-                    inverted={false}
-                    textAlign={null}
+                  <div
+                    className="flex-container"
+                    style={
+                      Object {
+                        "alignContent": null,
+                        "alignItems": null,
+                        "display": "flex",
+                        "flexDirection": "column",
+                        "flexGrow": "1",
+                        "flexWrap": null,
+                        "height": "100%",
+                        "justifyContent": "center",
+                      }
+                    }
                   >
-                    <h4
-                      className="ui header"
+                    <Heading
+                      className={null}
+                      isColorInverted={false}
+                      size="small"
+                      textAlign={null}
                     >
-                      someLogoText
-                    </h4>
-                  </Header>
-                </Heading>
+                      <Header
+                        as="h4"
+                        className={null}
+                        inverted={false}
+                        textAlign={null}
+                      >
+                        <h4
+                          className="ui header"
+                        >
+                          someLogoText
+                        </h4>
+                      </Header>
+                    </Heading>
+                  </div>
+                </FlexContainer>
               </a>
             </MenuItem>
             <MenuMenu
@@ -557,17 +609,26 @@ exports[`<Header /> if \`isMenuHidden\` is \`true\` should render the right stru
                       hasRoundedCorners={false}
                       header={
                         <MenuItem
+                          className=""
                           href="/"
                           link={true}
                         >
-                          <Heading
-                            className={null}
-                            isColorInverted={false}
-                            size="small"
-                            textAlign={null}
+                          <FlexContainer
+                            alignContent={null}
+                            alignItems={null}
+                            flexDirection="column"
+                            flexWrap={null}
+                            justifyContent="center"
                           >
-                            someLogoText
-                          </Heading>
+                            <Heading
+                              className={null}
+                              isColorInverted={false}
+                              size="small"
+                              textAlign={null}
+                            >
+                              someLogoText
+                            </Heading>
+                          </FlexContainer>
                         </MenuItem>
                       }
                       isFullscreen={true}
@@ -723,6 +784,7 @@ exports[`<Header /> if \`props.isBackgroundFilled\` is true should render the ri
   isBackgroundFilled={true}
   logoHref="/"
   logoSrc={null}
+  logoSubText={null}
   logoText="someLogoText"
   navigationItems={
     Array [
@@ -784,6 +846,7 @@ exports[`<Header /> if \`props.isBackgroundFilled\` is true should render the ri
             className="ui borderless ui text container menu"
           >
             <MenuItem
+              className=""
               href="/"
               link={true}
             >
@@ -792,25 +855,49 @@ exports[`<Header /> if \`props.isBackgroundFilled\` is true should render the ri
                 href="/"
                 onClick={[Function]}
               >
-                <Heading
-                  className={null}
-                  isColorInverted={false}
-                  size="small"
-                  textAlign={null}
+                <FlexContainer
+                  alignContent={null}
+                  alignItems={null}
+                  flexDirection="column"
+                  flexWrap={null}
+                  justifyContent="center"
                 >
-                  <Header
-                    as="h4"
-                    className={null}
-                    inverted={false}
-                    textAlign={null}
+                  <div
+                    className="flex-container"
+                    style={
+                      Object {
+                        "alignContent": null,
+                        "alignItems": null,
+                        "display": "flex",
+                        "flexDirection": "column",
+                        "flexGrow": "1",
+                        "flexWrap": null,
+                        "height": "100%",
+                        "justifyContent": "center",
+                      }
+                    }
                   >
-                    <h4
-                      className="ui header"
+                    <Heading
+                      className={null}
+                      isColorInverted={false}
+                      size="small"
+                      textAlign={null}
                     >
-                      someLogoText
-                    </h4>
-                  </Header>
-                </Heading>
+                      <Header
+                        as="h4"
+                        className={null}
+                        inverted={false}
+                        textAlign={null}
+                      >
+                        <h4
+                          className="ui header"
+                        >
+                          someLogoText
+                        </h4>
+                      </Header>
+                    </Heading>
+                  </div>
+                </FlexContainer>
               </a>
             </MenuItem>
             <MenuMenu

--- a/src/components/collections/Header/component.js
+++ b/src/components/collections/Header/component.js
@@ -60,10 +60,11 @@ export class Component extends PureComponent {
     const {
       isBackgroundFilled,
       logoHref,
-      logoText,
-      logoSrc,
       logoSizes,
+      logoSrc,
       logoSrcSet,
+      logoSubText,
+      logoText,
     } = this.props;
     const { activeNavigationItemIndex, isMenuHidden, isOpaque } = this.state;
 
@@ -76,7 +77,14 @@ export class Component extends PureComponent {
         ref={this.createHeaderRef}
       >
         <HorizontalGutters as={Menu} borderless text>
-          {getLogoMarkup(logoHref, logoText, logoSrc, logoSizes, logoSrcSet)}
+          {getLogoMarkup(
+            logoHref,
+            logoSubText,
+            logoText,
+            logoSrc,
+            logoSizes,
+            logoSrcSet
+          )}
           <Menu.Menu position="right">
             {isMenuHidden
               ? getHiddenMenuMarkup(this.props, activeNavigationItemIndex)
@@ -97,6 +105,7 @@ Component.defaultProps = {
   logoSizes: undefined,
   logoSrc: null,
   logoSrcSet: undefined,
+  logoSubText: null,
   primaryCTA: null,
 };
 
@@ -114,6 +123,8 @@ Component.propTypes = {
   logoSrc: PropTypes.string,
   /** A list of one or more strings separated by commas indicating a set of possible image sources for the user agent to use for the logo. See [the MDN docs for more information](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img). */
   logoSrcSet: PropTypes.string,
+  /** The text that appears under the logo or logo text. */
+  logoSubText: PropTypes.string,
   /** The text for the logo. */
   logoText: PropTypes.string.isRequired,
   /** The items for a user to navigate the site. */

--- a/src/components/collections/Header/utils/__snapshots__/getHiddenMenuMarkup.spec.js.snap
+++ b/src/components/collections/Header/utils/__snapshots__/getHiddenMenuMarkup.spec.js.snap
@@ -61,16 +61,25 @@ Array [
         hasRoundedCorners={false}
         header={
           <MenuItem
+            className=""
             link={true}
           >
-            <Image
-              alt="someLogoText"
-              as="img"
-              sizes="someLogoSizes"
-              src="someLogoSrc"
-              srcSet="someLogoSrcSet"
-              ui={true}
-            />
+            <FlexContainer
+              alignContent={null}
+              alignItems={null}
+              flexDirection="column"
+              flexWrap={null}
+              justifyContent="center"
+            >
+              <Image
+                alt="someLogoText"
+                as="img"
+                sizes="someLogoSizes"
+                src="someLogoSrc"
+                srcSet="someLogoSrcSet"
+                ui={true}
+              />
+            </FlexContainer>
           </MenuItem>
         }
         isFullscreen={true}

--- a/src/components/collections/Header/utils/__snapshots__/getLogoMarkup.spec.js.snap
+++ b/src/components/collections/Header/utils/__snapshots__/getLogoMarkup.spec.js.snap
@@ -2,63 +2,133 @@
 
 exports[`getLogoMarkup by default should render the right structure 1`] = `
 <MenuItem
+  className="has-sub-text"
   href="someLogoHref"
   link={true}
 >
   <a
-    className="link item"
+    className="link item has-sub-text"
     href="someLogoHref"
     onClick={[Function]}
   >
-    <Heading
-      className={null}
-      isColorInverted={false}
-      size="small"
-      textAlign={null}
+    <FlexContainer
+      alignContent={null}
+      alignItems={null}
+      flexDirection="column"
+      flexWrap={null}
+      justifyContent="center"
     >
-      <Header
-        as="h4"
-        className={null}
-        inverted={false}
-        textAlign={null}
+      <div
+        className="flex-container"
+        style={
+          Object {
+            "alignContent": null,
+            "alignItems": null,
+            "display": "flex",
+            "flexDirection": "column",
+            "flexGrow": "1",
+            "flexWrap": null,
+            "height": "100%",
+            "justifyContent": "center",
+          }
+        }
       >
-        <h4
-          className="ui header"
+        <Heading
+          className={null}
+          isColorInverted={false}
+          size="small"
+          textAlign={null}
         >
-          someLogoText
-        </h4>
-      </Header>
-    </Heading>
+          <Header
+            as="h4"
+            className={null}
+            inverted={false}
+            textAlign={null}
+          >
+            <h4
+              className="ui header"
+            >
+              someLogoText
+            </h4>
+          </Header>
+        </Heading>
+        <Paragraph
+          size="tiny"
+          weight={null}
+        >
+          <p
+            className="tiny"
+          >
+            someLogoTagline
+          </p>
+        </Paragraph>
+      </div>
+    </FlexContainer>
   </a>
 </MenuItem>
 `;
 
 exports[`getLogoMarkup if \`logoSrc\`, \`logoSizes\` and \`logoSrcSet\` are passed should render the right structure 1`] = `
 <MenuItem
+  className="has-sub-text"
   href="someLogoHref"
   link={true}
 >
   <a
-    className="link item"
+    className="link item has-sub-text"
     href="someLogoHref"
     onClick={[Function]}
   >
-    <Image
-      alt="someLogoText"
-      as="img"
-      sizes="someSizes"
-      src="someLogoSrc"
-      srcSet="someSrcSet"
-      ui={true}
+    <FlexContainer
+      alignContent={null}
+      alignItems={null}
+      flexDirection="column"
+      flexWrap={null}
+      justifyContent="center"
     >
-      <img
-        alt="someLogoText"
-        className="ui image"
-        sizes="someSizes"
-        src="someLogoSrc"
-        srcSet="someSrcSet"
-      />
-    </Image>
+      <div
+        className="flex-container"
+        style={
+          Object {
+            "alignContent": null,
+            "alignItems": null,
+            "display": "flex",
+            "flexDirection": "column",
+            "flexGrow": "1",
+            "flexWrap": null,
+            "height": "100%",
+            "justifyContent": "center",
+          }
+        }
+      >
+        <Image
+          alt="someLogoText"
+          as="img"
+          sizes="someSizes"
+          src="someLogoSrc"
+          srcSet="someSrcSet"
+          ui={true}
+        >
+          <img
+            alt="someLogoText"
+            className="ui image"
+            sizes="someSizes"
+            src="someLogoSrc"
+            srcSet="someSrcSet"
+          />
+        </Image>
+        <Paragraph
+          size="tiny"
+          weight={null}
+        >
+          <p
+            className="tiny"
+          >
+            someLogoTagline
+          </p>
+        </Paragraph>
+      </div>
+    </FlexContainer>
   </a>
 </MenuItem>
 `;

--- a/src/components/collections/Header/utils/getHiddenMenuMarkup.js
+++ b/src/components/collections/Header/utils/getHiddenMenuMarkup.js
@@ -47,6 +47,7 @@ export const getHiddenMenuMarkup = (
       <Modal
         header={getLogoMarkup(
           logoHref,
+          null,
           logoText,
           logoSrc,
           logoSizes,

--- a/src/components/collections/Header/utils/getLogoMarkup.js
+++ b/src/components/collections/Header/utils/getLogoMarkup.js
@@ -1,10 +1,14 @@
 import React from 'react';
 import { Menu, Image } from 'semantic-ui-react';
+import getClassNames from 'classnames';
 
 import { Heading } from 'typography/Heading';
+import { Paragraph } from 'typography/Paragraph';
+import { FlexContainer } from 'layout/FlexContainer';
 
 /**
  * @param  {string} logoHref
+ * @param  {string} logoSubText
  * @param  {string} logoText
  * @param  {string} logoSrc
  * @param  {string} logoSizes
@@ -13,21 +17,31 @@ import { Heading } from 'typography/Heading';
  */
 export const getLogoMarkup = (
   logoHref,
+  logoSubText,
   logoText,
   logoSrc,
   logoSizes,
   logoSrcSet
 ) => (
-  <Menu.Item href={logoHref} link>
-    {logoSrc ? (
-      <Image
-        alt={logoText}
-        sizes={logoSizes}
-        src={logoSrc}
-        srcSet={logoSrcSet}
-      />
-    ) : (
-      <Heading size="small">{logoText}</Heading>
-    )}
+  <Menu.Item
+    className={getClassNames({
+      'has-sub-text': !!logoSubText,
+    })}
+    href={logoHref}
+    link
+  >
+    <FlexContainer flexDirection="column" justifyContent="center">
+      {logoSrc ? (
+        <Image
+          alt={logoText}
+          sizes={logoSizes}
+          src={logoSrc}
+          srcSet={logoSrcSet}
+        />
+      ) : (
+        <Heading size="small">{logoText}</Heading>
+      )}
+      {logoSubText && <Paragraph size="tiny">{logoSubText}</Paragraph>}
+    </FlexContainer>
   </Menu.Item>
 );

--- a/src/components/collections/Header/utils/getLogoMarkup.spec.js
+++ b/src/components/collections/Header/utils/getLogoMarkup.spec.js
@@ -3,13 +3,14 @@ import { mount } from 'enzyme';
 import { getLogoMarkup } from './getLogoMarkup';
 
 const logoHref = 'someLogoHref';
+const logoSubText = 'someLogoTagline';
 const logoText = 'someLogoText';
 const logoSrc = 'someLogoSrc';
 const sizes = 'someSizes';
 const srcSet = 'someSrcSet';
 
 const getLogoMarkupAsComponent = (props = []) =>
-  mount(getLogoMarkup(logoHref, logoText, ...props));
+  mount(getLogoMarkup(logoHref, logoSubText, logoText, ...props));
 
 describe('getLogoMarkup', () => {
   describe('by default', () => {

--- a/src/components/collections/Hero/__snapshots__/component.spec.js.snap
+++ b/src/components/collections/Hero/__snapshots__/component.spec.js.snap
@@ -131,6 +131,7 @@ exports[`<Hero /> by default should render the right structure 1`] = `
           logoSizes="a load of logo sizes"
           logoSrc="https://darkgreen.com"
           logoSrcSet="a load of logo src sets"
+          logoSubText={null}
           logoText="Livingstone Cottage"
           navigationItems={
             Array [
@@ -168,6 +169,7 @@ exports[`<Hero /> by default should render the right structure 1`] = `
                     className="ui borderless ui text container menu"
                   >
                     <MenuItem
+                      className=""
                       href="/"
                       link={true}
                     >
@@ -176,22 +178,46 @@ exports[`<Hero /> by default should render the right structure 1`] = `
                         href="/"
                         onClick={[Function]}
                       >
-                        <Image
-                          alt="Livingstone Cottage"
-                          as="img"
-                          sizes="a load of logo sizes"
-                          src="https://darkgreen.com"
-                          srcSet="a load of logo src sets"
-                          ui={true}
+                        <FlexContainer
+                          alignContent={null}
+                          alignItems={null}
+                          flexDirection="column"
+                          flexWrap={null}
+                          justifyContent="center"
                         >
-                          <img
-                            alt="Livingstone Cottage"
-                            className="ui image"
-                            sizes="a load of logo sizes"
-                            src="https://darkgreen.com"
-                            srcSet="a load of logo src sets"
-                          />
-                        </Image>
+                          <div
+                            className="flex-container"
+                            style={
+                              Object {
+                                "alignContent": null,
+                                "alignItems": null,
+                                "display": "flex",
+                                "flexDirection": "column",
+                                "flexGrow": "1",
+                                "flexWrap": null,
+                                "height": "100%",
+                                "justifyContent": "center",
+                              }
+                            }
+                          >
+                            <Image
+                              alt="Livingstone Cottage"
+                              as="img"
+                              sizes="a load of logo sizes"
+                              src="https://darkgreen.com"
+                              srcSet="a load of logo src sets"
+                              ui={true}
+                            >
+                              <img
+                                alt="Livingstone Cottage"
+                                className="ui image"
+                                sizes="a load of logo sizes"
+                                src="https://darkgreen.com"
+                                srcSet="a load of logo src sets"
+                              />
+                            </Image>
+                          </div>
+                        </FlexContainer>
                       </a>
                     </MenuItem>
                     <MenuMenu

--- a/src/components/collections/Hero/component.js
+++ b/src/components/collections/Hero/component.js
@@ -26,6 +26,7 @@ export const Component = ({
   headerLogoText,
   headerNavigationItems,
   headerPrimaryCTA,
+  headerLogoSubText,
   placeholderBackgroundImageUrl,
 }) => (
   <FullBleed
@@ -44,6 +45,7 @@ export const Component = ({
       logoSizes={headerLogoSizes}
       logoSrc={headerLogoSrc}
       logoSrcSet={headerLogoSrcSet}
+      logoSubText={headerLogoSubText}
       logoText={headerLogoText}
       navigationItems={headerNavigationItems}
       primaryCTA={headerPrimaryCTA}
@@ -67,6 +69,7 @@ Component.defaultProps = {
   headerLogoSrc: null,
   headerLogoSrcSet: undefined,
   headerPrimaryCTA: null,
+  headerLogoSubText: undefined,
   placeholderBackgroundImageUrl: null,
 };
 
@@ -101,6 +104,8 @@ Component.propTypes = {
   headerLogoSrc: PropTypes.string,
   /** A list of one or more strings separated by commas indicating a set of possible image sources for the user agent to use for the header logo. See [the MDN docs for more information](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img). */
   headerLogoSrcSet: PropTypes.string,
+  /** The sub text that appears under the logo or logo text in the header. */
+  headerLogoSubText: PropTypes.string,
   /** The text for the logo in the header. */
   headerLogoText: PropTypes.string.isRequired,
   /** The items for a user to navigate the site. */

--- a/src/components/general-widgets/HomepageHero/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/HomepageHero/__snapshots__/component.spec.js.snap
@@ -164,6 +164,7 @@ exports[`HomepageHero should render the right structure 1`] = `
             logoSizes="a load of logo sizes"
             logoSrc="src"
             logoSrcSet="a load of logo src sets"
+            logoSubText={null}
             logoText="text"
             navigationItems={
               Array [
@@ -201,6 +202,7 @@ exports[`HomepageHero should render the right structure 1`] = `
                       className="ui borderless ui text container menu"
                     >
                       <MenuItem
+                        className=""
                         href="/"
                         link={true}
                       >
@@ -209,22 +211,46 @@ exports[`HomepageHero should render the right structure 1`] = `
                           href="/"
                           onClick={[Function]}
                         >
-                          <Image
-                            alt="text"
-                            as="img"
-                            sizes="a load of logo sizes"
-                            src="src"
-                            srcSet="a load of logo src sets"
-                            ui={true}
+                          <FlexContainer
+                            alignContent={null}
+                            alignItems={null}
+                            flexDirection="column"
+                            flexWrap={null}
+                            justifyContent="center"
                           >
-                            <img
-                              alt="text"
-                              className="ui image"
-                              sizes="a load of logo sizes"
-                              src="src"
-                              srcSet="a load of logo src sets"
-                            />
-                          </Image>
+                            <div
+                              className="flex-container"
+                              style={
+                                Object {
+                                  "alignContent": null,
+                                  "alignItems": null,
+                                  "display": "flex",
+                                  "flexDirection": "column",
+                                  "flexGrow": "1",
+                                  "flexWrap": null,
+                                  "height": "100%",
+                                  "justifyContent": "center",
+                                }
+                              }
+                            >
+                              <Image
+                                alt="text"
+                                as="img"
+                                sizes="a load of logo sizes"
+                                src="src"
+                                srcSet="a load of logo src sets"
+                                ui={true}
+                              >
+                                <img
+                                  alt="text"
+                                  className="ui image"
+                                  sizes="a load of logo sizes"
+                                  src="src"
+                                  srcSet="a load of logo src sets"
+                                />
+                              </Image>
+                            </div>
+                          </FlexContainer>
                         </a>
                       </MenuItem>
                       <MenuMenu

--- a/src/components/general-widgets/HomepageHero/component.js
+++ b/src/components/general-widgets/HomepageHero/component.js
@@ -29,6 +29,7 @@ export const Component = ({
   headerLogoText,
   headerNavigationItems,
   headerPrimaryCTA,
+  headerLogoSubText,
   headingText,
   placeholderBackgroundImageUrl,
   searchBarDateRangePickerLocaleCode,
@@ -72,6 +73,7 @@ export const Component = ({
       headerLogoSizes={headerLogoSizes}
       headerLogoSrc={headerLogoSrc}
       headerLogoSrcSet={headerLogoSrcSet}
+      headerLogoSubText={headerLogoSubText}
       headerLogoText={headerLogoText}
       headerNavigationItems={headerNavigationItems}
       headerPrimaryCTA={headerPrimaryCTA}
@@ -151,6 +153,7 @@ Component.defaultProps = {
   headerLogoSrc: null,
   headerLogoSrcSet: undefined,
   headerPrimaryCTA: null,
+  headerLogoSubText: undefined,
   headingText: null,
   searchBarLocationInputValue: undefined,
   placeholderBackgroundImageUrl: null,
@@ -192,6 +195,8 @@ Component.propTypes = {
   headerLogoSrc: PropTypes.string,
   /** A list of one or more strings separated by commas indicating a set of possible image sources for the user agent to use for the header logo. See [the MDN docs for more information](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img). */
   headerLogoSrcSet: PropTypes.string,
+  /** The sub text that appears under the logo or logo text in the header. */
+  headerLogoSubText: PropTypes.string,
   /** The text for the logo in the header. */
   headerLogoText: PropTypes.string.isRequired,
   /** The items for a user to navigate the site. */

--- a/src/components/property-page-widgets/PropertyPageHero/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/PropertyPageHero/__snapshots__/component.spec.js.snap
@@ -146,6 +146,7 @@ exports[`PropertyPageHero if there are fewer than two items in \`galleryImages\`
             logoSizes="a load of logo sizes"
             logoSrc="src"
             logoSrcSet="a load of logo src sets"
+            logoSubText={null}
             logoText="text"
             navigationItems={
               Array [
@@ -183,6 +184,7 @@ exports[`PropertyPageHero if there are fewer than two items in \`galleryImages\`
                       className="ui borderless ui text container menu"
                     >
                       <MenuItem
+                        className=""
                         href="/"
                         link={true}
                       >
@@ -191,22 +193,46 @@ exports[`PropertyPageHero if there are fewer than two items in \`galleryImages\`
                           href="/"
                           onClick={[Function]}
                         >
-                          <Image
-                            alt="text"
-                            as="img"
-                            sizes="a load of logo sizes"
-                            src="src"
-                            srcSet="a load of logo src sets"
-                            ui={true}
+                          <FlexContainer
+                            alignContent={null}
+                            alignItems={null}
+                            flexDirection="column"
+                            flexWrap={null}
+                            justifyContent="center"
                           >
-                            <img
-                              alt="text"
-                              className="ui image"
-                              sizes="a load of logo sizes"
-                              src="src"
-                              srcSet="a load of logo src sets"
-                            />
-                          </Image>
+                            <div
+                              className="flex-container"
+                              style={
+                                Object {
+                                  "alignContent": null,
+                                  "alignItems": null,
+                                  "display": "flex",
+                                  "flexDirection": "column",
+                                  "flexGrow": "1",
+                                  "flexWrap": null,
+                                  "height": "100%",
+                                  "justifyContent": "center",
+                                }
+                              }
+                            >
+                              <Image
+                                alt="text"
+                                as="img"
+                                sizes="a load of logo sizes"
+                                src="src"
+                                srcSet="a load of logo src sets"
+                                ui={true}
+                              >
+                                <img
+                                  alt="text"
+                                  className="ui image"
+                                  sizes="a load of logo sizes"
+                                  src="src"
+                                  srcSet="a load of logo src sets"
+                                />
+                              </Image>
+                            </div>
+                          </FlexContainer>
                         </a>
                       </MenuItem>
                       <MenuMenu
@@ -440,6 +466,7 @@ exports[`PropertyPageHero should render the right structure 1`] = `
             logoSizes="a load of logo sizes"
             logoSrc="src"
             logoSrcSet="a load of logo src sets"
+            logoSubText={null}
             logoText="text"
             navigationItems={
               Array [
@@ -477,6 +504,7 @@ exports[`PropertyPageHero should render the right structure 1`] = `
                       className="ui borderless ui text container menu"
                     >
                       <MenuItem
+                        className=""
                         href="/"
                         link={true}
                       >
@@ -485,22 +513,46 @@ exports[`PropertyPageHero should render the right structure 1`] = `
                           href="/"
                           onClick={[Function]}
                         >
-                          <Image
-                            alt="text"
-                            as="img"
-                            sizes="a load of logo sizes"
-                            src="src"
-                            srcSet="a load of logo src sets"
-                            ui={true}
+                          <FlexContainer
+                            alignContent={null}
+                            alignItems={null}
+                            flexDirection="column"
+                            flexWrap={null}
+                            justifyContent="center"
                           >
-                            <img
-                              alt="text"
-                              className="ui image"
-                              sizes="a load of logo sizes"
-                              src="src"
-                              srcSet="a load of logo src sets"
-                            />
-                          </Image>
+                            <div
+                              className="flex-container"
+                              style={
+                                Object {
+                                  "alignContent": null,
+                                  "alignItems": null,
+                                  "display": "flex",
+                                  "flexDirection": "column",
+                                  "flexGrow": "1",
+                                  "flexWrap": null,
+                                  "height": "100%",
+                                  "justifyContent": "center",
+                                }
+                              }
+                            >
+                              <Image
+                                alt="text"
+                                as="img"
+                                sizes="a load of logo sizes"
+                                src="src"
+                                srcSet="a load of logo src sets"
+                                ui={true}
+                              >
+                                <img
+                                  alt="text"
+                                  className="ui image"
+                                  sizes="a load of logo sizes"
+                                  src="src"
+                                  srcSet="a load of logo src sets"
+                                />
+                              </Image>
+                            </div>
+                          </FlexContainer>
                         </a>
                       </MenuItem>
                       <MenuMenu

--- a/src/components/property-page-widgets/PropertyPageHero/component.js
+++ b/src/components/property-page-widgets/PropertyPageHero/component.js
@@ -27,6 +27,7 @@ const Component = ({
   headerLogoText,
   headerNavigationItems,
   headerPrimaryCTA,
+  headerLogoSubText,
   placeholderBackgroundImageUrl,
   propertyName,
   ratingNumber,
@@ -44,6 +45,7 @@ const Component = ({
     headerLogoSizes={headerLogoSizes}
     headerLogoSrc={headerLogoSrc}
     headerLogoSrcSet={headerLogoSrcSet}
+    headerLogoSubText={headerLogoSubText}
     headerLogoText={headerLogoText}
     headerNavigationItems={headerNavigationItems}
     headerPrimaryCTA={headerPrimaryCTA}
@@ -73,6 +75,7 @@ Component.defaultProps = {
   headerLogoSrc: null,
   headerLogoSrcSet: undefined,
   headerPrimaryCTA: null,
+  headerLogoSubText: undefined,
   placeholderBackgroundImageUrl: null,
   propertyName: null,
   ratingNumber: null,
@@ -137,6 +140,8 @@ Component.propTypes = {
   headerLogoSrc: PropTypes.string,
   /** A list of one or more strings separated by commas indicating a set of possible image sources for the user agent to use for the header logo. See [the MDN docs for more information](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img). */
   headerLogoSrcSet: PropTypes.string,
+  /** The sub text that appears under the logo or logo text in the header. */
+  headerLogoSubText: PropTypes.string,
   /** The text for the logo in the header. */
   headerLogoText: PropTypes.string.isRequired,
   /** The items for a user to navigate the site. */

--- a/src/styles/semantic/themes/livingstone/collections/menu.overrides
+++ b/src/styles/semantic/themes/livingstone/collections/menu.overrides
@@ -288,6 +288,19 @@ header {
       margin: 0 @headerMenuItemHorizontalMargin;
       padding: @headerMenuItemVerticalPadding 0;
 
+      &.has-sub-text {
+        padding: @headerMenuItemVerticalPaddingWithSubText 0;
+
+        .header {
+          margin-bottom: 0;
+        }
+
+        p {
+          margin: @headerLogoSubTextMargin;
+          color: @offWhite;
+        }
+      }
+
       &,
       &:hover,
       &.active {
@@ -317,6 +330,7 @@ header {
       &.link {
 
         .ui.image {
+          align-self: flex-start;
           max-height: @headerLogoMaxHeight;
           max-width: @headerLogoMaxWidth;
         }

--- a/src/styles/semantic/themes/livingstone/collections/menu.variables
+++ b/src/styles/semantic/themes/livingstone/collections/menu.variables
@@ -19,10 +19,12 @@
 /* Need to use margin rather than padding to implement 'active' state bottom border */
 @headerMenuItemHorizontalMargin: @15px;
 @headerMenuItemVerticalPadding: @35px;
+@headerMenuItemVerticalPaddingWithSubText: @11px;
 @headerMenuItemMobileVerticalPadding: @15px;
 @headerMenuItemTextColor: @pureWhite;
 @headerLogoMaxWidth: 125px;
 @headerLogoMaxHeight: 55px;
+@headerLogoSubTextMargin: @5px 0 0;
 
 @footerMenuItemVerticalPadding: @8px;
 @footerMenuItemHorizontalPadding: @35px;

--- a/src/styles/semantic/themes/livingstone/modules/modal.overrides
+++ b/src/styles/semantic/themes/livingstone/modules/modal.overrides
@@ -76,9 +76,10 @@
       }
     }
 
-    .ui.container > .link.item {
+    .ui.container > .link.item > .flex-container {
 
       > img:only-of-type {
+        align-self: flex-start;
         max-height: @modalLogoMaxHeight;
       }
     }


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-2098)

### What **one** thing does this PR do?
Header, Hero, PropertyPageHero and HomepageHero can display a tagline under the header.

### Any other notes
#### Header
<img width="768" alt="Screenshot 2019-04-12 at 11 17 14" src="https://user-images.githubusercontent.com/10498995/56026903-6d3e3300-5d15-11e9-86f2-163f1b6ab41e.png">

![Kapture 2019-04-12 at 11 17 01](https://user-images.githubusercontent.com/10498995/56026900-6ca59c80-5d15-11e9-9c86-f6bd7d0db93e.gif)

#### HomepageHero
<img width="822" alt="Screenshot 2019-04-12 at 11 14 15" src="https://user-images.githubusercontent.com/10498995/56026901-6d3e3300-5d15-11e9-9928-6d3735e93a7d.png">

#### PropertyPageHero
<img width="725" alt="Screenshot 2019-04-12 at 11 14 45" src="https://user-images.githubusercontent.com/10498995/56026899-6ca59c80-5d15-11e9-8479-aaee91fce5c4.png">

#### Modal
<img width="811" alt="Screenshot 2019-04-12 at 12 07 51" src="https://user-images.githubusercontent.com/10498995/56030035-2869ca80-5d1c-11e9-84be-b0f244e21466.png">
