### PR TITLE
TE-2247 Fix promotion images

### DIFF
--- a/src/styles/semantic/themes/livingstone/elements/segment.overrides
+++ b/src/styles/semantic/themes/livingstone/elements/segment.overrides
@@ -288,13 +288,23 @@
       z-index: @promotionBeforeLayerZIndex;
 
       > img {
-        left: 50%;
-        max-width: none;
-        min-height: 100%;
-        position: absolute;
+        width: 100%;
+        height: auto;
         top: 50%;
+        left: 50%;
         transform: translate(-50%, -50%);
-        width: auto;
+      }
+
+      @supports (object-fit: cover) {
+
+        > img {
+          height: 100%;
+          width: 100%;
+          top: 0;
+          left: 0;
+          transform: none;
+          object-fit: cover;
+        }
       }
     }
 

--- a/src/styles/semantic/themes/livingstone/elements/segment.overrides
+++ b/src/styles/semantic/themes/livingstone/elements/segment.overrides
@@ -189,6 +189,8 @@
 
 .ui.segment.is-promotion {
   background-color: @promotionBackgroundColor;
+  background-color: var(@themeActionColorIdentifier, @themeActionColorDefault);
+  color: var(@themeActionContrastColorIdentifier, @themeActionContrastColorDefault);
   border-radius: @promotionBorderRadius;
   cursor: pointer;
   z-index: @promotionZIndex;


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-2247)

### What **one** thing does this PR do?
Promotion images fill available space and the widget takes the theme colour if set.

### Any other notes

#### Object fit
<img width="762" alt="Screenshot 2019-05-22 at 14 58 58" src="https://user-images.githubusercontent.com/10498995/58176519-bbded580-7ca2-11e9-8cc7-a105b2a2cb92.png">

#### With IE 11 fallback
<img width="759" alt="Screenshot 2019-05-22 at 14 59 09" src="https://user-images.githubusercontent.com/10498995/58176517-bbded580-7ca2-11e9-8fe9-219432ff40ae.png">

#### Theme colours
![Kapture 2019-05-22 at 11 56 09](https://user-images.githubusercontent.com/10498995/58176518-bbded580-7ca2-11e9-9abb-5af40e0c6425.gif)

