### PR TITLE
TE-2112 Availability day month translations

### DIFF
--- a/src/components/property-page-widgets/Availability/component.js
+++ b/src/components/property-page-widgets/Availability/component.js
@@ -41,8 +41,6 @@ class Component extends PureComponent {
     startDate: moment(),
   };
 
-  componentDidMount = () => moment.locale(this.props.localeCode);
-
   handleClickNextMonth = () =>
     this.setState({
       startDate: getNextStartDate(
@@ -89,6 +87,8 @@ class Component extends PureComponent {
       roomOptionsValue,
       roomOptionsWithImages,
     } = this.props;
+
+    moment.locale(this.props.localeCode);
 
     return (
       <div>
@@ -157,7 +157,9 @@ class Component extends PureComponent {
                       isVisible
                       month={month}
                       renderCalendarDay={this.renderCalendarDay}
-                      renderMonthElement={renderMonthHeader}
+                      renderMonthElement={renderMonthHeader(
+                        this.props.localeCode
+                      )}
                     />
                   </GridColumn>
                 )

--- a/src/components/property-page-widgets/Availability/component.spec.js
+++ b/src/components/property-page-widgets/Availability/component.spec.js
@@ -50,18 +50,6 @@ describe('<Availability />', () => {
     });
   });
 
-  describe('on mount', () => {
-    it('should set the correct `moment.locale`', () => {
-      const localeCode = 'ko';
-      const dateRangePicker = getWrappedAvailability({ localeCode });
-
-      dateRangePicker.instance().componentDidMount();
-      const actual = moment.locale();
-
-      expect(actual).toEqual(localeCode);
-    });
-  });
-
   describe('if `props.roomOptionsWithImages` is passed', () => {
     it('should render the right structure', () => {
       const actual = getAvailability({ roomOptionsWithImages });

--- a/src/components/property-page-widgets/Availability/utils/__snapshots__/renderMonthHeader.spec.js.snap
+++ b/src/components/property-page-widgets/Availability/utils/__snapshots__/renderMonthHeader.spec.js.snap
@@ -1,0 +1,79 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renderMonthHeader the returned function should return the correct structure 1`] = `
+<div
+  className="CalendarMonth_caption"
+>
+  <strong>
+    4월 2019
+  </strong>
+  <div
+    className="DayPicker_weekHeaders"
+  >
+    <div
+      className="DayPicker_weekHeader"
+    >
+      <ul
+        className="DayPicker_weekHeader_ul"
+      >
+        <li
+          className="DayPicker_weekHeader_li"
+          key="0"
+        >
+          <small>
+            Su
+          </small>
+        </li>
+        <li
+          className="DayPicker_weekHeader_li"
+          key="1"
+        >
+          <small>
+            Mo
+          </small>
+        </li>
+        <li
+          className="DayPicker_weekHeader_li"
+          key="2"
+        >
+          <small>
+            Tu
+          </small>
+        </li>
+        <li
+          className="DayPicker_weekHeader_li"
+          key="3"
+        >
+          <small>
+            We
+          </small>
+        </li>
+        <li
+          className="DayPicker_weekHeader_li"
+          key="4"
+        >
+          <small>
+            Th
+          </small>
+        </li>
+        <li
+          className="DayPicker_weekHeader_li"
+          key="5"
+        >
+          <small>
+            Fr
+          </small>
+        </li>
+        <li
+          className="DayPicker_weekHeader_li"
+          key="6"
+        >
+          <small>
+            Sa
+          </small>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/property-page-widgets/Availability/utils/renderMonthHeader.js
+++ b/src/components/property-page-widgets/Availability/utils/renderMonthHeader.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import moment from 'moment';
-import momentPropTypes from 'react-moment-proptypes';
 
 import { WEEKDAY_LENGTH } from '../constants';
 
@@ -21,20 +20,21 @@ const buildWeekDayMappingMarkup = () => (
 );
 
 /**
- * @typedef {Object} Moment
- * @param   {Object} header
- * @param   {Moment} header.month
- * @return  {Object}
+ * @param   {string} localeCode
+ * @return  {Function}
  */
-export const renderMonthHeader = ({ month }) => (
-  <div className="CalendarMonth_caption">
-    <strong>{month.format('MMMM YYYY')}</strong>
-    <div className="DayPicker_weekHeaders">
-      <div className="DayPicker_weekHeader">{buildWeekDayMappingMarkup()}</div>
-    </div>
-  </div>
-);
+// eslint-disable-next-line react/prop-types
+export const renderMonthHeader = localeCode => ({ month }) => {
+  month.locale(localeCode);
 
-renderMonthHeader.propTypes = {
-  month: momentPropTypes.momentObj.isRequired,
+  return (
+    <div className="CalendarMonth_caption">
+      <strong>{month.format('MMMM YYYY')}</strong>
+      <div className="DayPicker_weekHeaders">
+        <div className="DayPicker_weekHeader">
+          {buildWeekDayMappingMarkup()}
+        </div>
+      </div>
+    </div>
+  );
 };

--- a/src/components/property-page-widgets/Availability/utils/renderMonthHeader.spec.js
+++ b/src/components/property-page-widgets/Availability/utils/renderMonthHeader.spec.js
@@ -5,35 +5,27 @@ import { renderMonthHeader } from './renderMonthHeader';
 
 const today = moment();
 
+const localeCode = 'ko';
+
+const getMonthHeader = () =>
+  shallow(
+    renderMonthHeader(localeCode)({
+      month: today,
+    })
+  );
+
 describe('renderMonthHeader', () => {
-  const getMonthHeader = () =>
-    shallow(
-      renderMonthHeader({
-        month: today,
-      })
-    );
+  it('should return a function', () => {
+    const actual = renderMonthHeader();
 
-  it('should correctly render 7 list items for each day', () => {
-    const wrapper = getMonthHeader().find('li');
-
-    expect(wrapper).toHaveLength(7);
-    expect(
-      wrapper
-        .at(0)
-        .find('small')
-        .text()
-    ).toContain('Su');
-    expect(
-      wrapper
-        .at(6)
-        .find('small')
-        .text()
-    ).toContain('Sa');
+    expect(actual).toBeInstanceOf(Function);
   });
 
-  it('should correctly render the month title', () => {
-    const wrapper = getMonthHeader().find('strong');
+  describe('the returned function', () => {
+    it('should return the correct structure', () => {
+      const actual = getMonthHeader();
 
-    expect(wrapper.text()).toBe(today.format('MMMM YYYY'));
+      expect(actual).toMatchSnapshot();
+    });
   });
 });


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-2112)

### What **one** thing does this PR do?
Correct translations are picked up by moment.

### Any other notes
This component needs a serious rework to avoid this issues around moment instances. This change is only a quick fix to a greater problem. [Related YouTrack issue](https://youtrack.lodgify.net/agiles/86-56/87-1148?issue=TE-2180)

#### Before
![Kapture 2019-04-29 at 13 48 33](https://user-images.githubusercontent.com/10498995/56894293-ac92b080-6a85-11e9-8ece-a2e69d42bb59.gif)

#### After
![Kapture 2019-04-29 at 13 47 36](https://user-images.githubusercontent.com/10498995/56894294-ac92b080-6a85-11e9-8c08-b1b2f2287a85.gif)
