### PR TITLE
TE-2209 Import react-google-maps assets directly

### DIFF
--- a/src/utils/react-google-maps/component.js
+++ b/src/utils/react-google-maps/component.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { GoogleMap, Marker, Circle } from 'react-google-maps';
+import { GoogleMap } from 'react-google-maps/lib/components/GoogleMap';
+import { Marker } from 'react-google-maps/lib/components/Marker';
+import { Circle } from 'react-google-maps/lib/components/Circle';
 
 import { mapOptions, circleOptions } from './constants';
 import { adaptCoordinates } from './utils/adaptCoordinates';

--- a/src/utils/react-google-maps/component.spec.js
+++ b/src/utils/react-google-maps/component.spec.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { GoogleMap, Marker, Circle } from 'react-google-maps';
+import { GoogleMap } from 'react-google-maps/lib/components/GoogleMap';
+import { Marker } from 'react-google-maps/lib/components/Marker';
+import { Circle } from 'react-google-maps/lib/components/Circle';
 import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
 
 import { Component as ReactGoogleMap } from './component';


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-2209)

### What **one** thing does this PR do?
refactor(react-google-maps): directly import assets

### Any other notes
![image](https://user-images.githubusercontent.com/10498995/58177127-0d3b9480-7ca4-11e9-8f30-c2c96b84addd.png)
