### PR TITLE
TE-2184 Arial request to google fonts

### DIFF
--- a/src/styles/semantic/themes/livingstone/globals/site.variables
+++ b/src/styles/semantic/themes/livingstone/globals/site.variables
@@ -10,6 +10,8 @@
 
 @fontName: 'Arial';
 
+@importGoogleFonts: false;
+
 @bodyFontIdentifier: ~"@{themeCustomPropertyPrefix}-body-font";
 @bodyFontDefault: @fontName;
 @bodyFont: var(@bodyFontIdentifier, @bodyFontDefault) !important;


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-2184)

### What **one** thing does this PR do?
Prevents lodgify-ui from making a Arial font request to google fonts.

### Any other notes
`loadFonts` is required by `semantic-ui-less` so the fix is forcing the condition. 

```less
.loadFonts() when (@importGoogleFonts) {
  @import url('@{googleProtocol}fonts.googleapis.com/css?family=@{googleFontRequest}');
}
```

![image](https://user-images.githubusercontent.com/10498995/57295313-7fb84c00-70ca-11e9-8c8f-cf05c6ba28c9.png)

#### Before
<img width="481" alt="Screenshot 2019-05-07 at 13 10 38" src="https://user-images.githubusercontent.com/10498995/57295059-dc673700-70c9-11e9-92d3-993012db5c9a.png">
#### After
<img width="486" alt="Screenshot 2019-05-07 at 13 10 23" src="https://user-images.githubusercontent.com/10498995/57295058-dc673700-70c9-11e9-8160-4cd97dc368b1.png">