### PR TITLE
TE-2250 PropertypageSearchBar hide rating if not passed

### DIFF
--- a/src/components/property-page-widgets/Summary/utils/__snapshots__/getPricePerPeriodAndLocationMarkup.spec.js.snap
+++ b/src/components/property-page-widgets/Summary/utils/__snapshots__/getPricePerPeriodAndLocationMarkup.spec.js.snap
@@ -37,7 +37,7 @@ exports[`getPricePerPeriodAndLocationMarkup if \`isShowingPlaceholder\` === true
 </div>
 `;
 
-exports[`getPricePerPeriodAndLocationMarkup if \`ratingNumber\` is \`0\` should return the right markup 1`] = `
+exports[`getPricePerPeriodAndLocationMarkup if \`ratingNumber\` is falsy should return the right markup 1`] = `
 <div>
   <Segment
     className="is-location-name"
@@ -74,7 +74,7 @@ exports[`getPricePerPeriodAndLocationMarkup if \`ratingNumber\` is \`0\` should 
 </div>
 `;
 
-exports[`getPricePerPeriodAndLocationMarkup if \`ratingNumber\` is not \`0\` should return the right markup 1`] = `
+exports[`getPricePerPeriodAndLocationMarkup if \`ratingNumber\` is not truthy should return the right markup 1`] = `
 <div>
   <Segment
     className="is-location-name"

--- a/src/components/property-page-widgets/Summary/utils/__snapshots__/getPricePerPeriodAndRatingMarkup.spec.js.snap
+++ b/src/components/property-page-widgets/Summary/utils/__snapshots__/getPricePerPeriodAndRatingMarkup.spec.js.snap
@@ -25,7 +25,7 @@ exports[`getPricePerPeriodAndRatingMarkup if \`isShowingPlaceholder\` === true s
 </div>
 `;
 
-exports[`getPricePerPeriodAndRatingMarkup if \`ratingNumber\` is \`0\` should return the right markup 1`] = `
+exports[`getPricePerPeriodAndRatingMarkup if \`ratingNumber\` is falsy should return the right markup 1`] = `
 <div>
   <Segment>
     <div
@@ -60,7 +60,7 @@ exports[`getPricePerPeriodAndRatingMarkup if \`ratingNumber\` is \`0\` should re
 </div>
 `;
 
-exports[`getPricePerPeriodAndRatingMarkup if \`ratingNumber\` is not \`0\` should return the right markup 1`] = `
+exports[`getPricePerPeriodAndRatingMarkup if \`ratingNumber\` is truthy should return the right markup 1`] = `
 <div>
   <Segment>
     <div

--- a/src/components/property-page-widgets/Summary/utils/getPricePerPeriodAndLocationMarkup.js
+++ b/src/components/property-page-widgets/Summary/utils/getPricePerPeriodAndLocationMarkup.js
@@ -31,7 +31,7 @@ export const getPricePerPeriodAndLocationMarkup = (
       </div>
     ) : (
       <Fragment>
-        {ratingNumber !== 0 && (
+        {!!ratingNumber && (
           <Segment className="is-rating">
             <Rating iconSize="tiny" ratingNumber={ratingNumber} />
           </Segment>

--- a/src/components/property-page-widgets/Summary/utils/getPricePerPeriodAndLocationMarkup.spec.js
+++ b/src/components/property-page-widgets/Summary/utils/getPricePerPeriodAndLocationMarkup.spec.js
@@ -33,7 +33,7 @@ describe('getPricePerPeriodAndLocationMarkup', () => {
     });
   });
 
-  describe('if `ratingNumber` is not `0`', () => {
+  describe('if `ratingNumber` is not truthy', () => {
     it('should return the right markup', () => {
       const ratingNumber = 1;
       const wrapper = getMarkupAsRenderedComponent(ratingNumber, periodText);
@@ -42,7 +42,7 @@ describe('getPricePerPeriodAndLocationMarkup', () => {
     });
   });
 
-  describe('if `ratingNumber` is `0`', () => {
+  describe('if `ratingNumber` is falsy', () => {
     it('should return the right markup', () => {
       const ratingNumber = 0;
       const wrapper = getMarkupAsRenderedComponent(ratingNumber, periodText);

--- a/src/components/property-page-widgets/Summary/utils/getPricePerPeriodAndRatingMarkup.js
+++ b/src/components/property-page-widgets/Summary/utils/getPricePerPeriodAndRatingMarkup.js
@@ -28,7 +28,7 @@ export const getPricePerPeriodAndRatingMarkup = (
       <Segment>
         {getPricePerPeriodMarkup(pricePerPeriod, periodText, 'small')}
       </Segment>
-      {ratingNumber !== 0 && (
+      {!!ratingNumber && (
         <Segment className="is-rating">
           <Rating iconSize="tiny" ratingNumber={ratingNumber} />
         </Segment>

--- a/src/components/property-page-widgets/Summary/utils/getPricePerPeriodAndRatingMarkup.spec.js
+++ b/src/components/property-page-widgets/Summary/utils/getPricePerPeriodAndRatingMarkup.spec.js
@@ -27,7 +27,7 @@ describe('getPricePerPeriodAndRatingMarkup', () => {
     });
   });
 
-  describe('if `ratingNumber` is not `0`', () => {
+  describe('if `ratingNumber` is truthy', () => {
     it('should return the right markup', () => {
       const ratingNumber = 1;
       const wrapper = getMarkupAsRenderedComponent(ratingNumber);
@@ -36,7 +36,7 @@ describe('getPricePerPeriodAndRatingMarkup', () => {
     });
   });
 
-  describe('if `ratingNumber` is `0`', () => {
+  describe('if `ratingNumber` is falsy', () => {
     it('should return the right markup', () => {
       const ratingNumber = 0;
       const wrapper = getMarkupAsRenderedComponent(ratingNumber);


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-2250)

### What **one** thing does this PR do?
fix(Summary): hide rating if the rating value is falsy

### Any other notes
<img width="1435" alt="Screenshot 2019-05-17 at 11 22 21" src="https://user-images.githubusercontent.com/10498995/57917933-0f61b580-7896-11e9-99c9-6a48f18da6c2.png">
