### PR TITLE
TE-2267 Featured property header ellipsis

### DIFF
--- a/src/styles/semantic/themes/livingstone/views/card.overrides
+++ b/src/styles/semantic/themes/livingstone/views/card.overrides
@@ -97,7 +97,7 @@
     .content {
 
       > .meta,
-      > .header,
+      > .header .ui.header,
       > .description {
         overflow: hidden;
         text-overflow: ellipsis;


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-2267)

### What **one** thing does this PR do?
The header forms an ellipsis when the text is too long.

### Any other notes
<img width="599" alt="Screenshot 2019-05-28 at 15 47 31" src="https://user-images.githubusercontent.com/10498995/58487980-79187400-8160-11e9-9137-c289efc5e756.png">
