### PR TITLE
TE-2195 Hide privacy checkbox if error is passed

### DIFF
--- a/src/components/general-widgets/EmailCapture/component.js
+++ b/src/components/general-widgets/EmailCapture/component.js
@@ -100,7 +100,7 @@ const Component = ({
           </GridColumn>
         )}
       </GridRow>
-      {!isUserOnMobile && isPrivacyConsentRequired && (
+      {!errorMessage && !isUserOnMobile && isPrivacyConsentRequired && (
         <GridRow>
           <GridColumn computer={5} />
           <GridColumn computer={4} mobile={12} tablet={12}>


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-2195)

### What **one** thing does this PR do?
Hides the checkbox if component receives `errorMessage` prop.

### Any other notes
#### Before
<img width="1206" alt="Screenshot 2019-05-07 at 10 46 40" src="https://user-images.githubusercontent.com/10498995/57286382-6eb11000-70b5-11e9-890e-cd6ddf4b50c4.png">

#### After
<img width="1199" alt="Screenshot 2019-05-07 at 10 46 21" src="https://user-images.githubusercontent.com/10498995/57286383-6eb11000-70b5-11e9-94fa-3ac028e6f37a.png">
