### PR TITLE
TE-2178 Form privacy consent

### DIFF
--- a/src/components/general-widgets/CallMeBack/Readme.md
+++ b/src/components/general-widgets/CallMeBack/Readme.md
@@ -30,9 +30,13 @@ const timeOptions = [
   dateInputPlaceholder="The Date"
   emailInputLabel="Your email address"
   headingText="Can you call me back?"
+  isPrivacyConsentRequired
   nameInputLabel="Your name"
   notesInputLabel="Some notes?"
   phoneInputLabel="Your phone number"
+  privacyConsentLabelLinkText="click here"
+  privacyConsentLabelLinkUrl="erl"
+  privacyConsentLabelText="I give my consent if you "
   propertyInputLabel="What property?"
   propertyOptions={[]}
   submitButtonText="Submit form"

--- a/src/components/general-widgets/CallMeBack/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/CallMeBack/__snapshots__/component.spec.js.snap
@@ -11,7 +11,7 @@ exports[`<CallMeBack /> if \`isPrivacyConsentRequired\` is \`truthy\` should ren
   notesInputLabel="Notes"
   onSubmit={[Function]}
   phoneInputLabel="Phone"
-  privacyConsentLabel="I accept the privacy policy"
+  privacyConsentLabelText="I accept the privacy policy."
   propertyInputLabel="Property"
   propertyOptions={
     Array [
@@ -1264,7 +1264,13 @@ exports[`<CallMeBack /> if \`isPrivacyConsentRequired\` is \`truthy\` should ren
                       isRadioButton={false}
                       isToggle={false}
                       isValid={false}
-                      label="I accept the privacy policy"
+                      label={
+                        <div
+                          className="privacy-consent-label"
+                        >
+                          I accept the privacy policy.
+                        </div>
+                      }
                       name="privacyConsent"
                       onBlur={[Function]}
                       onChange={[Function]}
@@ -1278,7 +1284,13 @@ exports[`<CallMeBack /> if \`isPrivacyConsentRequired\` is \`truthy\` should ren
                         isFluid={false}
                         isFocused={false}
                         isValid={false}
-                        label={null}
+                        label={
+                          <div
+                            className="privacy-consent-label"
+                          >
+                            I accept the privacy policy.
+                          </div>
+                        }
                         mapValueToProps={[Function]}
                         name="privacyConsent"
                         onChange={[Function]}
@@ -1296,14 +1308,13 @@ exports[`<CallMeBack /> if \`isPrivacyConsentRequired\` is \`truthy\` should ren
                               checked={false}
                               disabled={false}
                               key=".0"
-                              label="I accept the privacy policy"
                               onChange={[Function]}
                               radio={false}
                               toggle={false}
                               type="checkbox"
                             >
                               <div
-                                className="ui checkbox"
+                                className="ui fitted checkbox"
                                 onChange={[Function]}
                                 onClick={[Function]}
                                 onMouseDown={[Function]}
@@ -1316,13 +1327,19 @@ exports[`<CallMeBack /> if \`isPrivacyConsentRequired\` is \`truthy\` should ren
                                   tabIndex={0}
                                   type="checkbox"
                                 />
-                                <label
-                                  key="I accept the privacy policy"
-                                >
-                                  I accept the privacy policy
-                                </label>
+                                <label />
                               </div>
                             </Checkbox>
+                            <label
+                              key=".3"
+                              onClick={[Function]}
+                            >
+                              <div
+                                className="privacy-consent-label"
+                              >
+                                I accept the privacy policy.
+                              </div>
+                            </label>
                           </div>
                         </Input>
                       </InputController>
@@ -1388,7 +1405,7 @@ exports[`<CallMeBack /> if there is no \`props.propertyOptions\` should have the
   notesInputLabel="Notes"
   onSubmit={[Function]}
   phoneInputLabel="Phone"
-  privacyConsentLabel="I accept the privacy policy"
+  privacyConsentLabelText="I accept the privacy policy."
   propertyInputLabel="Property"
   propertyOptions={null}
   submitButtonText="Send"
@@ -2370,7 +2387,7 @@ exports[`<CallMeBack /> should have the correct structure 1`] = `
   notesInputLabel="Notes"
   onSubmit={[Function]}
   phoneInputLabel="Phone"
-  privacyConsentLabel="I accept the privacy policy"
+  privacyConsentLabelText="I accept the privacy policy."
   propertyInputLabel="Property"
   propertyOptions={
     Array [

--- a/src/components/general-widgets/CallMeBack/component.js
+++ b/src/components/general-widgets/CallMeBack/component.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { getPrivacyConsentLabel } from 'utils/get-privacy-consent-label';
 import {
   ACCEPT_PRIVACY_POLICY,
   CALL_ME_BACK,
@@ -44,7 +45,9 @@ export const Component = ({
   notesInputLabel,
   onSubmit,
   phoneInputLabel,
-  privacyConsentLabel,
+  privacyConsentLabelText,
+  privacyConsentLabelLinkText,
+  privacyConsentLabelLinkUrl,
   propertyInputLabel,
   propertyOptions,
   submitButtonText,
@@ -104,7 +107,14 @@ export const Component = ({
       name="notes"
     />
     {isPrivacyConsentRequired && (
-      <Checkbox label={privacyConsentLabel} name="privacyConsent" />
+      <Checkbox
+        label={getPrivacyConsentLabel(
+          privacyConsentLabelText,
+          privacyConsentLabelLinkUrl,
+          privacyConsentLabelLinkText
+        )}
+        name="privacyConsent"
+      />
     )}
   </Form>
 );
@@ -117,11 +127,13 @@ Component.defaultProps = {
   errorMessage: '',
   headingText: CALL_ME_BACK,
   isPrivacyConsentRequired: false,
-  privacyConsentLabel: ACCEPT_PRIVACY_POLICY,
   nameInputLabel: NAME,
   notesInputLabel: NOTES,
   onSubmit: Function.prototype,
   phoneInputLabel: PHONE,
+  privacyConsentLabelText: ACCEPT_PRIVACY_POLICY,
+  privacyConsentLabelLinkText: undefined,
+  privacyConsentLabelLinkUrl: undefined,
   propertyInputLabel: PROPERTY,
   propertyOptions: null,
   submitButtonText: SEND,
@@ -151,8 +163,12 @@ Component.propTypes = {
   onSubmit: PropTypes.func,
   /** The label for the phone input */
   phoneInputLabel: PropTypes.string,
+  /** The text to display as the privacy policy link next to the privacy consent checkbox. */
+  privacyConsentLabelLinkText: PropTypes.string,
+  /** The location the privacy policy link next to the privacy consent checkbox. */
+  privacyConsentLabelLinkUrl: PropTypes.string,
   /** The text to display next to the privacy consent checkbox. */
-  privacyConsentLabel: PropTypes.node,
+  privacyConsentLabelText: PropTypes.node,
   /** The label for the property input. */
   propertyInputLabel: PropTypes.string,
   /** The options which the user can select for the property field. */

--- a/src/components/general-widgets/Contact/Readme.md
+++ b/src/components/general-widgets/Contact/Readme.md
@@ -69,8 +69,12 @@ const {
   emailInputLabel="Your email"
   guestsInputLabel="Visitors"
   headingText="Get in touch"
+  isPrivacyConsentRequired
   nameInputLabel="Your name"
   phoneInputLabel="Your phone"
+  privacyConsentLabelLinkText="call me back"
+  privacyConsentLabelLinkUrl="erl"
+  privacyConsentLabelText="I give my consent if you "
   propertyInputLabel="Chalet"
   propertyOptions={propertyOptions}
   roomInputLabel="Salon"

--- a/src/components/general-widgets/Contact/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/Contact/__snapshots__/component.spec.js.snap
@@ -14,7 +14,7 @@ exports[`<Contact /> if \`isPrivacyConsentRequired\` is \`truthy\` should render
   onChangeProperty={[Function]}
   onSubmit={[Function]}
   phoneInputLabel="Phone"
-  privacyConsentLabel="I accept the privacy policy"
+  privacyConsentLabelText="I accept the privacy policy."
   propertyInputLabel="Property"
   propertyOptions={null}
   roomInputLabel="Room"
@@ -623,7 +623,13 @@ exports[`<Contact /> if \`isPrivacyConsentRequired\` is \`truthy\` should render
                       isRadioButton={false}
                       isToggle={false}
                       isValid={false}
-                      label="I accept the privacy policy"
+                      label={
+                        <div
+                          className="privacy-consent-label"
+                        >
+                          I accept the privacy policy.
+                        </div>
+                      }
                       name="privacyConsent"
                       onBlur={[Function]}
                       onChange={[Function]}
@@ -637,7 +643,13 @@ exports[`<Contact /> if \`isPrivacyConsentRequired\` is \`truthy\` should render
                         isFluid={false}
                         isFocused={false}
                         isValid={false}
-                        label={null}
+                        label={
+                          <div
+                            className="privacy-consent-label"
+                          >
+                            I accept the privacy policy.
+                          </div>
+                        }
                         mapValueToProps={[Function]}
                         name="privacyConsent"
                         onChange={[Function]}
@@ -655,14 +667,13 @@ exports[`<Contact /> if \`isPrivacyConsentRequired\` is \`truthy\` should render
                               checked={false}
                               disabled={false}
                               key=".0"
-                              label="I accept the privacy policy"
                               onChange={[Function]}
                               radio={false}
                               toggle={false}
                               type="checkbox"
                             >
                               <div
-                                className="ui checkbox"
+                                className="ui fitted checkbox"
                                 onChange={[Function]}
                                 onClick={[Function]}
                                 onMouseDown={[Function]}
@@ -675,13 +686,19 @@ exports[`<Contact /> if \`isPrivacyConsentRequired\` is \`truthy\` should render
                                   tabIndex={0}
                                   type="checkbox"
                                 />
-                                <label
-                                  key="I accept the privacy policy"
-                                >
-                                  I accept the privacy policy
-                                </label>
+                                <label />
                               </div>
                             </Checkbox>
+                            <label
+                              key=".3"
+                              onClick={[Function]}
+                            >
+                              <div
+                                className="privacy-consent-label"
+                              >
+                                I accept the privacy policy.
+                              </div>
+                            </label>
                           </div>
                         </Input>
                       </InputController>
@@ -750,7 +767,7 @@ exports[`<Contact /> if \`propertyOptions\` and \`roomOptions\` are passed shoul
   onChangeProperty={[Function]}
   onSubmit={[Function]}
   phoneInputLabel="Phone"
-  privacyConsentLabel="I accept the privacy policy"
+  privacyConsentLabelText="I accept the privacy policy."
   propertyInputLabel="Property"
   propertyOptions={
     Array [
@@ -2009,7 +2026,7 @@ exports[`<Contact /> if \`props.propertyOptions\` is passed should have the corr
   onChangeProperty={[Function]}
   onSubmit={[Function]}
   phoneInputLabel="Phone"
-  privacyConsentLabel="I accept the privacy policy"
+  privacyConsentLabelText="I accept the privacy policy."
   propertyInputLabel="Property"
   propertyOptions={
     Array [
@@ -2995,7 +3012,7 @@ exports[`<Contact /> if \`props.roomOptions\` is passed should have the correct 
   onChangeProperty={[Function]}
   onSubmit={[Function]}
   phoneInputLabel="Phone"
-  privacyConsentLabel="I accept the privacy policy"
+  privacyConsentLabelText="I accept the privacy policy."
   propertyInputLabel="Property"
   propertyOptions={null}
   roomInputLabel="Room"
@@ -3936,7 +3953,7 @@ exports[`<Contact /> should have the correct structure 1`] = `
   onChangeProperty={[Function]}
   onSubmit={[Function]}
   phoneInputLabel="Phone"
-  privacyConsentLabel="I accept the privacy policy"
+  privacyConsentLabelText="I accept the privacy policy."
   propertyInputLabel="Property"
   propertyOptions={null}
   roomInputLabel="Room"

--- a/src/components/general-widgets/Contact/component.js
+++ b/src/components/general-widgets/Contact/component.js
@@ -24,6 +24,7 @@ import {
   ROOM,
   SEND,
 } from 'utils/default-strings';
+import { getPrivacyConsentLabel } from 'utils/get-privacy-consent-label';
 
 import {
   COMMENT_MAX_CHARACTERS,
@@ -50,7 +51,9 @@ export const Component = ({
   onChangeProperty,
   onSubmit,
   phoneInputLabel,
-  privacyConsentLabel,
+  privacyConsentLabelLinkText,
+  privacyConsentLabelLinkUrl,
+  privacyConsentLabelText,
   propertyInputLabel,
   propertyOptions,
   roomInputLabel,
@@ -124,7 +127,14 @@ export const Component = ({
       </InputGroup>
     )}
     {isPrivacyConsentRequired && (
-      <Checkbox label={privacyConsentLabel} name="privacyConsent" />
+      <Checkbox
+        label={getPrivacyConsentLabel(
+          privacyConsentLabelText,
+          privacyConsentLabelLinkUrl,
+          privacyConsentLabelLinkText
+        )}
+        name="privacyConsent"
+      />
     )}
   </Form>
 );
@@ -145,7 +155,9 @@ Component.defaultProps = {
   onChangeProperty: Function.prototype,
   onSubmit: Function.prototype,
   phoneInputLabel: PHONE,
-  privacyConsentLabel: ACCEPT_PRIVACY_POLICY,
+  privacyConsentLabelLinkText: undefined,
+  privacyConsentLabelLinkUrl: undefined,
+  privacyConsentLabelText: ACCEPT_PRIVACY_POLICY,
   propertyInputLabel: PROPERTY,
   propertyOptions: null,
   roomInputLabel: ROOM,
@@ -187,8 +199,12 @@ Component.propTypes = {
   onSubmit: PropTypes.func,
   /** The label for the phone input.*/
   phoneInputLabel: PropTypes.string,
+  /** The text to display as the privacy policy link next to the privacy consent checkbox. */
+  privacyConsentLabelLinkText: PropTypes.string,
+  /** The location the privacy policy link next to the privacy consent checkbox. */
+  privacyConsentLabelLinkUrl: PropTypes.string,
   /** The text to display next to the privacy consent checkbox. */
-  privacyConsentLabel: PropTypes.node,
+  privacyConsentLabelText: PropTypes.node,
   /** The label for the property input.*/
   propertyInputLabel: PropTypes.string,
   /** The options which the user can select for the property field. */

--- a/src/components/general-widgets/OwnerSignUp/Readme.md
+++ b/src/components/general-widgets/OwnerSignUp/Readme.md
@@ -11,8 +11,12 @@
   emailInputLabel="Enter email"
   firstNameInputLabel="Your first name"
   headingText="Sign up today!"
+  isPrivacyConsentRequired
   lastNameInputLabel="Your last name"
   submitButtonText="Submit here"
+  privacyConsentLabelLinkText="sign here"
+  privacyConsentLabelLinkUrl="erl"
+  privacyConsentLabelText="please"
 />
 ```
 

--- a/src/components/general-widgets/OwnerSignUp/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/OwnerSignUp/__snapshots__/component.spec.js.snap
@@ -9,7 +9,7 @@ exports[`<OwnerSignUp /> if \`isPrivacyConsentRequired\` is \`truthy\` should re
   isPrivacyConsentRequired={true}
   lastNameInputLabel="Last Name"
   onSubmit={[Function]}
-  privacyConsentLabel="I accept the privacy policy"
+  privacyConsentLabelText="I accept the privacy policy."
   submitButtonText="Sign up"
   successMessage=""
   validation={Object {}}
@@ -275,7 +275,13 @@ exports[`<OwnerSignUp /> if \`isPrivacyConsentRequired\` is \`truthy\` should re
                       isRadioButton={false}
                       isToggle={false}
                       isValid={false}
-                      label="I accept the privacy policy"
+                      label={
+                        <div
+                          className="privacy-consent-label"
+                        >
+                          I accept the privacy policy.
+                        </div>
+                      }
                       name="privacyConsent"
                       onBlur={[Function]}
                       onChange={[Function]}
@@ -289,7 +295,13 @@ exports[`<OwnerSignUp /> if \`isPrivacyConsentRequired\` is \`truthy\` should re
                         isFluid={false}
                         isFocused={false}
                         isValid={false}
-                        label={null}
+                        label={
+                          <div
+                            className="privacy-consent-label"
+                          >
+                            I accept the privacy policy.
+                          </div>
+                        }
                         mapValueToProps={[Function]}
                         name="privacyConsent"
                         onChange={[Function]}
@@ -307,14 +319,13 @@ exports[`<OwnerSignUp /> if \`isPrivacyConsentRequired\` is \`truthy\` should re
                               checked={false}
                               disabled={false}
                               key=".0"
-                              label="I accept the privacy policy"
                               onChange={[Function]}
                               radio={false}
                               toggle={false}
                               type="checkbox"
                             >
                               <div
-                                className="ui checkbox"
+                                className="ui fitted checkbox"
                                 onChange={[Function]}
                                 onClick={[Function]}
                                 onMouseDown={[Function]}
@@ -327,13 +338,19 @@ exports[`<OwnerSignUp /> if \`isPrivacyConsentRequired\` is \`truthy\` should re
                                   tabIndex={0}
                                   type="checkbox"
                                 />
-                                <label
-                                  key="I accept the privacy policy"
-                                >
-                                  I accept the privacy policy
-                                </label>
+                                <label />
                               </div>
                             </Checkbox>
+                            <label
+                              key=".3"
+                              onClick={[Function]}
+                            >
+                              <div
+                                className="privacy-consent-label"
+                              >
+                                I accept the privacy policy.
+                              </div>
+                            </label>
                           </div>
                         </Input>
                       </InputController>
@@ -397,7 +414,7 @@ exports[`<OwnerSignUp /> if \`props.errorMessage\` is passed should render the e
   isPrivacyConsentRequired={false}
   lastNameInputLabel="Last Name"
   onSubmit={[Function]}
-  privacyConsentLabel="I accept the privacy policy"
+  privacyConsentLabelText="I accept the privacy policy."
   submitButtonText="Sign up"
   successMessage=""
   validation={Object {}}
@@ -728,7 +745,7 @@ exports[`<OwnerSignUp /> if \`props.successMessage\` is passed should render the
   isPrivacyConsentRequired={false}
   lastNameInputLabel="Last Name"
   onSubmit={[Function]}
-  privacyConsentLabel="I accept the privacy policy"
+  privacyConsentLabelText="I accept the privacy policy."
   submitButtonText="Sign up"
   successMessage="This is a successful message"
   validation={Object {}}
@@ -1059,7 +1076,7 @@ exports[`<OwnerSignUp /> should render the correct structure 1`] = `
   isPrivacyConsentRequired={false}
   lastNameInputLabel="Last Name"
   onSubmit={[Function]}
-  privacyConsentLabel="I accept the privacy policy"
+  privacyConsentLabelText="I accept the privacy policy."
   submitButtonText="Sign up"
   successMessage=""
   validation={Object {}}

--- a/src/components/general-widgets/OwnerSignUp/component.js
+++ b/src/components/general-widgets/OwnerSignUp/component.js
@@ -12,6 +12,7 @@ import {
 import { Form } from 'collections/Form';
 import { TextInput } from 'inputs/TextInput';
 import { Checkbox } from 'inputs/Checkbox';
+import { getPrivacyConsentLabel } from 'utils/get-privacy-consent-label';
 
 import {
   EMAIL_MAX_CHARACTERS,
@@ -31,7 +32,9 @@ export const Component = ({
   isPrivacyConsentRequired,
   lastNameInputLabel,
   onSubmit,
-  privacyConsentLabel,
+  privacyConsentLabelText,
+  privacyConsentLabelLinkText,
+  privacyConsentLabelLinkUrl,
   submitButtonText,
   successMessage,
   validation,
@@ -63,7 +66,14 @@ export const Component = ({
       name="email"
     />
     {isPrivacyConsentRequired && (
-      <Checkbox label={privacyConsentLabel} name="privacyConsent" />
+      <Checkbox
+        label={getPrivacyConsentLabel(
+          privacyConsentLabelText,
+          privacyConsentLabelLinkUrl,
+          privacyConsentLabelLinkText
+        )}
+        name="privacyConsent"
+      />
     )}
   </Form>
 );
@@ -78,7 +88,9 @@ Component.defaultProps = {
   isPrivacyConsentRequired: false,
   lastNameInputLabel: LAST_NAME,
   onSubmit: Function.prototype,
-  privacyConsentLabel: ACCEPT_PRIVACY_POLICY,
+  privacyConsentLabelLinkText: undefined,
+  privacyConsentLabelLinkUrl: undefined,
+  privacyConsentLabelText: ACCEPT_PRIVACY_POLICY,
   submitButtonText: SIGN_UP,
   successMessage: '',
   validation: {},
@@ -101,8 +113,12 @@ Component.propTypes = {
    *  @param {Object} values - The values of the inputs in the form.
    */
   onSubmit: PropTypes.func,
+  /** The text to display as the privacy policy link next to the privacy consent checkbox. */
+  privacyConsentLabelLinkText: PropTypes.string,
+  /** The location the privacy policy link next to the privacy consent checkbox. */
+  privacyConsentLabelLinkUrl: PropTypes.string,
   /** The text to display next to the privacy consent checkbox. */
-  privacyConsentLabel: PropTypes.node,
+  privacyConsentLabelText: PropTypes.node,
   /** The text to display on the submit button. */
   submitButtonText: PropTypes.string,
   /** The message to display when the form is successful. */

--- a/src/components/inputs/Checkbox/__snapshots__/component.spec.js.snap
+++ b/src/components/inputs/Checkbox/__snapshots__/component.spec.js.snap
@@ -10,14 +10,13 @@ exports[`<Checkbox /> should return the right structure 1`] = `
   isFluid={false}
   isFocused={false}
   isValid={false}
-  label={null}
+  label=""
   mapValueToProps={[Function]}
   name=""
   onChange={[Function]}
 >
   <Checkbox
     disabled={false}
-    label=""
     radio={false}
     toggle={false}
     type="checkbox"

--- a/src/components/inputs/Checkbox/component.js
+++ b/src/components/inputs/Checkbox/component.js
@@ -26,17 +26,13 @@ export const Component = ({
     adaptOnChangeEvent={adaptOnChangeEvent}
     error={error}
     isValid={isValid}
+    label={label}
     mapValueToProps={mapValueToProps}
     name={name}
     onChange={onChange}
     value={isChecked}
   >
-    <Checkbox
-      disabled={isDisabled}
-      label={label}
-      radio={isRadioButton}
-      toggle={isToggle}
-    />
+    <Checkbox disabled={isDisabled} radio={isRadioButton} toggle={isToggle} />
   </InputController>
 );
 
@@ -68,7 +64,7 @@ Component.propTypes = {
   /** Is the checkbox in a valid state. */
   isValid: PropTypes.bool,
   /** The label for the checkbox */
-  label: PropTypes.string,
+  label: PropTypes.node,
   /** The HTML input name. */
   name: PropTypes.string,
   /**

--- a/src/components/inputs/InputController/component.js
+++ b/src/components/inputs/InputController/component.js
@@ -127,7 +127,7 @@ Component.propTypes = {
   /** Is input in a valid state. */
   isValid: PropTypes.bool.isRequired,
   /** The visible label for the input. */
-  label: PropTypes.string,
+  label: PropTypes.node,
   /**
    * A function which maps the value persisted in the input controller state to the props passed to the input.
    * @param  {any} value

--- a/src/components/property-page-widgets/Reviews/Readme.md
+++ b/src/components/property-page-widgets/Reviews/Readme.md
@@ -61,17 +61,20 @@ const reviews = [
 ];
 
 <Reviews
-
   commentInputLabel="How did it go?"
   emailInputLabel="Email"
   formHeadingText="Tell us"
   guestTypeInputLabel="Guest"
   guestTypeOptions={guestTypeOptions}
   headingText="Write your review"
+  isPrivacyConsentRequired
   locationInputLabel="Location"
   monthInputLabel="month"
   monthOptions={monthOptions}
   nameInputLabel="name"
+  privacyConsentLabelLinkText="clicking there"
+  privacyConsentLabelLinkUrl="erl"
+  privacyConsentLabelText="I accept by"
   ratingAverage={ratingAverage}
   ratingInputLabel="Input your rating"
   reviews={reviews}

--- a/src/components/property-page-widgets/Reviews/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Reviews/__snapshots__/component.spec.js.snap
@@ -15,7 +15,7 @@ exports[`<Reviews /> if \`props.isShowingPlaceholder\` is \`true\` if \`props.re
   monthOptions={Array []}
   nameInputLabel="Your name"
   onSubmit={[Function]}
-  privacyConsentLabel="I accept the privacy policy"
+  privacyConsentLabelText="I accept the privacy policy."
   ratingAverage={4}
   ratingInputLabel="Your review"
   reviewFormHeading="Add a Review"
@@ -1040,7 +1040,7 @@ exports[`<Reviews /> if \`props.isShowingPlaceholder\` is \`true\` should render
   monthOptions={Array []}
   nameInputLabel="Your name"
   onSubmit={[Function]}
-  privacyConsentLabel="I accept the privacy policy"
+  privacyConsentLabelText="I accept the privacy policy."
   ratingAverage={4}
   ratingInputLabel="Your review"
   reviewFormHeading="Add a Review"
@@ -1974,7 +1974,7 @@ exports[`<Reviews /> should render the right structure 1`] = `
   monthOptions={Array []}
   nameInputLabel="Your name"
   onSubmit={[Function]}
-  privacyConsentLabel="I accept the privacy policy"
+  privacyConsentLabelText="I accept the privacy policy."
   ratingAverage={4}
   ratingInputLabel="Your review"
   reviewFormHeading="Add a Review"

--- a/src/components/property-page-widgets/Reviews/component.js
+++ b/src/components/property-page-widgets/Reviews/component.js
@@ -105,7 +105,9 @@ Component.defaultProps = {
   monthOptions: [],
   nameInputLabel: YOUR_NAME,
   onSubmit: Function.prototype,
-  privacyConsentLabel: ACCEPT_PRIVACY_POLICY,
+  privacyConsentLabelLinkText: undefined,
+  privacyConsentLabelLinkUrl: undefined,
+  privacyConsentLabelText: ACCEPT_PRIVACY_POLICY,
   roomTypeOptions: [],
   ratingInputLabel: YOUR_REVIEW,
   reviewFormHeading: ADD_A_REVIEW,
@@ -179,8 +181,12 @@ Component.propTypes = {
    */
   // eslint-disable-next-line react/no-unused-prop-types
   onSubmit: PropTypes.func,
+  /** The text to display as the privacy policy link next to the privacy consent checkbox. */
+  privacyConsentLabelLinkText: PropTypes.string,
+  /** The location the privacy policy link next to the privacy consent checkbox. */
+  privacyConsentLabelLinkUrl: PropTypes.string,
   /** The text to display next to the privacy consent checkbox. */
-  privacyConsentLabel: PropTypes.node,
+  privacyConsentLabelText: PropTypes.node,
   /** The average numeral rating for the properties. */
   ratingAverage: PropTypes.number.isRequired,
   /** A visible label to display with the rating stars. */

--- a/src/components/property-page-widgets/Reviews/utils/getModalFormMarkup.js
+++ b/src/components/property-page-widgets/Reviews/utils/getModalFormMarkup.js
@@ -9,6 +9,7 @@ import { TextArea } from 'inputs/TextArea';
 import { Dropdown } from 'inputs/Dropdown';
 import { RatingInput } from 'inputs/RatingInput';
 import { Checkbox } from 'inputs/Checkbox';
+import { getPrivacyConsentLabel } from 'utils/get-privacy-consent-label';
 
 import {
   EMAIL_MAX_CHARACTERS,
@@ -69,7 +70,9 @@ export const getModalFormMarkup = (
     validation,
     yearInputLabel,
     yearOptions,
-    privacyConsentLabel,
+    privacyConsentLabelText,
+    privacyConsentLabelLinkUrl,
+    privacyConsentLabelLinkText,
     /* eslint-enable react/prop-types */
   },
   isShowingPlaceholder
@@ -144,7 +147,14 @@ export const getModalFormMarkup = (
         name="comments"
       />
       {isPrivacyConsentRequired && (
-        <Checkbox label={privacyConsentLabel} name="privacyConsent" />
+        <Checkbox
+          label={getPrivacyConsentLabel(
+            privacyConsentLabelText,
+            privacyConsentLabelLinkUrl,
+            privacyConsentLabelLinkText
+          )}
+          name="privacyConsent"
+        />
       )}
     </Form>
   </Modal>

--- a/src/styles/semantic/themes/livingstone/elements/input.overrides
+++ b/src/styles/semantic/themes/livingstone/elements/input.overrides
@@ -85,6 +85,14 @@
     transition: transform @defaultDuration, font-size @defaultDuration;
   }
 
+  .ui.checkbox {
+
+    label {
+      left: 0;
+      top: 0;
+    }
+  }
+
   input:focus + label,
   textarea:focus + label,
   &.dirty > label {
@@ -93,10 +101,21 @@
     transform: translate(-(@labelFocusXTranslate), -(@labelFocusYTranslate));
   }
 
-  input[type=checkbox] ~ label {
+  .ui.checkbox ~ label {
+    width: 100%;
     color: @checkboxLabelColor;
+    left: @checkboxLabelLeftPosition;
     top: 0;
-    left: 0;
+
+    .privacy-consent-label {
+      line-height: @checkboxLabelLineHeight;
+      display: flex;
+
+      .ui.button {
+        padding: @checkboxPrivacyConsentLabelButtonPadding;
+        line-height: inherit;
+      }
+    }
 
     &:before,
     &:after {
@@ -213,6 +232,10 @@
       padding: @validIconPadding;
       position: absolute;
       right: @inputHorizontalPadding;
+    }
+
+    .ui.checkbox ~ i.green.icon {
+      top: @validCheckBoxIconTopPosition;
     }
   }
 

--- a/src/styles/semantic/themes/livingstone/elements/input.variables
+++ b/src/styles/semantic/themes/livingstone/elements/input.variables
@@ -27,6 +27,10 @@
 /* Labeled Input */
 @labelColor: @greySix;
 @checkboxLabelColor: @black;
+@checkboxLabelLineHeight: @16px;
+@checkboxLabelLeftPosition: @22px;
+
+@checkboxPrivacyConsentLabelButtonPadding:  0 0 0 @6px;
 
 /* Date Range Picker Input */
 @dateRangePickerMinWidth: 135px;
@@ -70,6 +74,8 @@
 
 @validIconOpacity: 1;
 @validIconPadding: @8px 0;
+
+@validCheckBoxIconTopPosition: -(@12px);
 
 /*-------------------
       Variations

--- a/src/styles/semantic/themes/livingstone/modules/checkbox.overrides
+++ b/src/styles/semantic/themes/livingstone/modules/checkbox.overrides
@@ -11,6 +11,11 @@
     & ~ label {
       top: 0;
       left: 0;
+
+      &:before,
+      &:after {
+        cursor: pointer;
+      }
     }
   }
 
@@ -133,7 +138,3 @@
 }
 
 /* Label */
-.ui.checkbox + label {
-  left: 0;
-  top: 0;
-}

--- a/src/utils/default-strings/constants.js
+++ b/src/utils/default-strings/constants.js
@@ -1,5 +1,5 @@
 export const ACCEPT = 'Accept';
-export const ACCEPT_PRIVACY_POLICY = 'I accept the privacy policy';
+export const ACCEPT_PRIVACY_POLICY = 'I accept the privacy policy.';
 export const ADD_A_REVIEW = 'Add a Review';
 export const AND = 'and';
 export const ARRIVAL = 'Arrival';
@@ -49,6 +49,7 @@ export const PHONE = 'Phone';
 export const POLICY_AND_NOTES = 'Policy and Notes';
 export const PREVIOUS = 'Previous';
 export const PRICE_PER_EXTRA_PER = 'Price per extra per.';
+export const PRIVACY_POLICY = 'Privacy policy';
 export const PROPERTIES = 'Properties';
 export const PROPERTY = 'Property';
 export const PROPERTY_PICTURES = 'Property pictures';

--- a/src/utils/get-privacy-consent-label/__snapshots__/getPrivacyConsentLabel.spec.js.snap
+++ b/src/utils/get-privacy-consent-label/__snapshots__/getPrivacyConsentLabel.spec.js.snap
@@ -1,0 +1,79 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getPrivacyConsentLabel if \`privacyConsentLabelLinkUrl\` is passed should return the right structure 1`] = `
+<div
+  className="privacy-consent-label"
+>
+  labelText
+  <Link
+    href="labelLinkUrl"
+    isPositionedRight={false}
+    onClick={[Function]}
+    willOpenInNewTab={true}
+  >
+    <Button
+      as="a"
+      basic={true}
+      floated="left"
+      href="labelLinkUrl"
+      onClick={[Function]}
+      target="_blank"
+      type="button"
+    >
+      <a
+        className="ui basic left floated button"
+        href="labelLinkUrl"
+        onClick={[Function]}
+        role="button"
+        target="_blank"
+        type="button"
+      >
+        Privacy policy
+      </a>
+    </Button>
+  </Link>
+</div>
+`;
+
+exports[`getPrivacyConsentLabel if both \`privacyConsentLabelLinkUrl\` and \`privacyConsentLabelLinkText\` are passed should return the right structure 1`] = `
+<div
+  className="privacy-consent-label"
+>
+  labelText
+  <Link
+    href="labelLinkUrl"
+    isPositionedRight={false}
+    onClick={[Function]}
+    willOpenInNewTab={true}
+  >
+    <Button
+      as="a"
+      basic={true}
+      floated="left"
+      href="labelLinkUrl"
+      onClick={[Function]}
+      target="_blank"
+      type="button"
+    >
+      <a
+        className="ui basic left floated button"
+        href="labelLinkUrl"
+        onClick={[Function]}
+        role="button"
+        target="_blank"
+        type="button"
+      >
+        labelLinkText
+      </a>
+    </Button>
+  </Link>
+</div>
+`;
+
+exports[`getPrivacyConsentLabel should return the right structure 1`] = `
+<div
+  className="privacy-consent-label"
+>
+  labelText
+</div>
+`;

--- a/src/utils/get-privacy-consent-label/getPrivacyConsentLabel.js
+++ b/src/utils/get-privacy-consent-label/getPrivacyConsentLabel.js
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import { Link } from 'elements/Link';
+import { PRIVACY_POLICY } from 'utils/default-strings/constants';
+
+/**
+ * @param  {string} privacyConsentLabelText
+ * @param  {string} privacyConsentLabelLinkUrl
+ * @param  {string} [privacyConsentLabelLinkText=PRIVACY_POLICY]
+ * @return {Object}
+ */
+export const getPrivacyConsentLabel = (
+  privacyConsentLabelText,
+  privacyConsentLabelLinkUrl,
+  privacyConsentLabelLinkText = PRIVACY_POLICY
+) => (
+  <div className="privacy-consent-label">
+    {privacyConsentLabelText}
+    {privacyConsentLabelLinkUrl && (
+      <Link href={privacyConsentLabelLinkUrl} willOpenInNewTab>
+        {privacyConsentLabelLinkText}
+      </Link>
+    )}
+  </div>
+);

--- a/src/utils/get-privacy-consent-label/getPrivacyConsentLabel.spec.js
+++ b/src/utils/get-privacy-consent-label/getPrivacyConsentLabel.spec.js
@@ -1,0 +1,38 @@
+import { mount } from 'enzyme';
+
+import { getPrivacyConsentLabel } from './getPrivacyConsentLabel';
+
+const getPrivacyConsentLabelMarkup = props =>
+  mount(getPrivacyConsentLabel(...props));
+
+const labelText = 'labelText';
+const labelLinkUrl = 'labelLinkUrl';
+const labelLinkText = 'labelLinkText';
+
+describe('getPrivacyConsentLabel', () => {
+  it('should return the right structure', () => {
+    const actual = getPrivacyConsentLabelMarkup([labelText]);
+
+    expect(actual).toMatchSnapshot();
+  });
+
+  describe('if `privacyConsentLabelLinkUrl` is passed', () => {
+    it('should return the right structure', () => {
+      const actual = getPrivacyConsentLabelMarkup([labelText, labelLinkUrl]);
+
+      expect(actual).toMatchSnapshot();
+    });
+  });
+
+  describe('if both `privacyConsentLabelLinkUrl` and `privacyConsentLabelLinkText` are passed', () => {
+    it('should return the right structure', () => {
+      const actual = getPrivacyConsentLabelMarkup([
+        labelText,
+        labelLinkUrl,
+        labelLinkText,
+      ]);
+
+      expect(actual).toMatchSnapshot();
+    });
+  });
+});

--- a/src/utils/get-privacy-consent-label/index.js
+++ b/src/utils/get-privacy-consent-label/index.js
@@ -1,0 +1,1 @@
+export { getPrivacyConsentLabel } from './getPrivacyConsentLabel';


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-2178)

### What **one** thing does this PR do?
CallMeBack, Contact, Reviews and OwnerSignup expose privacy consent props to create a label with a link next to the privacy consent checkbox.

### Any other notes
#### Reviews
<img width="575" alt="Screenshot 2019-04-30 at 15 08 04" src="https://user-images.githubusercontent.com/10498995/56964248-1af57280-6b5b-11e9-82c5-ee4ec54d0d9e.png">

#### CallMeBack
<img width="576" alt="Screenshot 2019-04-30 at 15 03 43" src="https://user-images.githubusercontent.com/10498995/56964262-25177100-6b5b-11e9-849c-4be2000a40c6.png">

#### OwnerSignup
<img width="594" alt="Screenshot 2019-04-30 at 15 02 48" src="https://user-images.githubusercontent.com/10498995/56964302-3496ba00-6b5b-11e9-844c-006720d5510f.png">

#### Contact
<img width="554" alt="Screenshot 2019-04-30 at 15 19 39" src="https://user-images.githubusercontent.com/10498995/56964390-64de5880-6b5b-11e9-9041-cd3b16e85909.png">

#### Checkbox
<img width="582" alt="Screenshot 2019-04-30 at 14 35 03" src="https://user-images.githubusercontent.com/10498995/56964312-3bbdc800-6b5b-11e9-9928-6f37abb16b5f.png">


