### PR TITLE
TE-2225 fix slideshow

### DIFF
--- a/src/components/layout/LazyLoader/Readme.md
+++ b/src/components/layout/LazyLoader/Readme.md
@@ -1,6 +1,6 @@
 ```jsx
 <LazyLoader 
-  lazyComponent={<ResponsiveImage />}
+  lazyComponent={ResponsiveImage}
   componentProps={{
     placeholderImageUrl:"https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=20&mode=max",
     imageUrl:"https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max",
@@ -15,7 +15,7 @@
 #### Lazy props
 ```jsx
 <LazyLoader 
-  lazyComponent={<ResponsiveImage />}
+  lazyComponent={ResponsiveImage}
   componentProps={{
     placeholderImageUrl:"https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=20&mode=max",
     imageWidth: 1024,

--- a/src/styles/semantic/definitions/third-party-components/react-image-gallery.less
+++ b/src/styles/semantic/definitions/third-party-components/react-image-gallery.less
@@ -57,7 +57,7 @@
 
           @supports (object-fit: cover) {
             align-items: normal;
-            display: inline;
+            display: block;
           }
 
           > img {


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-2225)

### What **one** thing does this PR do?
- Slideshow in `RoomTypes` show the images.
- Example for `LazyLoader` shows preview without error.

### Any other notes
![image](https://user-images.githubusercontent.com/10498995/57536000-91f0ef00-7343-11e9-8149-f518e2c5bcc4.png)
![image](https://user-images.githubusercontent.com/10498995/57536027-9c12ed80-7343-11e9-8525-0d78753f19ea.png)
