### PR TITLE
TE-2198 Checkbox bug fixes

### DIFF
--- a/src/components/general-widgets/CallMeBack/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/CallMeBack/__snapshots__/component.spec.js.snap
@@ -1263,13 +1263,17 @@ exports[`<CallMeBack /> if \`isPrivacyConsentRequired\` is \`truthy\` should ren
                       isDisabled={false}
                       isRadioButton={false}
                       isToggle={false}
-                      isValid={false}
                       label={
-                        <div
+                        <label
                           className="privacy-consent-label"
                         >
-                          I accept the privacy policy.
-                        </div>
+                          <Paragraph
+                            size="medium"
+                            weight={null}
+                          >
+                            I accept the privacy policy.
+                          </Paragraph>
+                        </label>
                       }
                       name="privacyConsent"
                       onBlur={[Function]}
@@ -1285,13 +1289,7 @@ exports[`<CallMeBack /> if \`isPrivacyConsentRequired\` is \`truthy\` should ren
                         isFluid={false}
                         isFocused={false}
                         isValid={false}
-                        label={
-                          <div
-                            className="privacy-consent-label"
-                          >
-                            I accept the privacy policy.
-                          </div>
-                        }
+                        label={null}
                         mapValueToProps={[Function]}
                         name="privacyConsent"
                         onChange={[Function]}
@@ -1309,6 +1307,18 @@ exports[`<CallMeBack /> if \`isPrivacyConsentRequired\` is \`truthy\` should ren
                               checked={false}
                               disabled={false}
                               key=".0"
+                              label={
+                                <label
+                                  className="privacy-consent-label"
+                                >
+                                  <Paragraph
+                                    size="medium"
+                                    weight={null}
+                                  >
+                                    I accept the privacy policy.
+                                  </Paragraph>
+                                </label>
+                              }
                               onChange={[Function]}
                               onClick={[Function]}
                               radio={false}
@@ -1316,7 +1326,7 @@ exports[`<CallMeBack /> if \`isPrivacyConsentRequired\` is \`truthy\` should ren
                               type="checkbox"
                             >
                               <div
-                                className="ui fitted checkbox"
+                                className="ui checkbox"
                                 onChange={[Function]}
                                 onClick={[Function]}
                                 onMouseDown={[Function]}
@@ -1329,19 +1339,22 @@ exports[`<CallMeBack /> if \`isPrivacyConsentRequired\` is \`truthy\` should ren
                                   tabIndex={0}
                                   type="checkbox"
                                 />
-                                <label />
+                                <label
+                                  className="privacy-consent-label"
+                                >
+                                  <Paragraph
+                                    size="medium"
+                                    weight={null}
+                                  >
+                                    <p
+                                      className=""
+                                    >
+                                      I accept the privacy policy.
+                                    </p>
+                                  </Paragraph>
+                                </label>
                               </div>
                             </Checkbox>
-                            <label
-                              key=".3"
-                              onClick={[Function]}
-                            >
-                              <div
-                                className="privacy-consent-label"
-                              >
-                                I accept the privacy policy.
-                              </div>
-                            </label>
                           </div>
                         </Input>
                       </InputController>

--- a/src/components/general-widgets/Contact/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/Contact/__snapshots__/component.spec.js.snap
@@ -622,13 +622,17 @@ exports[`<Contact /> if \`isPrivacyConsentRequired\` is \`truthy\` should render
                       isDisabled={false}
                       isRadioButton={false}
                       isToggle={false}
-                      isValid={false}
                       label={
-                        <div
+                        <label
                           className="privacy-consent-label"
                         >
-                          I accept the privacy policy.
-                        </div>
+                          <Paragraph
+                            size="medium"
+                            weight={null}
+                          >
+                            I accept the privacy policy.
+                          </Paragraph>
+                        </label>
                       }
                       name="privacyConsent"
                       onBlur={[Function]}
@@ -644,13 +648,7 @@ exports[`<Contact /> if \`isPrivacyConsentRequired\` is \`truthy\` should render
                         isFluid={false}
                         isFocused={false}
                         isValid={false}
-                        label={
-                          <div
-                            className="privacy-consent-label"
-                          >
-                            I accept the privacy policy.
-                          </div>
-                        }
+                        label={null}
                         mapValueToProps={[Function]}
                         name="privacyConsent"
                         onChange={[Function]}
@@ -668,6 +666,18 @@ exports[`<Contact /> if \`isPrivacyConsentRequired\` is \`truthy\` should render
                               checked={false}
                               disabled={false}
                               key=".0"
+                              label={
+                                <label
+                                  className="privacy-consent-label"
+                                >
+                                  <Paragraph
+                                    size="medium"
+                                    weight={null}
+                                  >
+                                    I accept the privacy policy.
+                                  </Paragraph>
+                                </label>
+                              }
                               onChange={[Function]}
                               onClick={[Function]}
                               radio={false}
@@ -675,7 +685,7 @@ exports[`<Contact /> if \`isPrivacyConsentRequired\` is \`truthy\` should render
                               type="checkbox"
                             >
                               <div
-                                className="ui fitted checkbox"
+                                className="ui checkbox"
                                 onChange={[Function]}
                                 onClick={[Function]}
                                 onMouseDown={[Function]}
@@ -688,19 +698,22 @@ exports[`<Contact /> if \`isPrivacyConsentRequired\` is \`truthy\` should render
                                   tabIndex={0}
                                   type="checkbox"
                                 />
-                                <label />
+                                <label
+                                  className="privacy-consent-label"
+                                >
+                                  <Paragraph
+                                    size="medium"
+                                    weight={null}
+                                  >
+                                    <p
+                                      className=""
+                                    >
+                                      I accept the privacy policy.
+                                    </p>
+                                  </Paragraph>
+                                </label>
                               </div>
                             </Checkbox>
-                            <label
-                              key=".3"
-                              onClick={[Function]}
-                            >
-                              <div
-                                className="privacy-consent-label"
-                              >
-                                I accept the privacy policy.
-                              </div>
-                            </label>
                           </div>
                         </Input>
                       </InputController>

--- a/src/components/general-widgets/EmailCapture/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/EmailCapture/__snapshots__/component.spec.js.snap
@@ -467,13 +467,17 @@ exports[`<EmailCapture /> the wrapped component if \`props.isUserOnMobile === fa
                             isDisabled={false}
                             isRadioButton={false}
                             isToggle={false}
-                            isValid={false}
                             label={
-                              <div
+                              <label
                                 className="privacy-consent-label"
                               >
-                                I accept the privacy policy.
-                              </div>
+                                <Paragraph
+                                  size="medium"
+                                  weight={null}
+                                >
+                                  I accept the privacy policy.
+                                </Paragraph>
+                              </label>
                             }
                             name=""
                             onChange={[Function]}
@@ -488,13 +492,7 @@ exports[`<EmailCapture /> the wrapped component if \`props.isUserOnMobile === fa
                               isFluid={false}
                               isFocused={false}
                               isValid={false}
-                              label={
-                                <div
-                                  className="privacy-consent-label"
-                                >
-                                  I accept the privacy policy.
-                                </div>
-                              }
+                              label={null}
                               mapValueToProps={[Function]}
                               name=""
                               onChange={[Function]}
@@ -513,6 +511,18 @@ exports[`<EmailCapture /> the wrapped component if \`props.isUserOnMobile === fa
                                     checked={false}
                                     disabled={false}
                                     key=".0"
+                                    label={
+                                      <label
+                                        className="privacy-consent-label"
+                                      >
+                                        <Paragraph
+                                          size="medium"
+                                          weight={null}
+                                        >
+                                          I accept the privacy policy.
+                                        </Paragraph>
+                                      </label>
+                                    }
                                     onChange={[Function]}
                                     onClick={[Function]}
                                     radio={false}
@@ -520,7 +530,7 @@ exports[`<EmailCapture /> the wrapped component if \`props.isUserOnMobile === fa
                                     type="checkbox"
                                   >
                                     <div
-                                      className="ui fitted checkbox"
+                                      className="ui checkbox"
                                       onChange={[Function]}
                                       onClick={[Function]}
                                       onMouseDown={[Function]}
@@ -533,19 +543,22 @@ exports[`<EmailCapture /> the wrapped component if \`props.isUserOnMobile === fa
                                         tabIndex={0}
                                         type="checkbox"
                                       />
-                                      <label />
+                                      <label
+                                        className="privacy-consent-label"
+                                      >
+                                        <Paragraph
+                                          size="medium"
+                                          weight={null}
+                                        >
+                                          <p
+                                            className=""
+                                          >
+                                            I accept the privacy policy.
+                                          </p>
+                                        </Paragraph>
+                                      </label>
                                     </div>
                                   </Checkbox>
-                                  <label
-                                    key=".3"
-                                    onClick={[Function]}
-                                  >
-                                    <div
-                                      className="privacy-consent-label"
-                                    >
-                                      I accept the privacy policy.
-                                    </div>
-                                  </label>
                                 </div>
                               </Input>
                             </InputController>
@@ -834,13 +847,17 @@ exports[`<EmailCapture /> the wrapped component if \`props.isUserOnMobile === tr
                             isDisabled={false}
                             isRadioButton={false}
                             isToggle={false}
-                            isValid={false}
                             label={
-                              <div
+                              <label
                                 className="privacy-consent-label"
                               >
-                                I accept the privacy policy.
-                              </div>
+                                <Paragraph
+                                  size="medium"
+                                  weight={null}
+                                >
+                                  I accept the privacy policy.
+                                </Paragraph>
+                              </label>
                             }
                             name=""
                             onChange={[Function]}
@@ -855,13 +872,7 @@ exports[`<EmailCapture /> the wrapped component if \`props.isUserOnMobile === tr
                               isFluid={false}
                               isFocused={false}
                               isValid={false}
-                              label={
-                                <div
-                                  className="privacy-consent-label"
-                                >
-                                  I accept the privacy policy.
-                                </div>
-                              }
+                              label={null}
                               mapValueToProps={[Function]}
                               name=""
                               onChange={[Function]}
@@ -880,6 +891,18 @@ exports[`<EmailCapture /> the wrapped component if \`props.isUserOnMobile === tr
                                     checked={false}
                                     disabled={false}
                                     key=".0"
+                                    label={
+                                      <label
+                                        className="privacy-consent-label"
+                                      >
+                                        <Paragraph
+                                          size="medium"
+                                          weight={null}
+                                        >
+                                          I accept the privacy policy.
+                                        </Paragraph>
+                                      </label>
+                                    }
                                     onChange={[Function]}
                                     onClick={[Function]}
                                     radio={false}
@@ -887,7 +910,7 @@ exports[`<EmailCapture /> the wrapped component if \`props.isUserOnMobile === tr
                                     type="checkbox"
                                   >
                                     <div
-                                      className="ui fitted checkbox"
+                                      className="ui checkbox"
                                       onChange={[Function]}
                                       onClick={[Function]}
                                       onMouseDown={[Function]}
@@ -900,19 +923,22 @@ exports[`<EmailCapture /> the wrapped component if \`props.isUserOnMobile === tr
                                         tabIndex={0}
                                         type="checkbox"
                                       />
-                                      <label />
+                                      <label
+                                        className="privacy-consent-label"
+                                      >
+                                        <Paragraph
+                                          size="medium"
+                                          weight={null}
+                                        >
+                                          <p
+                                            className=""
+                                          >
+                                            I accept the privacy policy.
+                                          </p>
+                                        </Paragraph>
+                                      </label>
                                     </div>
                                   </Checkbox>
-                                  <label
-                                    key=".3"
-                                    onClick={[Function]}
-                                  >
-                                    <div
-                                      className="privacy-consent-label"
-                                    >
-                                      I accept the privacy policy.
-                                    </div>
-                                  </label>
                                 </div>
                               </Input>
                             </InputController>

--- a/src/components/general-widgets/EmailCapture/utils/__snapshots__/getPrivacyCheckboxMarkup.spec.js.snap
+++ b/src/components/general-widgets/EmailCapture/utils/__snapshots__/getPrivacyCheckboxMarkup.spec.js.snap
@@ -7,12 +7,16 @@ exports[`getPrivacyCheckboxMarkup should return the correct structure 1`] = `
   isDisabled={false}
   isRadioButton={false}
   isToggle={false}
-  isValid={false}
   label={
-    <div
+    <label
       className="privacy-consent-label"
     >
-      privacyConsentLabelText
+      <Paragraph
+        size="medium"
+        weight={null}
+      >
+        privacyConsentLabelText
+      </Paragraph>
       <Link
         href="privacyConsentLabelLinkUrl"
         isPositionedRight={false}
@@ -21,7 +25,7 @@ exports[`getPrivacyCheckboxMarkup should return the correct structure 1`] = `
       >
         privacyConsentLabelLinkText
       </Link>
-    </div>
+    </label>
   }
   name=""
   onChange={[Function]}

--- a/src/components/general-widgets/OwnerSignUp/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/OwnerSignUp/__snapshots__/component.spec.js.snap
@@ -274,13 +274,17 @@ exports[`<OwnerSignUp /> if \`isPrivacyConsentRequired\` is \`truthy\` should re
                       isDisabled={false}
                       isRadioButton={false}
                       isToggle={false}
-                      isValid={false}
                       label={
-                        <div
+                        <label
                           className="privacy-consent-label"
                         >
-                          I accept the privacy policy.
-                        </div>
+                          <Paragraph
+                            size="medium"
+                            weight={null}
+                          >
+                            I accept the privacy policy.
+                          </Paragraph>
+                        </label>
                       }
                       name="privacyConsent"
                       onBlur={[Function]}
@@ -296,13 +300,7 @@ exports[`<OwnerSignUp /> if \`isPrivacyConsentRequired\` is \`truthy\` should re
                         isFluid={false}
                         isFocused={false}
                         isValid={false}
-                        label={
-                          <div
-                            className="privacy-consent-label"
-                          >
-                            I accept the privacy policy.
-                          </div>
-                        }
+                        label={null}
                         mapValueToProps={[Function]}
                         name="privacyConsent"
                         onChange={[Function]}
@@ -320,6 +318,18 @@ exports[`<OwnerSignUp /> if \`isPrivacyConsentRequired\` is \`truthy\` should re
                               checked={false}
                               disabled={false}
                               key=".0"
+                              label={
+                                <label
+                                  className="privacy-consent-label"
+                                >
+                                  <Paragraph
+                                    size="medium"
+                                    weight={null}
+                                  >
+                                    I accept the privacy policy.
+                                  </Paragraph>
+                                </label>
+                              }
                               onChange={[Function]}
                               onClick={[Function]}
                               radio={false}
@@ -327,7 +337,7 @@ exports[`<OwnerSignUp /> if \`isPrivacyConsentRequired\` is \`truthy\` should re
                               type="checkbox"
                             >
                               <div
-                                className="ui fitted checkbox"
+                                className="ui checkbox"
                                 onChange={[Function]}
                                 onClick={[Function]}
                                 onMouseDown={[Function]}
@@ -340,19 +350,22 @@ exports[`<OwnerSignUp /> if \`isPrivacyConsentRequired\` is \`truthy\` should re
                                   tabIndex={0}
                                   type="checkbox"
                                 />
-                                <label />
+                                <label
+                                  className="privacy-consent-label"
+                                >
+                                  <Paragraph
+                                    size="medium"
+                                    weight={null}
+                                  >
+                                    <p
+                                      className=""
+                                    >
+                                      I accept the privacy policy.
+                                    </p>
+                                  </Paragraph>
+                                </label>
                               </div>
                             </Checkbox>
-                            <label
-                              key=".3"
-                              onClick={[Function]}
-                            >
-                              <div
-                                className="privacy-consent-label"
-                              >
-                                I accept the privacy policy.
-                              </div>
-                            </label>
                           </div>
                         </Input>
                       </InputController>

--- a/src/components/inputs/Checkbox/__snapshots__/component.spec.js.snap
+++ b/src/components/inputs/Checkbox/__snapshots__/component.spec.js.snap
@@ -10,13 +10,14 @@ exports[`<Checkbox /> should return the right structure 1`] = `
   isFluid={false}
   isFocused={false}
   isValid={false}
-  label=""
+  label={null}
   mapValueToProps={[Function]}
   name=""
   onChange={[Function]}
 >
   <Checkbox
     disabled={false}
+    label=""
     onClick={[Function]}
     radio={false}
     toggle={false}

--- a/src/components/inputs/Checkbox/component.js
+++ b/src/components/inputs/Checkbox/component.js
@@ -17,7 +17,6 @@ export const Component = ({
   isChecked,
   isRadioButton,
   isToggle,
-  isValid,
   label,
   name,
   onChange,
@@ -26,7 +25,7 @@ export const Component = ({
   <InputController
     adaptOnChangeEvent={adaptOnChangeEvent}
     error={error}
-    isValid={isValid}
+    isValid={false}
     label={label}
     mapValueToProps={mapValueToProps}
     name={name}
@@ -50,7 +49,6 @@ Component.defaultProps = {
   isDisabled: false,
   isToggle: false,
   isRadioButton: false,
-  isValid: false,
   label: '',
   name: '',
   onChange: Function.prototype,
@@ -68,8 +66,6 @@ Component.propTypes = {
   isRadioButton: PropTypes.bool,
   /** Format to show an on or off choice. */
   isToggle: PropTypes.bool,
-  /** Is the checkbox in a valid state. */
-  isValid: PropTypes.bool,
   /** The label for the checkbox */
   label: PropTypes.node,
   /** The HTML input name. */

--- a/src/components/inputs/Checkbox/component.js
+++ b/src/components/inputs/Checkbox/component.js
@@ -26,7 +26,6 @@ export const Component = ({
     adaptOnChangeEvent={adaptOnChangeEvent}
     error={error}
     isValid={false}
-    label={label}
     mapValueToProps={mapValueToProps}
     name={name}
     onChange={onChange}
@@ -34,6 +33,7 @@ export const Component = ({
   >
     <Checkbox
       disabled={isDisabled}
+      label={label}
       onClick={onClick}
       radio={isRadioButton}
       toggle={isToggle}

--- a/src/components/property-page-widgets/Reviews/utils/getModalFormMarkup.spec.js
+++ b/src/components/property-page-widgets/Reviews/utils/getModalFormMarkup.spec.js
@@ -54,6 +54,7 @@ describe('getModalFormMarkup', () => {
       const wrapper = getModalForm({
         ...props,
         isPrivacyConsentRequired: true,
+        privacyConsentLabelText: 'adhd',
       });
 
       expect(wrapper).toMatchSnapshot();

--- a/src/styles/semantic/themes/livingstone/elements/input.overrides
+++ b/src/styles/semantic/themes/livingstone/elements/input.overrides
@@ -123,6 +123,11 @@
     }
   }
 
+  .ui.checkbox.toggle ~ label {
+    left: @checkboxToggleLabelLeftPosition;
+    top: @checkboxToggleLabelTopPosition;
+  }
+
   /* textarea */
 
   /* Date range picker */

--- a/src/styles/semantic/themes/livingstone/elements/input.overrides
+++ b/src/styles/semantic/themes/livingstone/elements/input.overrides
@@ -101,25 +101,20 @@
     transform: translate(-(@labelFocusXTranslate), -(@labelFocusYTranslate));
   }
 
-  .ui.checkbox ~ label {
-    width: 100%;
-    color: @checkboxLabelColor;
-    left: @checkboxLabelLeftPosition;
-    top: 0;
+  .ui.checkbox > label.privacy-consent-label {
+    display: flex;
+    cursor: pointer;
+    flex-wrap: wrap;
 
-    .privacy-consent-label {
-      line-height: @checkboxLabelLineHeight;
-      display: flex;
-
-      .ui.button {
-        padding: @checkboxPrivacyConsentLabelButtonPadding;
-        line-height: inherit;
-      }
+    .ui.button {
+      padding: @checkboxPrivacyConsentLabelButtonPadding;
+      line-height: inherit;
+      margin-bottom: @checkboxPrivacyConsentButtonBottomMargin;
     }
 
-    &:before,
-    &:after {
-      cursor: pointer;
+    .ui.button,
+    p {
+      line-height: @checkboxPrivacyConsentParagraphLineHeight;
     }
   }
 

--- a/src/styles/semantic/themes/livingstone/elements/input.variables
+++ b/src/styles/semantic/themes/livingstone/elements/input.variables
@@ -31,8 +31,9 @@
 @checkboxLabelLeftPosition: @22px;
 @checkboxToggleLabelLeftPosition: @45px;
 @checkboxToggleLabelTopPosition: @1px;
-
 @checkboxPrivacyConsentLabelButtonPadding:  0 0 0 @6px;
+@checkboxPrivacyConsentParagraphLineHeight: @17px;
+@checkboxPrivacyConsentButtonBottomMargin: @7px;
 
 /* Date Range Picker Input */
 @dateRangePickerMinWidth: 135px;

--- a/src/styles/semantic/themes/livingstone/elements/input.variables
+++ b/src/styles/semantic/themes/livingstone/elements/input.variables
@@ -29,6 +29,8 @@
 @checkboxLabelColor: @black;
 @checkboxLabelLineHeight: @16px;
 @checkboxLabelLeftPosition: @22px;
+@checkboxToggleLabelLeftPosition: @45px;
+@checkboxToggleLabelTopPosition: @1px;
 
 @checkboxPrivacyConsentLabelButtonPadding:  0 0 0 @6px;
 

--- a/src/styles/semantic/themes/livingstone/modules/checkbox.overrides
+++ b/src/styles/semantic/themes/livingstone/modules/checkbox.overrides
@@ -6,6 +6,11 @@
   width: 100%;
 
   /* Label */
+  & ~ label {
+    cursor: pointer;
+    user-select: none;
+  }
+
   input {
 
     & ~ label {

--- a/src/utils/get-privacy-consent-label/__snapshots__/getPrivacyConsentLabel.spec.js.snap
+++ b/src/utils/get-privacy-consent-label/__snapshots__/getPrivacyConsentLabel.spec.js.snap
@@ -1,10 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`getPrivacyConsentLabel if \`privacyConsentLabelLinkUrl\` is passed should return the right structure 1`] = `
-<div
+<label
   className="privacy-consent-label"
 >
-  labelText
+  <Paragraph
+    size="medium"
+    weight={null}
+  >
+    <p
+      className=""
+    >
+      labelText
+    </p>
+  </Paragraph>
   <Link
     href="labelLinkUrl"
     isPositionedRight={false}
@@ -32,14 +41,23 @@ exports[`getPrivacyConsentLabel if \`privacyConsentLabelLinkUrl\` is passed shou
       </a>
     </Button>
   </Link>
-</div>
+</label>
 `;
 
 exports[`getPrivacyConsentLabel if both \`privacyConsentLabelLinkUrl\` and \`privacyConsentLabelLinkText\` are passed should return the right structure 1`] = `
-<div
+<label
   className="privacy-consent-label"
 >
-  labelText
+  <Paragraph
+    size="medium"
+    weight={null}
+  >
+    <p
+      className=""
+    >
+      labelText
+    </p>
+  </Paragraph>
   <Link
     href="labelLinkUrl"
     isPositionedRight={false}
@@ -67,13 +85,22 @@ exports[`getPrivacyConsentLabel if both \`privacyConsentLabelLinkUrl\` and \`pri
       </a>
     </Button>
   </Link>
-</div>
+</label>
 `;
 
 exports[`getPrivacyConsentLabel should return the right structure 1`] = `
-<div
+<label
   className="privacy-consent-label"
 >
-  labelText
-</div>
+  <Paragraph
+    size="medium"
+    weight={null}
+  >
+    <p
+      className=""
+    >
+      labelText
+    </p>
+  </Paragraph>
+</label>
 `;

--- a/src/utils/get-privacy-consent-label/getPrivacyConsentLabel.js
+++ b/src/utils/get-privacy-consent-label/getPrivacyConsentLabel.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { Link } from 'elements/Link';
+import { Paragraph } from 'typography/Paragraph';
 import { PRIVACY_POLICY } from 'utils/default-strings/constants';
 
 /**
@@ -14,12 +15,12 @@ export const getPrivacyConsentLabel = (
   privacyConsentLabelLinkUrl,
   privacyConsentLabelLinkText = PRIVACY_POLICY
 ) => (
-  <div className="privacy-consent-label">
-    {privacyConsentLabelText}
+  <label className="privacy-consent-label">
+    <Paragraph>{privacyConsentLabelText}</Paragraph>
     {privacyConsentLabelLinkUrl && (
       <Link href={privacyConsentLabelLinkUrl} willOpenInNewTab>
         {privacyConsentLabelLinkText}
       </Link>
     )}
-  </div>
+  </label>
 );


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-2198)

### What **one** thing does this PR do?
- Checkbox no longer has an `isValid` state.
- Checkbox label can be clicked to toggle it's value.

### Any other notes
![Kapture 2019-05-15 at 11 17 03](https://user-images.githubusercontent.com/10498995/57764069-01c7f680-7703-11e9-8517-49271a29d6b0.gif)
<img width="559" alt="Screenshot 2019-05-14 at 18 04 04" src="https://user-images.githubusercontent.com/10498995/57763849-91b97080-7702-11e9-83a8-e98effddff7f.png">
<img width="562" alt="Screenshot 2019-05-14 at 18 04 08" src="https://user-images.githubusercontent.com/10498995/57763850-91b97080-7702-11e9-8de9-a91bd897a845.png">
<img width="565" alt="Screenshot 2019-05-14 at 18 04 37" src="https://user-images.githubusercontent.com/10498995/57763852-91b97080-7702-11e9-92bc-b0383fd6ca30.png">
<img width="564" alt="Screenshot 2019-05-14 at 18 04 41" src="https://user-images.githubusercontent.com/10498995/57763853-91b97080-7702-11e9-96ec-2920cff817dd.png">
<img width="787" alt="Screenshot 2019-05-14 at 18 02 34" src="https://user-images.githubusercontent.com/10498995/57763854-92520700-7702-11e9-9426-534abed288e6.png">
<img width="806" alt="Screenshot 2019-05-14 at 18 02 48" src="https://user-images.githubusercontent.com/10498995/57763855-92520700-7702-11e9-9e65-89ccf38d1d39.png">
<img width="583" alt="Screenshot 2019-05-14 at 12 43 39" src="https://user-images.githubusercontent.com/10498995/57763856-92ea9d80-7702-11e9-8657-0fe10cb77ba3.png">
