### PR TITLE
TE-2253 Responsive image defaults to lazyload

### DIFF
--- a/src/components/collections/Hero/__snapshots__/component.spec.js.snap
+++ b/src/components/collections/Hero/__snapshots__/component.spec.js.snap
@@ -66,55 +66,77 @@ exports[`<Hero /> by default should render the right structure 1`] = `
         <withLazyLoad(ResponsiveImage)
           imageUrl="https://darkpurple.com"
           isFluid={true}
-          isLazyLoaded={false}
+          isLazyLoaded={true}
           placeholderImageUrl={null}
           sizes="a load of sizes"
           srcSet="a load of sources"
         >
-          <ResponsiveImage
-            alternativeText="Image Widget"
-            hasRoundedCorners={false}
-            imageHeight={null}
-            imageNotFoundLabelText="Image not found!"
-            imageTitle="Image Title"
-            imageUrl="https://darkpurple.com"
-            imageWidth={null}
-            isAvatar={false}
-            isCircular={false}
-            isFluid={true}
-            isLazyLoaded={false}
-            label={null}
-            placeholderImageUrl={null}
-            sizes="a load of sizes"
-            srcSet="a load of sources"
+          <LazyLoader
+            componentProps={
+              Object {
+                "imageHeight": undefined,
+                "imageWidth": undefined,
+                "isFluid": true,
+                "isLazyLoaded": true,
+                "placeholderImageUrl": null,
+                "sizes": "a load of sizes",
+                "srcSet": "a load of sources",
+              }
+            }
+            lazyComponent={[Function]}
+            lazyProps={
+              Object {
+                "imageUrl": "https://darkpurple.com",
+              }
+            }
           >
-            <figure
-              className="responsive-image is-fluid"
+            <div />
+            <ResponsiveImage
+              alternativeText="Image Widget"
+              hasRoundedCorners={false}
+              imageHeight={null}
+              imageNotFoundLabelText="Image not found!"
+              imageTitle="Image Title"
+              imageUrl="https://darkpurple.com"
+              imageWidth={null}
+              isAvatar={false}
+              isCircular={false}
+              isFluid={true}
+              isLazyLoaded={true}
+              label={null}
+              placeholderImageUrl={null}
+              sizes="a load of sizes"
+              srcSet="a load of sources"
             >
-              <Image
-                alt="Image Widget"
-                as="img"
-                avatar={false}
-                fluid={true}
-                onLoad={[Function]}
-                sizes="a load of sizes"
-                src="https://darkpurple.com"
-                srcSet="a load of sources"
-                title="Image Title"
-                ui={true}
+              <figure
+                className="responsive-image is-fluid"
               >
-                <img
+                <Image
                   alt="Image Widget"
-                  className="ui fluid image"
+                  as="img"
+                  avatar={false}
+                  fluid={true}
                   onLoad={[Function]}
                   sizes="a load of sizes"
                   src="https://darkpurple.com"
                   srcSet="a load of sources"
                   title="Image Title"
-                />
-              </Image>
-            </figure>
-          </ResponsiveImage>
+                  ui={true}
+                >
+                  <img
+                    alt="Image Widget"
+                    className="ui fluid image"
+                    onLoad={[Function]}
+                    sizes="a load of sizes"
+                    src="https://darkpurple.com"
+                    srcSet="a load of sources"
+                    title="Image Title"
+                  />
+                </Image>
+              </figure>
+            </ResponsiveImage>
+            <div />
+          </LazyLoader>
         </withLazyLoad(ResponsiveImage)>
         <Header
           activeNavigationItemIndex={1}

--- a/src/components/general-widgets/FeaturedProperties/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/FeaturedProperties/__snapshots__/component.spec.js.snap
@@ -60,51 +60,72 @@ exports[`<FeaturedProperties /> by default should render the right structure 1`]
         <withLazyLoad(ResponsiveImage)
           imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
           isFluid={true}
-          isLazyLoaded={false}
+          isLazyLoaded={true}
         >
-          <ResponsiveImage
-            alternativeText="Image Widget"
-            hasRoundedCorners={false}
-            imageHeight={null}
-            imageNotFoundLabelText="Image not found!"
-            imageTitle="Image Title"
-            imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
-            imageWidth={null}
-            isAvatar={false}
-            isCircular={false}
-            isFluid={true}
-            isLazyLoaded={false}
-            label={null}
-            sizes={null}
-            srcSet={null}
+          <LazyLoader
+            componentProps={
+              Object {
+                "alternativeText": undefined,
+                "isFluid": true,
+                "isLazyLoaded": true,
+                "placeholderImageUrl": undefined,
+                "sizes": undefined,
+                "srcSet": undefined,
+              }
+            }
+            lazyComponent={[Function]}
+            lazyProps={
+              Object {
+                "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
+              }
+            }
           >
-            <figure
-              className="responsive-image is-fluid"
+            <div />
+            <ResponsiveImage
+              alternativeText="Image Widget"
+              hasRoundedCorners={false}
+              imageHeight={null}
+              imageNotFoundLabelText="Image not found!"
+              imageTitle="Image Title"
+              imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
+              imageWidth={null}
+              isAvatar={false}
+              isCircular={false}
+              isFluid={true}
+              isLazyLoaded={true}
+              label={null}
+              sizes={null}
+              srcSet={null}
             >
-              <Image
-                alt="Image Widget"
-                as="img"
-                avatar={false}
-                fluid={true}
-                onLoad={[Function]}
-                sizes={null}
-                src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
-                srcSet={null}
-                title="Image Title"
-                ui={true}
+              <figure
+                className="responsive-image is-fluid"
               >
-                <img
+                <Image
                   alt="Image Widget"
-                  className="ui fluid image"
+                  as="img"
+                  avatar={false}
+                  fluid={true}
                   onLoad={[Function]}
                   sizes={null}
                   src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
                   srcSet={null}
                   title="Image Title"
-                />
-              </Image>
-            </figure>
-          </ResponsiveImage>
+                  ui={true}
+                >
+                  <img
+                    alt="Image Widget"
+                    className="ui fluid image"
+                    onLoad={[Function]}
+                    sizes={null}
+                    src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
+                    srcSet={null}
+                    title="Image Title"
+                  />
+                </Image>
+              </figure>
+            </ResponsiveImage>
+            <div />
+          </LazyLoader>
         </withLazyLoad(ResponsiveImage)>
         <CardContent>
           <div
@@ -374,51 +395,72 @@ exports[`<FeaturedProperties /> by default should render the right structure 1`]
         <withLazyLoad(ResponsiveImage)
           imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
           isFluid={true}
-          isLazyLoaded={false}
+          isLazyLoaded={true}
         >
-          <ResponsiveImage
-            alternativeText="Image Widget"
-            hasRoundedCorners={false}
-            imageHeight={null}
-            imageNotFoundLabelText="Image not found!"
-            imageTitle="Image Title"
-            imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
-            imageWidth={null}
-            isAvatar={false}
-            isCircular={false}
-            isFluid={true}
-            isLazyLoaded={false}
-            label={null}
-            sizes={null}
-            srcSet={null}
+          <LazyLoader
+            componentProps={
+              Object {
+                "alternativeText": undefined,
+                "isFluid": true,
+                "isLazyLoaded": true,
+                "placeholderImageUrl": undefined,
+                "sizes": undefined,
+                "srcSet": undefined,
+              }
+            }
+            lazyComponent={[Function]}
+            lazyProps={
+              Object {
+                "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
+              }
+            }
           >
-            <figure
-              className="responsive-image is-fluid"
+            <div />
+            <ResponsiveImage
+              alternativeText="Image Widget"
+              hasRoundedCorners={false}
+              imageHeight={null}
+              imageNotFoundLabelText="Image not found!"
+              imageTitle="Image Title"
+              imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
+              imageWidth={null}
+              isAvatar={false}
+              isCircular={false}
+              isFluid={true}
+              isLazyLoaded={true}
+              label={null}
+              sizes={null}
+              srcSet={null}
             >
-              <Image
-                alt="Image Widget"
-                as="img"
-                avatar={false}
-                fluid={true}
-                onLoad={[Function]}
-                sizes={null}
-                src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
-                srcSet={null}
-                title="Image Title"
-                ui={true}
+              <figure
+                className="responsive-image is-fluid"
               >
-                <img
+                <Image
                   alt="Image Widget"
-                  className="ui fluid image"
+                  as="img"
+                  avatar={false}
+                  fluid={true}
                   onLoad={[Function]}
                   sizes={null}
                   src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
                   srcSet={null}
                   title="Image Title"
-                />
-              </Image>
-            </figure>
-          </ResponsiveImage>
+                  ui={true}
+                >
+                  <img
+                    alt="Image Widget"
+                    className="ui fluid image"
+                    onLoad={[Function]}
+                    sizes={null}
+                    src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
+                    srcSet={null}
+                    title="Image Title"
+                  />
+                </Image>
+              </figure>
+            </ResponsiveImage>
+            <div />
+          </LazyLoader>
         </withLazyLoad(ResponsiveImage)>
         <CardContent>
           <div
@@ -742,51 +784,72 @@ exports[`<FeaturedProperties /> if \`props.headingText\` is passed should render
         <withLazyLoad(ResponsiveImage)
           imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
           isFluid={true}
-          isLazyLoaded={false}
+          isLazyLoaded={true}
         >
-          <ResponsiveImage
-            alternativeText="Image Widget"
-            hasRoundedCorners={false}
-            imageHeight={null}
-            imageNotFoundLabelText="Image not found!"
-            imageTitle="Image Title"
-            imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
-            imageWidth={null}
-            isAvatar={false}
-            isCircular={false}
-            isFluid={true}
-            isLazyLoaded={false}
-            label={null}
-            sizes={null}
-            srcSet={null}
+          <LazyLoader
+            componentProps={
+              Object {
+                "alternativeText": undefined,
+                "isFluid": true,
+                "isLazyLoaded": true,
+                "placeholderImageUrl": undefined,
+                "sizes": undefined,
+                "srcSet": undefined,
+              }
+            }
+            lazyComponent={[Function]}
+            lazyProps={
+              Object {
+                "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
+              }
+            }
           >
-            <figure
-              className="responsive-image is-fluid"
+            <div />
+            <ResponsiveImage
+              alternativeText="Image Widget"
+              hasRoundedCorners={false}
+              imageHeight={null}
+              imageNotFoundLabelText="Image not found!"
+              imageTitle="Image Title"
+              imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
+              imageWidth={null}
+              isAvatar={false}
+              isCircular={false}
+              isFluid={true}
+              isLazyLoaded={true}
+              label={null}
+              sizes={null}
+              srcSet={null}
             >
-              <Image
-                alt="Image Widget"
-                as="img"
-                avatar={false}
-                fluid={true}
-                onLoad={[Function]}
-                sizes={null}
-                src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
-                srcSet={null}
-                title="Image Title"
-                ui={true}
+              <figure
+                className="responsive-image is-fluid"
               >
-                <img
+                <Image
                   alt="Image Widget"
-                  className="ui fluid image"
+                  as="img"
+                  avatar={false}
+                  fluid={true}
                   onLoad={[Function]}
                   sizes={null}
                   src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
                   srcSet={null}
                   title="Image Title"
-                />
-              </Image>
-            </figure>
-          </ResponsiveImage>
+                  ui={true}
+                >
+                  <img
+                    alt="Image Widget"
+                    className="ui fluid image"
+                    onLoad={[Function]}
+                    sizes={null}
+                    src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
+                    srcSet={null}
+                    title="Image Title"
+                  />
+                </Image>
+              </figure>
+            </ResponsiveImage>
+            <div />
+          </LazyLoader>
         </withLazyLoad(ResponsiveImage)>
         <CardContent>
           <div
@@ -1056,51 +1119,72 @@ exports[`<FeaturedProperties /> if \`props.headingText\` is passed should render
         <withLazyLoad(ResponsiveImage)
           imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
           isFluid={true}
-          isLazyLoaded={false}
+          isLazyLoaded={true}
         >
-          <ResponsiveImage
-            alternativeText="Image Widget"
-            hasRoundedCorners={false}
-            imageHeight={null}
-            imageNotFoundLabelText="Image not found!"
-            imageTitle="Image Title"
-            imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
-            imageWidth={null}
-            isAvatar={false}
-            isCircular={false}
-            isFluid={true}
-            isLazyLoaded={false}
-            label={null}
-            sizes={null}
-            srcSet={null}
+          <LazyLoader
+            componentProps={
+              Object {
+                "alternativeText": undefined,
+                "isFluid": true,
+                "isLazyLoaded": true,
+                "placeholderImageUrl": undefined,
+                "sizes": undefined,
+                "srcSet": undefined,
+              }
+            }
+            lazyComponent={[Function]}
+            lazyProps={
+              Object {
+                "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
+              }
+            }
           >
-            <figure
-              className="responsive-image is-fluid"
+            <div />
+            <ResponsiveImage
+              alternativeText="Image Widget"
+              hasRoundedCorners={false}
+              imageHeight={null}
+              imageNotFoundLabelText="Image not found!"
+              imageTitle="Image Title"
+              imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
+              imageWidth={null}
+              isAvatar={false}
+              isCircular={false}
+              isFluid={true}
+              isLazyLoaded={true}
+              label={null}
+              sizes={null}
+              srcSet={null}
             >
-              <Image
-                alt="Image Widget"
-                as="img"
-                avatar={false}
-                fluid={true}
-                onLoad={[Function]}
-                sizes={null}
-                src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
-                srcSet={null}
-                title="Image Title"
-                ui={true}
+              <figure
+                className="responsive-image is-fluid"
               >
-                <img
+                <Image
                   alt="Image Widget"
-                  className="ui fluid image"
+                  as="img"
+                  avatar={false}
+                  fluid={true}
                   onLoad={[Function]}
                   sizes={null}
                   src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
                   srcSet={null}
                   title="Image Title"
-                />
-              </Image>
-            </figure>
-          </ResponsiveImage>
+                  ui={true}
+                >
+                  <img
+                    alt="Image Widget"
+                    className="ui fluid image"
+                    onLoad={[Function]}
+                    sizes={null}
+                    src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
+                    srcSet={null}
+                    title="Image Title"
+                  />
+                </Image>
+              </figure>
+            </ResponsiveImage>
+            <div />
+          </LazyLoader>
         </withLazyLoad(ResponsiveImage)>
         <CardContent>
           <div

--- a/src/components/general-widgets/FeaturedProperty/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/FeaturedProperty/__snapshots__/component.spec.js.snap
@@ -44,7 +44,7 @@ exports[`<FeaturedProperty /> should render the right structure 1`] = `
   <withLazyLoad(ResponsiveImage)
     imageUrl="🐱🐱"
     isFluid={true}
-    isLazyLoaded={false}
+    isLazyLoaded={true}
   />
   <CardContent>
     <CardMeta>

--- a/src/components/general-widgets/FeaturedRoomType/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/FeaturedRoomType/__snapshots__/component.spec.js.snap
@@ -45,7 +45,7 @@ exports[`<FeaturedRoomType /> should render the right structure 1`] = `
     alternativeText="this alt tag"
     imageUrl="🐱🐱"
     isFluid={true}
-    isLazyLoaded={false}
+    isLazyLoaded={true}
   />
   <CardContent>
     <CardHeader>

--- a/src/components/general-widgets/FeaturedRoomTypes/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/FeaturedRoomTypes/__snapshots__/component.spec.js.snap
@@ -59,51 +59,72 @@ exports[`<FeaturedRoomTypes /> by default should render the right structure 1`] 
         <withLazyLoad(ResponsiveImage)
           imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
           isFluid={true}
-          isLazyLoaded={false}
+          isLazyLoaded={true}
         >
-          <ResponsiveImage
-            alternativeText="Image Widget"
-            hasRoundedCorners={false}
-            imageHeight={null}
-            imageNotFoundLabelText="Image not found!"
-            imageTitle="Image Title"
-            imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
-            imageWidth={null}
-            isAvatar={false}
-            isCircular={false}
-            isFluid={true}
-            isLazyLoaded={false}
-            label={null}
-            sizes={null}
-            srcSet={null}
+          <LazyLoader
+            componentProps={
+              Object {
+                "alternativeText": undefined,
+                "isFluid": true,
+                "isLazyLoaded": true,
+                "placeholderImageUrl": undefined,
+                "sizes": undefined,
+                "srcSet": undefined,
+              }
+            }
+            lazyComponent={[Function]}
+            lazyProps={
+              Object {
+                "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
+              }
+            }
           >
-            <figure
-              className="responsive-image is-fluid"
+            <div />
+            <ResponsiveImage
+              alternativeText="Image Widget"
+              hasRoundedCorners={false}
+              imageHeight={null}
+              imageNotFoundLabelText="Image not found!"
+              imageTitle="Image Title"
+              imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
+              imageWidth={null}
+              isAvatar={false}
+              isCircular={false}
+              isFluid={true}
+              isLazyLoaded={true}
+              label={null}
+              sizes={null}
+              srcSet={null}
             >
-              <Image
-                alt="Image Widget"
-                as="img"
-                avatar={false}
-                fluid={true}
-                onLoad={[Function]}
-                sizes={null}
-                src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
-                srcSet={null}
-                title="Image Title"
-                ui={true}
+              <figure
+                className="responsive-image is-fluid"
               >
-                <img
+                <Image
                   alt="Image Widget"
-                  className="ui fluid image"
+                  as="img"
+                  avatar={false}
+                  fluid={true}
                   onLoad={[Function]}
                   sizes={null}
                   src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
                   srcSet={null}
                   title="Image Title"
-                />
-              </Image>
-            </figure>
-          </ResponsiveImage>
+                  ui={true}
+                >
+                  <img
+                    alt="Image Widget"
+                    className="ui fluid image"
+                    onLoad={[Function]}
+                    sizes={null}
+                    src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
+                    srcSet={null}
+                    title="Image Title"
+                  />
+                </Image>
+              </figure>
+            </ResponsiveImage>
+            <div />
+          </LazyLoader>
         </withLazyLoad(ResponsiveImage)>
         <CardContent>
           <div
@@ -214,51 +235,72 @@ exports[`<FeaturedRoomTypes /> by default should render the right structure 1`] 
         <withLazyLoad(ResponsiveImage)
           imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
           isFluid={true}
-          isLazyLoaded={false}
+          isLazyLoaded={true}
         >
-          <ResponsiveImage
-            alternativeText="Image Widget"
-            hasRoundedCorners={false}
-            imageHeight={null}
-            imageNotFoundLabelText="Image not found!"
-            imageTitle="Image Title"
-            imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
-            imageWidth={null}
-            isAvatar={false}
-            isCircular={false}
-            isFluid={true}
-            isLazyLoaded={false}
-            label={null}
-            sizes={null}
-            srcSet={null}
+          <LazyLoader
+            componentProps={
+              Object {
+                "alternativeText": undefined,
+                "isFluid": true,
+                "isLazyLoaded": true,
+                "placeholderImageUrl": undefined,
+                "sizes": undefined,
+                "srcSet": undefined,
+              }
+            }
+            lazyComponent={[Function]}
+            lazyProps={
+              Object {
+                "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
+              }
+            }
           >
-            <figure
-              className="responsive-image is-fluid"
+            <div />
+            <ResponsiveImage
+              alternativeText="Image Widget"
+              hasRoundedCorners={false}
+              imageHeight={null}
+              imageNotFoundLabelText="Image not found!"
+              imageTitle="Image Title"
+              imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
+              imageWidth={null}
+              isAvatar={false}
+              isCircular={false}
+              isFluid={true}
+              isLazyLoaded={true}
+              label={null}
+              sizes={null}
+              srcSet={null}
             >
-              <Image
-                alt="Image Widget"
-                as="img"
-                avatar={false}
-                fluid={true}
-                onLoad={[Function]}
-                sizes={null}
-                src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
-                srcSet={null}
-                title="Image Title"
-                ui={true}
+              <figure
+                className="responsive-image is-fluid"
               >
-                <img
+                <Image
                   alt="Image Widget"
-                  className="ui fluid image"
+                  as="img"
+                  avatar={false}
+                  fluid={true}
                   onLoad={[Function]}
                   sizes={null}
                   src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
                   srcSet={null}
                   title="Image Title"
-                />
-              </Image>
-            </figure>
-          </ResponsiveImage>
+                  ui={true}
+                >
+                  <img
+                    alt="Image Widget"
+                    className="ui fluid image"
+                    onLoad={[Function]}
+                    sizes={null}
+                    src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
+                    srcSet={null}
+                    title="Image Title"
+                  />
+                </Image>
+              </figure>
+            </ResponsiveImage>
+            <div />
+          </LazyLoader>
         </withLazyLoad(ResponsiveImage)>
         <CardContent>
           <div
@@ -697,51 +739,72 @@ exports[`<FeaturedRoomTypes /> if \`props.headingText\` is passed should render 
         <withLazyLoad(ResponsiveImage)
           imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
           isFluid={true}
-          isLazyLoaded={false}
+          isLazyLoaded={true}
         >
-          <ResponsiveImage
-            alternativeText="Image Widget"
-            hasRoundedCorners={false}
-            imageHeight={null}
-            imageNotFoundLabelText="Image not found!"
-            imageTitle="Image Title"
-            imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
-            imageWidth={null}
-            isAvatar={false}
-            isCircular={false}
-            isFluid={true}
-            isLazyLoaded={false}
-            label={null}
-            sizes={null}
-            srcSet={null}
+          <LazyLoader
+            componentProps={
+              Object {
+                "alternativeText": undefined,
+                "isFluid": true,
+                "isLazyLoaded": true,
+                "placeholderImageUrl": undefined,
+                "sizes": undefined,
+                "srcSet": undefined,
+              }
+            }
+            lazyComponent={[Function]}
+            lazyProps={
+              Object {
+                "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
+              }
+            }
           >
-            <figure
-              className="responsive-image is-fluid"
+            <div />
+            <ResponsiveImage
+              alternativeText="Image Widget"
+              hasRoundedCorners={false}
+              imageHeight={null}
+              imageNotFoundLabelText="Image not found!"
+              imageTitle="Image Title"
+              imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
+              imageWidth={null}
+              isAvatar={false}
+              isCircular={false}
+              isFluid={true}
+              isLazyLoaded={true}
+              label={null}
+              sizes={null}
+              srcSet={null}
             >
-              <Image
-                alt="Image Widget"
-                as="img"
-                avatar={false}
-                fluid={true}
-                onLoad={[Function]}
-                sizes={null}
-                src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
-                srcSet={null}
-                title="Image Title"
-                ui={true}
+              <figure
+                className="responsive-image is-fluid"
               >
-                <img
+                <Image
                   alt="Image Widget"
-                  className="ui fluid image"
+                  as="img"
+                  avatar={false}
+                  fluid={true}
                   onLoad={[Function]}
                   sizes={null}
                   src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
                   srcSet={null}
                   title="Image Title"
-                />
-              </Image>
-            </figure>
-          </ResponsiveImage>
+                  ui={true}
+                >
+                  <img
+                    alt="Image Widget"
+                    className="ui fluid image"
+                    onLoad={[Function]}
+                    sizes={null}
+                    src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
+                    srcSet={null}
+                    title="Image Title"
+                  />
+                </Image>
+              </figure>
+            </ResponsiveImage>
+            <div />
+          </LazyLoader>
         </withLazyLoad(ResponsiveImage)>
         <CardContent>
           <div
@@ -852,51 +915,72 @@ exports[`<FeaturedRoomTypes /> if \`props.headingText\` is passed should render 
         <withLazyLoad(ResponsiveImage)
           imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
           isFluid={true}
-          isLazyLoaded={false}
+          isLazyLoaded={true}
         >
-          <ResponsiveImage
-            alternativeText="Image Widget"
-            hasRoundedCorners={false}
-            imageHeight={null}
-            imageNotFoundLabelText="Image not found!"
-            imageTitle="Image Title"
-            imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
-            imageWidth={null}
-            isAvatar={false}
-            isCircular={false}
-            isFluid={true}
-            isLazyLoaded={false}
-            label={null}
-            sizes={null}
-            srcSet={null}
+          <LazyLoader
+            componentProps={
+              Object {
+                "alternativeText": undefined,
+                "isFluid": true,
+                "isLazyLoaded": true,
+                "placeholderImageUrl": undefined,
+                "sizes": undefined,
+                "srcSet": undefined,
+              }
+            }
+            lazyComponent={[Function]}
+            lazyProps={
+              Object {
+                "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
+              }
+            }
           >
-            <figure
-              className="responsive-image is-fluid"
+            <div />
+            <ResponsiveImage
+              alternativeText="Image Widget"
+              hasRoundedCorners={false}
+              imageHeight={null}
+              imageNotFoundLabelText="Image not found!"
+              imageTitle="Image Title"
+              imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
+              imageWidth={null}
+              isAvatar={false}
+              isCircular={false}
+              isFluid={true}
+              isLazyLoaded={true}
+              label={null}
+              sizes={null}
+              srcSet={null}
             >
-              <Image
-                alt="Image Widget"
-                as="img"
-                avatar={false}
-                fluid={true}
-                onLoad={[Function]}
-                sizes={null}
-                src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
-                srcSet={null}
-                title="Image Title"
-                ui={true}
+              <figure
+                className="responsive-image is-fluid"
               >
-                <img
+                <Image
                   alt="Image Widget"
-                  className="ui fluid image"
+                  as="img"
+                  avatar={false}
+                  fluid={true}
                   onLoad={[Function]}
                   sizes={null}
                   src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
                   srcSet={null}
                   title="Image Title"
-                />
-              </Image>
-            </figure>
-          </ResponsiveImage>
+                  ui={true}
+                >
+                  <img
+                    alt="Image Widget"
+                    className="ui fluid image"
+                    onLoad={[Function]}
+                    sizes={null}
+                    src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
+                    srcSet={null}
+                    title="Image Title"
+                  />
+                </Image>
+              </figure>
+            </ResponsiveImage>
+            <div />
+          </LazyLoader>
         </withLazyLoad(ResponsiveImage)>
         <CardContent>
           <div

--- a/src/components/general-widgets/HomepageHero/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/HomepageHero/__snapshots__/component.spec.js.snap
@@ -99,55 +99,77 @@ exports[`HomepageHero should render the right structure 1`] = `
           <withLazyLoad(ResponsiveImage)
             imageUrl="bare sources"
             isFluid={true}
-            isLazyLoaded={false}
+            isLazyLoaded={true}
             placeholderImageUrl={null}
             sizes="url"
             srcSet="a load of sizes"
           >
-            <ResponsiveImage
-              alternativeText="Image Widget"
-              hasRoundedCorners={false}
-              imageHeight={null}
-              imageNotFoundLabelText="Image not found!"
-              imageTitle="Image Title"
-              imageUrl="bare sources"
-              imageWidth={null}
-              isAvatar={false}
-              isCircular={false}
-              isFluid={true}
-              isLazyLoaded={false}
-              label={null}
-              placeholderImageUrl={null}
-              sizes="url"
-              srcSet="a load of sizes"
+            <LazyLoader
+              componentProps={
+                Object {
+                  "imageHeight": undefined,
+                  "imageWidth": undefined,
+                  "isFluid": true,
+                  "isLazyLoaded": true,
+                  "placeholderImageUrl": null,
+                  "sizes": "url",
+                  "srcSet": "a load of sizes",
+                }
+              }
+              lazyComponent={[Function]}
+              lazyProps={
+                Object {
+                  "imageUrl": "bare sources",
+                }
+              }
             >
-              <figure
-                className="responsive-image is-fluid"
+              <div />
+              <ResponsiveImage
+                alternativeText="Image Widget"
+                hasRoundedCorners={false}
+                imageHeight={null}
+                imageNotFoundLabelText="Image not found!"
+                imageTitle="Image Title"
+                imageUrl="bare sources"
+                imageWidth={null}
+                isAvatar={false}
+                isCircular={false}
+                isFluid={true}
+                isLazyLoaded={true}
+                label={null}
+                placeholderImageUrl={null}
+                sizes="url"
+                srcSet="a load of sizes"
               >
-                <Image
-                  alt="Image Widget"
-                  as="img"
-                  avatar={false}
-                  fluid={true}
-                  onLoad={[Function]}
-                  sizes="url"
-                  src="bare sources"
-                  srcSet="a load of sizes"
-                  title="Image Title"
-                  ui={true}
+                <figure
+                  className="responsive-image is-fluid"
                 >
-                  <img
+                  <Image
                     alt="Image Widget"
-                    className="ui fluid image"
+                    as="img"
+                    avatar={false}
+                    fluid={true}
                     onLoad={[Function]}
                     sizes="url"
                     src="bare sources"
                     srcSet="a load of sizes"
                     title="Image Title"
-                  />
-                </Image>
-              </figure>
-            </ResponsiveImage>
+                    ui={true}
+                  >
+                    <img
+                      alt="Image Widget"
+                      className="ui fluid image"
+                      onLoad={[Function]}
+                      sizes="url"
+                      src="bare sources"
+                      srcSet="a load of sizes"
+                      title="Image Title"
+                    />
+                  </Image>
+                </figure>
+              </ResponsiveImage>
+              <div />
+            </LazyLoader>
           </withLazyLoad(ResponsiveImage)>
           <Header
             activeNavigationItemIndex={1}

--- a/src/components/general-widgets/Promotion/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/Promotion/__snapshots__/component.spec.js.snap
@@ -66,53 +66,74 @@ exports[`The \`Promotion\` component if \`backgroundImageUrl\` prop is passed sh
                       >
                         <withLazyLoad(ResponsiveImage)
                           imageUrl="testimage"
-                          isLazyLoaded={false}
+                          isLazyLoaded={true}
                           placeholderImageUrl={null}
                         >
-                          <ResponsiveImage
-                            alternativeText="Image Widget"
-                            hasRoundedCorners={false}
-                            imageHeight={null}
-                            imageNotFoundLabelText="Image not found!"
-                            imageTitle="Image Title"
-                            imageUrl="testimage"
-                            imageWidth={null}
-                            isAvatar={false}
-                            isCircular={false}
-                            isFluid={false}
-                            isLazyLoaded={false}
-                            label={null}
-                            placeholderImageUrl={null}
-                            sizes={null}
-                            srcSet={null}
+                          <LazyLoader
+                            componentProps={
+                              Object {
+                                "imageHeight": undefined,
+                                "imageWidth": undefined,
+                                "isLazyLoaded": true,
+                                "placeholderImageUrl": null,
+                                "sizes": undefined,
+                                "srcSet": undefined,
+                              }
+                            }
+                            lazyComponent={[Function]}
+                            lazyProps={
+                              Object {
+                                "imageUrl": "testimage",
+                              }
+                            }
                           >
-                            <figure
-                              className="responsive-image"
+                            <div />
+                            <ResponsiveImage
+                              alternativeText="Image Widget"
+                              hasRoundedCorners={false}
+                              imageHeight={null}
+                              imageNotFoundLabelText="Image not found!"
+                              imageTitle="Image Title"
+                              imageUrl="testimage"
+                              imageWidth={null}
+                              isAvatar={false}
+                              isCircular={false}
+                              isFluid={false}
+                              isLazyLoaded={true}
+                              label={null}
+                              placeholderImageUrl={null}
+                              sizes={null}
+                              srcSet={null}
                             >
-                              <Image
-                                alt="Image Widget"
-                                as="img"
-                                avatar={false}
-                                fluid={true}
-                                onLoad={[Function]}
-                                sizes={null}
-                                src="testimage"
-                                srcSet={null}
-                                title="Image Title"
-                                ui={true}
+                              <figure
+                                className="responsive-image"
                               >
-                                <img
+                                <Image
                                   alt="Image Widget"
-                                  className="ui fluid image"
+                                  as="img"
+                                  avatar={false}
+                                  fluid={true}
                                   onLoad={[Function]}
                                   sizes={null}
                                   src="testimage"
                                   srcSet={null}
                                   title="Image Title"
-                                />
-                              </Image>
-                            </figure>
-                          </ResponsiveImage>
+                                  ui={true}
+                                >
+                                  <img
+                                    alt="Image Widget"
+                                    className="ui fluid image"
+                                    onLoad={[Function]}
+                                    sizes={null}
+                                    src="testimage"
+                                    srcSet={null}
+                                    title="Image Title"
+                                  />
+                                </Image>
+                              </figure>
+                            </ResponsiveImage>
+                            <div />
+                          </LazyLoader>
                         </withLazyLoad(ResponsiveImage)>
                         <Grid
                           areColumnsCentered={false}

--- a/src/components/layout/LazyLoader/__snapshots__/component.spec.js.snap
+++ b/src/components/layout/LazyLoader/__snapshots__/component.spec.js.snap
@@ -5,6 +5,7 @@ exports[`LazyLoader by default should render the right structure 1`] = `
   lazyComponent={[Function]}
 >
   <div />
+  <div />
 </LazyLoader>
 `;
 
@@ -17,15 +18,15 @@ exports[`LazyLoader if \`componentProps\` !== undefined should render the right 
   }
   lazyComponent={[Function]}
 >
-  <div>
-    <Component
-      mad="props"
-    >
-      <div>
-        🚸
-      </div>
-    </Component>
-  </div>
+  <div />
+  <Component
+    mad="props"
+  >
+    <div>
+      🚸
+    </div>
+  </Component>
+  <div />
 </LazyLoader>
 `;
 
@@ -38,13 +39,13 @@ exports[`LazyLoader if \`lazyProps\` is passed by default should render the righ
     }
   }
 >
-  <div>
-    <Component>
-      <div>
-        🚸
-      </div>
-    </Component>
-  </div>
+  <div />
+  <Component>
+    <div>
+      🚸
+    </div>
+  </Component>
+  <div />
 </LazyLoader>
 `;
 
@@ -57,13 +58,13 @@ exports[`LazyLoader if \`lazyProps\` is passed if \`shouldRender\` === true shou
     }
   }
 >
-  <div>
-    <Component>
-      <div>
-        🚸
-      </div>
-    </Component>
-  </div>
+  <div />
+  <Component>
+    <div>
+      🚸
+    </div>
+  </Component>
+  <div />
 </LazyLoader>
 `;
 
@@ -71,12 +72,12 @@ exports[`LazyLoader if \`shouldRender\` === true should render the right structu
 <LazyLoader
   lazyComponent={[Function]}
 >
-  <div>
-    <Component>
-      <div>
-        🚸
-      </div>
-    </Component>
-  </div>
+  <div />
+  <Component>
+    <div>
+      🚸
+    </div>
+  </Component>
+  <div />
 </LazyLoader>
 `;

--- a/src/components/layout/LazyLoader/utils/getComponentPosition.js
+++ b/src/components/layout/LazyLoader/utils/getComponentPosition.js
@@ -1,0 +1,6 @@
+/**
+ * @param {Object} component
+ * @return {Object}
+ */
+export const getComponentPosition = component =>
+  !!component ? component.getBoundingClientRect() : undefined;

--- a/src/components/layout/LazyLoader/utils/getComponentPosition.spec.js
+++ b/src/components/layout/LazyLoader/utils/getComponentPosition.spec.js
@@ -1,0 +1,46 @@
+import { getComponentPosition } from './getComponentPosition';
+
+Element.prototype.getBoundingClientRect = jest.fn(() => ({
+  width: 120,
+  height: 120,
+  top: 0,
+  left: 0,
+  bottom: 0,
+  right: 0,
+}));
+
+describe('`getComponentPosition`', () => {
+  describe('if the component is undefined', () => {
+    it('should return `undefined` ', () => {
+      const COMPONENT = undefined;
+
+      const actual = getComponentPosition(COMPONENT);
+
+      expect(actual).toBe(undefined);
+    });
+  });
+
+  it('should return the postion of the component', () => {
+    const COMPONENT = Element;
+
+    COMPONENT.getBoundingClientRect = jest.fn(() => ({
+      width: 120,
+      height: 120,
+      top: 0,
+      left: 0,
+      bottom: 0,
+      right: 0,
+    }));
+
+    const actual = getComponentPosition(COMPONENT);
+
+    expect(actual).toEqual({
+      bottom: 0,
+      height: 120,
+      left: 0,
+      right: 0,
+      top: 0,
+      width: 120,
+    });
+  });
+});

--- a/src/components/layout/LazyLoader/utils/getIsBottomComponentVisible.js
+++ b/src/components/layout/LazyLoader/utils/getIsBottomComponentVisible.js
@@ -1,0 +1,12 @@
+import { HEIGHT_OFF_SET } from './constants';
+
+/**
+ * @param {Object} boundingClientRect
+ * @param {number} boundingClientRect.top
+ * @param {number} boundingClientRect.bottom
+ * @param {number} boundingClientRect.height
+ * @param {number} windowHeight
+ * @return {boolean}
+ */
+export const getIsBottomComponentVisible = ({ bottom }, windowHeight) =>
+  bottom + HEIGHT_OFF_SET > -windowHeight && bottom - windowHeight / 2 <= 0;

--- a/src/components/layout/LazyLoader/utils/getIsBottomComponentVisible.spec.js
+++ b/src/components/layout/LazyLoader/utils/getIsBottomComponentVisible.spec.js
@@ -1,0 +1,25 @@
+import { getIsBottomComponentVisible } from './getIsBottomComponentVisible';
+
+describe('`getIsBottomComponentVisible`', () => {
+  describe('when boundingClientRect coordinates are inside the windowHeight', () => {
+    it('should return true', () => {
+      const actual = getIsBottomComponentVisible(
+        { top: 50, bottom: 100, height: 50 },
+        1000
+      );
+
+      expect(actual).toBe(true);
+    });
+  });
+
+  describe('when boundingClientRect coordinates are outside the windowHeight', () => {
+    it('should return false', () => {
+      const actual = getIsBottomComponentVisible(
+        { top: -1100, bottom: -1300, height: 200 },
+        1000
+      );
+
+      expect(actual).toBe(false);
+    });
+  });
+});

--- a/src/components/layout/LazyLoader/utils/getIsTopComponentVisible.js
+++ b/src/components/layout/LazyLoader/utils/getIsTopComponentVisible.js
@@ -6,7 +6,7 @@ import { HEIGHT_OFF_SET } from './constants';
  * @param {number} boundingClientRect.bottom
  * @param {number} boundingClientRect.height
  * @param {number} windowHeight
+ * @return {boolean}
  */
-export const getIsVisible = ({ top, bottom, height }, windowHeight) =>
-  top + height >= 0 - HEIGHT_OFF_SET &&
-  bottom - height <= windowHeight + HEIGHT_OFF_SET;
+export const getIsTopComponentVisible = ({ top }, windowHeight) =>
+  top - HEIGHT_OFF_SET <= windowHeight && top > -windowHeight / 2;

--- a/src/components/layout/LazyLoader/utils/getIsTopComponentVisible.spec.js
+++ b/src/components/layout/LazyLoader/utils/getIsTopComponentVisible.spec.js
@@ -1,9 +1,12 @@
-import { getIsVisible } from './getIsVisible';
+import { getIsTopComponentVisible } from './getIsTopComponentVisible';
 
 describe('getIsVisible', () => {
   describe('when boundingClientRect coordinates are inside the windowHeight', () => {
     it('should return true', () => {
-      const actual = getIsVisible({ top: 50, bottom: 100, height: 50 }, 1000);
+      const actual = getIsTopComponentVisible(
+        { top: 50, bottom: 100, height: 50 },
+        1000
+      );
 
       expect(actual).toBe(true);
     });
@@ -11,7 +14,7 @@ describe('getIsVisible', () => {
 
   describe('when boundingClientRect coordinates are outside the windowHeight', () => {
     it('should return false', () => {
-      const actual = getIsVisible(
+      const actual = getIsTopComponentVisible(
         { top: -1100, bottom: -1300, height: 200 },
         1000
       );

--- a/src/components/media/FullBleed/__snapshots__/component.spec.js.snap
+++ b/src/components/media/FullBleed/__snapshots__/component.spec.js.snap
@@ -29,55 +29,77 @@ exports[`<FullBleed /> by default should have the right structure 1`] = `
       <withLazyLoad(ResponsiveImage)
         imageUrl="🐱🐱"
         isFluid={true}
-        isLazyLoaded={false}
+        isLazyLoaded={true}
         placeholderImageUrl={null}
         sizes={null}
         srcSet={null}
       >
-        <ResponsiveImage
-          alternativeText="Image Widget"
-          hasRoundedCorners={false}
-          imageHeight={null}
-          imageNotFoundLabelText="Image not found!"
-          imageTitle="Image Title"
-          imageUrl="🐱🐱"
-          imageWidth={null}
-          isAvatar={false}
-          isCircular={false}
-          isFluid={true}
-          isLazyLoaded={false}
-          label={null}
-          placeholderImageUrl={null}
-          sizes={null}
-          srcSet={null}
+        <LazyLoader
+          componentProps={
+            Object {
+              "imageHeight": undefined,
+              "imageWidth": undefined,
+              "isFluid": true,
+              "isLazyLoaded": true,
+              "placeholderImageUrl": null,
+              "sizes": null,
+              "srcSet": null,
+            }
+          }
+          lazyComponent={[Function]}
+          lazyProps={
+            Object {
+              "imageUrl": "🐱🐱",
+            }
+          }
         >
-          <figure
-            className="responsive-image is-fluid"
+          <div />
+          <ResponsiveImage
+            alternativeText="Image Widget"
+            hasRoundedCorners={false}
+            imageHeight={null}
+            imageNotFoundLabelText="Image not found!"
+            imageTitle="Image Title"
+            imageUrl="🐱🐱"
+            imageWidth={null}
+            isAvatar={false}
+            isCircular={false}
+            isFluid={true}
+            isLazyLoaded={true}
+            label={null}
+            placeholderImageUrl={null}
+            sizes={null}
+            srcSet={null}
           >
-            <Image
-              alt="Image Widget"
-              as="img"
-              avatar={false}
-              fluid={true}
-              onLoad={[Function]}
-              sizes={null}
-              src="🐱🐱"
-              srcSet={null}
-              title="Image Title"
-              ui={true}
+            <figure
+              className="responsive-image is-fluid"
             >
-              <img
+              <Image
                 alt="Image Widget"
-                className="ui fluid image"
+                as="img"
+                avatar={false}
+                fluid={true}
                 onLoad={[Function]}
                 sizes={null}
                 src="🐱🐱"
                 srcSet={null}
                 title="Image Title"
-              />
-            </Image>
-          </figure>
-        </ResponsiveImage>
+                ui={true}
+              >
+                <img
+                  alt="Image Widget"
+                  className="ui fluid image"
+                  onLoad={[Function]}
+                  sizes={null}
+                  src="🐱🐱"
+                  srcSet={null}
+                  title="Image Title"
+                />
+              </Image>
+            </figure>
+          </ResponsiveImage>
+          <div />
+        </LazyLoader>
       </withLazyLoad(ResponsiveImage)>
     </div>
   </Segment>
@@ -113,55 +135,77 @@ exports[`<FullBleed /> if \`hasGradient\` is passed should have the right struct
       <withLazyLoad(ResponsiveImage)
         imageUrl="🐱🐱"
         isFluid={true}
-        isLazyLoaded={false}
+        isLazyLoaded={true}
         placeholderImageUrl={null}
         sizes={null}
         srcSet={null}
       >
-        <ResponsiveImage
-          alternativeText="Image Widget"
-          hasRoundedCorners={false}
-          imageHeight={null}
-          imageNotFoundLabelText="Image not found!"
-          imageTitle="Image Title"
-          imageUrl="🐱🐱"
-          imageWidth={null}
-          isAvatar={false}
-          isCircular={false}
-          isFluid={true}
-          isLazyLoaded={false}
-          label={null}
-          placeholderImageUrl={null}
-          sizes={null}
-          srcSet={null}
+        <LazyLoader
+          componentProps={
+            Object {
+              "imageHeight": undefined,
+              "imageWidth": undefined,
+              "isFluid": true,
+              "isLazyLoaded": true,
+              "placeholderImageUrl": null,
+              "sizes": null,
+              "srcSet": null,
+            }
+          }
+          lazyComponent={[Function]}
+          lazyProps={
+            Object {
+              "imageUrl": "🐱🐱",
+            }
+          }
         >
-          <figure
-            className="responsive-image is-fluid"
+          <div />
+          <ResponsiveImage
+            alternativeText="Image Widget"
+            hasRoundedCorners={false}
+            imageHeight={null}
+            imageNotFoundLabelText="Image not found!"
+            imageTitle="Image Title"
+            imageUrl="🐱🐱"
+            imageWidth={null}
+            isAvatar={false}
+            isCircular={false}
+            isFluid={true}
+            isLazyLoaded={true}
+            label={null}
+            placeholderImageUrl={null}
+            sizes={null}
+            srcSet={null}
           >
-            <Image
-              alt="Image Widget"
-              as="img"
-              avatar={false}
-              fluid={true}
-              onLoad={[Function]}
-              sizes={null}
-              src="🐱🐱"
-              srcSet={null}
-              title="Image Title"
-              ui={true}
+            <figure
+              className="responsive-image is-fluid"
             >
-              <img
+              <Image
                 alt="Image Widget"
-                className="ui fluid image"
+                as="img"
+                avatar={false}
+                fluid={true}
                 onLoad={[Function]}
                 sizes={null}
                 src="🐱🐱"
                 srcSet={null}
                 title="Image Title"
-              />
-            </Image>
-          </figure>
-        </ResponsiveImage>
+                ui={true}
+              >
+                <img
+                  alt="Image Widget"
+                  className="ui fluid image"
+                  onLoad={[Function]}
+                  sizes={null}
+                  src="🐱🐱"
+                  srcSet={null}
+                  title="Image Title"
+                />
+              </Image>
+            </figure>
+          </ResponsiveImage>
+          <div />
+        </LazyLoader>
       </withLazyLoad(ResponsiveImage)>
     </div>
   </Segment>
@@ -197,55 +241,77 @@ exports[`<FullBleed /> if \`props.children > 0\` should have the right structure
       <withLazyLoad(ResponsiveImage)
         imageUrl="🐱🐱"
         isFluid={true}
-        isLazyLoaded={false}
+        isLazyLoaded={true}
         placeholderImageUrl={null}
         sizes={null}
         srcSet={null}
       >
-        <ResponsiveImage
-          alternativeText="Image Widget"
-          hasRoundedCorners={false}
-          imageHeight={null}
-          imageNotFoundLabelText="Image not found!"
-          imageTitle="Image Title"
-          imageUrl="🐱🐱"
-          imageWidth={null}
-          isAvatar={false}
-          isCircular={false}
-          isFluid={true}
-          isLazyLoaded={false}
-          label={null}
-          placeholderImageUrl={null}
-          sizes={null}
-          srcSet={null}
+        <LazyLoader
+          componentProps={
+            Object {
+              "imageHeight": undefined,
+              "imageWidth": undefined,
+              "isFluid": true,
+              "isLazyLoaded": true,
+              "placeholderImageUrl": null,
+              "sizes": null,
+              "srcSet": null,
+            }
+          }
+          lazyComponent={[Function]}
+          lazyProps={
+            Object {
+              "imageUrl": "🐱🐱",
+            }
+          }
         >
-          <figure
-            className="responsive-image is-fluid"
+          <div />
+          <ResponsiveImage
+            alternativeText="Image Widget"
+            hasRoundedCorners={false}
+            imageHeight={null}
+            imageNotFoundLabelText="Image not found!"
+            imageTitle="Image Title"
+            imageUrl="🐱🐱"
+            imageWidth={null}
+            isAvatar={false}
+            isCircular={false}
+            isFluid={true}
+            isLazyLoaded={true}
+            label={null}
+            placeholderImageUrl={null}
+            sizes={null}
+            srcSet={null}
           >
-            <Image
-              alt="Image Widget"
-              as="img"
-              avatar={false}
-              fluid={true}
-              onLoad={[Function]}
-              sizes={null}
-              src="🐱🐱"
-              srcSet={null}
-              title="Image Title"
-              ui={true}
+            <figure
+              className="responsive-image is-fluid"
             >
-              <img
+              <Image
                 alt="Image Widget"
-                className="ui fluid image"
+                as="img"
+                avatar={false}
+                fluid={true}
                 onLoad={[Function]}
                 sizes={null}
                 src="🐱🐱"
                 srcSet={null}
                 title="Image Title"
-              />
-            </Image>
-          </figure>
-        </ResponsiveImage>
+                ui={true}
+              >
+                <img
+                  alt="Image Widget"
+                  className="ui fluid image"
+                  onLoad={[Function]}
+                  sizes={null}
+                  src="🐱🐱"
+                  srcSet={null}
+                  title="Image Title"
+                />
+              </Image>
+            </figure>
+          </ResponsiveImage>
+          <div />
+        </LazyLoader>
       </withLazyLoad(ResponsiveImage)>
       🏛
     </div>

--- a/src/components/media/ResponsiveImage/Readme.md
+++ b/src/components/media/ResponsiveImage/Readme.md
@@ -53,7 +53,7 @@ const getSrc = width => `https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536
  />
 ```
 
-#### With lazy loading
+#### Without lazy loading
 
 ```jsx
 <ResponsiveImage
@@ -61,7 +61,7 @@ const getSrc = width => `https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536
   imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1023&mode=max"
   imageWidth={1024}
   imageHeight={683}
-  isLazyLoaded
+  isLazyLoaded={false}
  />
 ```
 

--- a/src/components/media/ResponsiveImage/__snapshots__/component.spec.js.snap
+++ b/src/components/media/ResponsiveImage/__snapshots__/component.spec.js.snap
@@ -23,7 +23,11 @@ exports[`<ResponsiveImage /> by default should have the right structure 1`] = `
       }
     }
     lazyComponent={[Function]}
-    lazyProps={Object {}}
+    lazyProps={
+      Object {
+        "imageUrl": undefined,
+      }
+    }
   >
     <div />
     <ResponsiveImage
@@ -284,7 +288,11 @@ exports[`<ResponsiveImage /> if \`props.placeholderImageUrl\` is passed should h
       }
     }
     lazyComponent={[Function]}
-    lazyProps={Object {}}
+    lazyProps={
+      Object {
+        "imageUrl": undefined,
+      }
+    }
   >
     <div />
     <ResponsiveImage

--- a/src/components/media/ResponsiveImage/__snapshots__/component.spec.js.snap
+++ b/src/components/media/ResponsiveImage/__snapshots__/component.spec.js.snap
@@ -6,75 +6,6 @@ exports[`<ResponsiveImage /> by default should have the right structure 1`] = `
   imageTitle="ResponsiveImage title"
   isAvatar={false}
   isFluid={true}
-  isLazyLoaded={false}
-  onLoad={[Function]}
-  sources={Array []}
->
-  <ResponsiveImage
-    alternativeText="Alternative Text 😝"
-    hasRoundedCorners={false}
-    imageHeight={null}
-    imageNotFoundLabelText="Image not found!"
-    imageTitle="ResponsiveImage title"
-    imageUrl=""
-    imageWidth={null}
-    isAvatar={false}
-    isCircular={false}
-    isFluid={true}
-    isLazyLoaded={false}
-    label={null}
-    onLoad={[Function]}
-    sizes={null}
-    sources={Array []}
-    srcSet={null}
-  >
-    <figure
-      className="responsive-image is-fluid"
-    >
-      <Image
-        alt="Alternative Text 😝"
-        as="img"
-        avatar={false}
-        fluid={true}
-        onLoad={[Function]}
-        sizes={null}
-        src=""
-        srcSet={null}
-        title="ResponsiveImage title"
-        ui={true}
-      >
-        <div
-          alt="Alternative Text 😝"
-          className="ui fluid image"
-          onLoad={[Function]}
-          sizes={null}
-          src=""
-          srcSet={null}
-          title="ResponsiveImage title"
-        >
-          <Label
-            content="Image not found!"
-          >
-            <div
-              className="ui label"
-              onClick={[Function]}
-            >
-              Image not found!
-            </div>
-          </Label>
-        </div>
-      </Image>
-    </figure>
-  </ResponsiveImage>
-</withLazyLoad(ResponsiveImage)>
-`;
-
-exports[`<ResponsiveImage /> if \`props.isLazyLoaded\` is true should have the right structure 1`] = `
-<withLazyLoad(ResponsiveImage)
-  alternativeText="Alternative Text 😝"
-  imageTitle="ResponsiveImage title"
-  isAvatar={false}
-  isFluid={true}
   isLazyLoaded={true}
   onLoad={[Function]}
   sources={Array []}
@@ -92,82 +23,77 @@ exports[`<ResponsiveImage /> if \`props.isLazyLoaded\` is true should have the r
       }
     }
     lazyComponent={[Function]}
-    lazyProps={
-      Object {
-        "imageUrl": undefined,
-      }
-    }
+    lazyProps={Object {}}
   >
-    <div>
-      <ResponsiveImage
-        alternativeText="Alternative Text 😝"
-        hasRoundedCorners={false}
-        imageHeight={null}
-        imageNotFoundLabelText="Image not found!"
-        imageTitle="ResponsiveImage title"
-        imageUrl=""
-        imageWidth={null}
-        isAvatar={false}
-        isCircular={false}
-        isFluid={true}
-        isLazyLoaded={true}
-        label={null}
-        onLoad={[Function]}
-        sizes={null}
-        sources={Array []}
-        srcSet={null}
+    <div />
+    <ResponsiveImage
+      alternativeText="Alternative Text 😝"
+      hasRoundedCorners={false}
+      imageHeight={null}
+      imageNotFoundLabelText="Image not found!"
+      imageTitle="ResponsiveImage title"
+      imageUrl=""
+      imageWidth={null}
+      isAvatar={false}
+      isCircular={false}
+      isFluid={true}
+      isLazyLoaded={true}
+      label={null}
+      onLoad={[Function]}
+      sizes={null}
+      sources={Array []}
+      srcSet={null}
+    >
+      <figure
+        className="responsive-image is-fluid"
       >
-        <figure
-          className="responsive-image is-fluid"
+        <Image
+          alt="Alternative Text 😝"
+          as="img"
+          avatar={false}
+          fluid={true}
+          onLoad={[Function]}
+          sizes={null}
+          src=""
+          srcSet={null}
+          title="ResponsiveImage title"
+          ui={true}
         >
-          <Image
+          <div
             alt="Alternative Text 😝"
-            as="img"
-            avatar={false}
-            fluid={true}
+            className="ui fluid image"
             onLoad={[Function]}
             sizes={null}
             src=""
             srcSet={null}
             title="ResponsiveImage title"
-            ui={true}
           >
-            <div
-              alt="Alternative Text 😝"
-              className="ui fluid image"
-              onLoad={[Function]}
-              sizes={null}
-              src=""
-              srcSet={null}
-              title="ResponsiveImage title"
+            <Label
+              content="Image not found!"
             >
-              <Label
-                content="Image not found!"
+              <div
+                className="ui label"
+                onClick={[Function]}
               >
-                <div
-                  className="ui label"
-                  onClick={[Function]}
-                >
-                  Image not found!
-                </div>
-              </Label>
-            </div>
-          </Image>
-        </figure>
-      </ResponsiveImage>
-    </div>
+                Image not found!
+              </div>
+            </Label>
+          </div>
+        </Image>
+      </figure>
+    </ResponsiveImage>
+    <div />
   </LazyLoader>
 </withLazyLoad(ResponsiveImage)>
 `;
 
-exports[`<ResponsiveImage /> if \`props.label\` is passed should have the right structure 1`] = `
+exports[`<ResponsiveImage /> if \`props.isLazyLoaded\` is false should have the right structure 1`] = `
 <withLazyLoad(ResponsiveImage)
   alternativeText="Alternative Text 😝"
   imageTitle="ResponsiveImage title"
   isAvatar={false}
   isFluid={true}
   isLazyLoaded={false}
-  label="🔷"
   onLoad={[Function]}
   sources={Array []}
 >
@@ -183,7 +109,7 @@ exports[`<ResponsiveImage /> if \`props.label\` is passed should have the right 
     isCircular={false}
     isFluid={true}
     isLazyLoaded={false}
-    label="🔷"
+    label={null}
     onLoad={[Function]}
     sizes={null}
     sources={Array []}
@@ -225,18 +151,111 @@ exports[`<ResponsiveImage /> if \`props.label\` is passed should have the right 
           </Label>
         </div>
       </Image>
-      <Paragraph
-        size="medium"
-        weight={null}
-      >
-        <p
-          className=""
-        >
-          🔷
-        </p>
-      </Paragraph>
     </figure>
   </ResponsiveImage>
+</withLazyLoad(ResponsiveImage)>
+`;
+
+exports[`<ResponsiveImage /> if \`props.label\` is passed should have the right structure 1`] = `
+<withLazyLoad(ResponsiveImage)
+  alternativeText="Alternative Text 😝"
+  imageTitle="ResponsiveImage title"
+  isAvatar={false}
+  isFluid={true}
+  isLazyLoaded={true}
+  label="🔷"
+  onLoad={[Function]}
+  sources={Array []}
+>
+  <LazyLoader
+    componentProps={
+      Object {
+        "alternativeText": "Alternative Text 😝",
+        "imageTitle": "ResponsiveImage title",
+        "isAvatar": false,
+        "isFluid": true,
+        "isLazyLoaded": true,
+        "label": "🔷",
+        "onLoad": [Function],
+        "sources": Array [],
+      }
+    }
+    lazyComponent={[Function]}
+    lazyProps={
+      Object {
+        "imageUrl": undefined,
+      }
+    }
+  >
+    <div />
+    <ResponsiveImage
+      alternativeText="Alternative Text 😝"
+      hasRoundedCorners={false}
+      imageHeight={null}
+      imageNotFoundLabelText="Image not found!"
+      imageTitle="ResponsiveImage title"
+      imageUrl=""
+      imageWidth={null}
+      isAvatar={false}
+      isCircular={false}
+      isFluid={true}
+      isLazyLoaded={true}
+      label="🔷"
+      onLoad={[Function]}
+      sizes={null}
+      sources={Array []}
+      srcSet={null}
+    >
+      <figure
+        className="responsive-image is-fluid"
+      >
+        <Image
+          alt="Alternative Text 😝"
+          as="img"
+          avatar={false}
+          fluid={true}
+          onLoad={[Function]}
+          sizes={null}
+          src=""
+          srcSet={null}
+          title="ResponsiveImage title"
+          ui={true}
+        >
+          <div
+            alt="Alternative Text 😝"
+            className="ui fluid image"
+            onLoad={[Function]}
+            sizes={null}
+            src=""
+            srcSet={null}
+            title="ResponsiveImage title"
+          >
+            <Label
+              content="Image not found!"
+            >
+              <div
+                className="ui label"
+                onClick={[Function]}
+              >
+                Image not found!
+              </div>
+            </Label>
+          </div>
+        </Image>
+        <Paragraph
+          size="medium"
+          weight={null}
+        >
+          <p
+            className=""
+          >
+            🔷
+          </p>
+        </Paragraph>
+      </figure>
+    </ResponsiveImage>
+    <div />
+  </LazyLoader>
 </withLazyLoad(ResponsiveImage)>
 `;
 
@@ -246,78 +265,97 @@ exports[`<ResponsiveImage /> if \`props.placeholderImageUrl\` is passed should h
   imageTitle="ResponsiveImage title"
   isAvatar={false}
   isFluid={true}
-  isLazyLoaded={false}
+  isLazyLoaded={true}
   onLoad={[Function]}
   placeholderImageUrl="ayyy"
   sources={Array []}
 >
-  <ResponsiveImage
-    alternativeText="Alternative Text 😝"
-    hasRoundedCorners={false}
-    imageHeight={null}
-    imageNotFoundLabelText="Image not found!"
-    imageTitle="ResponsiveImage title"
-    imageUrl=""
-    imageWidth={null}
-    isAvatar={false}
-    isCircular={false}
-    isFluid={true}
-    isLazyLoaded={false}
-    label={null}
-    onLoad={[Function]}
-    placeholderImageUrl="ayyy"
-    sizes={null}
-    sources={Array []}
-    srcSet={null}
+  <LazyLoader
+    componentProps={
+      Object {
+        "alternativeText": "Alternative Text 😝",
+        "imageTitle": "ResponsiveImage title",
+        "isAvatar": false,
+        "isFluid": true,
+        "isLazyLoaded": true,
+        "onLoad": [Function],
+        "placeholderImageUrl": "ayyy",
+        "sources": Array [],
+      }
+    }
+    lazyComponent={[Function]}
+    lazyProps={Object {}}
   >
-    <figure
-      className="responsive-image has-blurred-children has-placeholder is-fluid"
+    <div />
+    <ResponsiveImage
+      alternativeText="Alternative Text 😝"
+      hasRoundedCorners={false}
+      imageHeight={null}
+      imageNotFoundLabelText="Image not found!"
+      imageTitle="ResponsiveImage title"
+      imageUrl=""
+      imageWidth={null}
+      isAvatar={false}
+      isCircular={false}
+      isFluid={true}
+      isLazyLoaded={true}
+      label={null}
+      onLoad={[Function]}
+      placeholderImageUrl="ayyy"
+      sizes={null}
+      sources={Array []}
+      srcSet={null}
     >
-      <Image
-        alt="Alternative Text 😝"
-        as="img"
-        avatar={false}
-        fluid={true}
-        onLoad={[Function]}
-        sizes={null}
-        src=""
-        srcSet={null}
-        title="ResponsiveImage title"
-        ui={true}
+      <figure
+        className="responsive-image has-blurred-children has-placeholder is-fluid"
       >
-        <div
+        <Image
           alt="Alternative Text 😝"
-          className="ui fluid image"
+          as="img"
+          avatar={false}
+          fluid={true}
           onLoad={[Function]}
           sizes={null}
           src=""
           srcSet={null}
           title="ResponsiveImage title"
+          ui={true}
         >
-          <Label
-            content="Image not found!"
+          <div
+            alt="Alternative Text 😝"
+            className="ui fluid image"
+            onLoad={[Function]}
+            sizes={null}
+            src=""
+            srcSet={null}
+            title="ResponsiveImage title"
           >
-            <div
-              className="ui label"
-              onClick={[Function]}
+            <Label
+              content="Image not found!"
             >
-              Image not found!
-            </div>
-          </Label>
-        </div>
-      </Image>
-      <Image
-        as="img"
-        fluid={true}
-        src="ayyy"
-        ui={true}
-      >
-        <img
-          className="ui fluid image"
+              <div
+                className="ui label"
+                onClick={[Function]}
+              >
+                Image not found!
+              </div>
+            </Label>
+          </div>
+        </Image>
+        <Image
+          as="img"
+          fluid={true}
           src="ayyy"
-        />
-      </Image>
-    </figure>
-  </ResponsiveImage>
+          ui={true}
+        >
+          <img
+            className="ui fluid image"
+            src="ayyy"
+          />
+        </Image>
+      </figure>
+    </ResponsiveImage>
+    <div />
+  </LazyLoader>
 </withLazyLoad(ResponsiveImage)>
 `;

--- a/src/components/media/ResponsiveImage/component.js
+++ b/src/components/media/ResponsiveImage/component.js
@@ -88,7 +88,7 @@ Component.defaultProps = {
   isAvatar: false,
   isCircular: false,
   isFluid: false,
-  isLazyLoaded: false,
+  isLazyLoaded: true,
   label: null,
   placeholderImageUrl: undefined,
   sizes: null,

--- a/src/components/media/ResponsiveImage/component.spec.js
+++ b/src/components/media/ResponsiveImage/component.spec.js
@@ -15,7 +15,8 @@ const props = {
 const getResponsiveImage = extraProps =>
   mount(<ResponsiveImage {...props} {...extraProps} />);
 
-const getWrappedResponsiveImage = () => getResponsiveImage().childAt(0);
+const getWrappedResponsiveImage = () =>
+  getResponsiveImage().find('ResponsiveImage');
 
 describe('<ResponsiveImage />', () => {
   describe('by default', () => {
@@ -44,9 +45,9 @@ describe('<ResponsiveImage />', () => {
     });
   });
 
-  describe('if `props.isLazyLoaded` is true', () => {
+  describe('if `props.isLazyLoaded` is false', () => {
     it('should have the right structure', () => {
-      const actual = getResponsiveImage({ isLazyLoaded: true });
+      const actual = getResponsiveImage({ isLazyLoaded: false });
 
       expect(actual).toMatchSnapshot();
     });

--- a/src/components/media/Thumbnail/__snapshots__/component.spec.js.snap
+++ b/src/components/media/Thumbnail/__snapshots__/component.spec.js.snap
@@ -18,53 +18,75 @@ exports[`<Thumbnail /> by default should render the right structure 1`] = `
       hasRoundedCorners={false}
       imageUrl="www.⚡️.net"
       isCircular={false}
-      isLazyLoaded={false}
+      isLazyLoaded={true}
       isSquare={false}
     >
-      <ResponsiveImage
-        alternativeText="Image Widget"
-        hasRoundedCorners={false}
-        imageHeight={null}
-        imageNotFoundLabelText="Image not found!"
-        imageTitle="Image Title"
-        imageUrl="www.⚡️.net"
-        imageWidth={null}
-        isAvatar={false}
-        isCircular={false}
-        isFluid={false}
-        isLazyLoaded={false}
-        isSquare={false}
-        label={null}
-        sizes={null}
-        srcSet={null}
+      <LazyLoader
+        componentProps={
+          Object {
+            "alternativeText": undefined,
+            "hasRoundedCorners": false,
+            "isCircular": false,
+            "isLazyLoaded": true,
+            "isSquare": false,
+            "sizes": undefined,
+            "srcSet": undefined,
+          }
+        }
+        lazyComponent={[Function]}
+        lazyProps={
+          Object {
+            "imageUrl": "www.⚡️.net",
+          }
+        }
       >
-        <figure
-          className="responsive-image"
+        <div />
+        <ResponsiveImage
+          alternativeText="Image Widget"
+          hasRoundedCorners={false}
+          imageHeight={null}
+          imageNotFoundLabelText="Image not found!"
+          imageTitle="Image Title"
+          imageUrl="www.⚡️.net"
+          imageWidth={null}
+          isAvatar={false}
+          isCircular={false}
+          isFluid={false}
+          isLazyLoaded={true}
+          isSquare={false}
+          label={null}
+          sizes={null}
+          srcSet={null}
         >
-          <Image
-            alt="Image Widget"
-            as="img"
-            avatar={false}
-            fluid={true}
-            onLoad={[Function]}
-            sizes={null}
-            src="www.⚡️.net"
-            srcSet={null}
-            title="Image Title"
-            ui={true}
+          <figure
+            className="responsive-image"
           >
-            <img
+            <Image
               alt="Image Widget"
-              className="ui fluid image"
+              as="img"
+              avatar={false}
+              fluid={true}
               onLoad={[Function]}
               sizes={null}
               src="www.⚡️.net"
               srcSet={null}
               title="Image Title"
-            />
-          </Image>
-        </figure>
-      </ResponsiveImage>
+              ui={true}
+            >
+              <img
+                alt="Image Widget"
+                className="ui fluid image"
+                onLoad={[Function]}
+                sizes={null}
+                src="www.⚡️.net"
+                srcSet={null}
+                title="Image Title"
+              />
+            </Image>
+          </figure>
+        </ResponsiveImage>
+        <div />
+      </LazyLoader>
     </withLazyLoad(ResponsiveImage)>
   </div>
 </Thumbnail>
@@ -88,53 +110,75 @@ exports[`<Thumbnail /> if \`props.isCircular\` is true should render the right s
       hasRoundedCorners={false}
       imageUrl="www.⚡️.net"
       isCircular={true}
-      isLazyLoaded={false}
+      isLazyLoaded={true}
       isSquare={false}
     >
-      <ResponsiveImage
-        alternativeText="Image Widget"
-        hasRoundedCorners={false}
-        imageHeight={null}
-        imageNotFoundLabelText="Image not found!"
-        imageTitle="Image Title"
-        imageUrl="www.⚡️.net"
-        imageWidth={null}
-        isAvatar={false}
-        isCircular={true}
-        isFluid={false}
-        isLazyLoaded={false}
-        isSquare={false}
-        label={null}
-        sizes={null}
-        srcSet={null}
+      <LazyLoader
+        componentProps={
+          Object {
+            "alternativeText": undefined,
+            "hasRoundedCorners": false,
+            "isCircular": true,
+            "isLazyLoaded": true,
+            "isSquare": false,
+            "sizes": undefined,
+            "srcSet": undefined,
+          }
+        }
+        lazyComponent={[Function]}
+        lazyProps={
+          Object {
+            "imageUrl": "www.⚡️.net",
+          }
+        }
       >
-        <figure
-          className="responsive-image is-circular"
+        <div />
+        <ResponsiveImage
+          alternativeText="Image Widget"
+          hasRoundedCorners={false}
+          imageHeight={null}
+          imageNotFoundLabelText="Image not found!"
+          imageTitle="Image Title"
+          imageUrl="www.⚡️.net"
+          imageWidth={null}
+          isAvatar={false}
+          isCircular={true}
+          isFluid={false}
+          isLazyLoaded={true}
+          isSquare={false}
+          label={null}
+          sizes={null}
+          srcSet={null}
         >
-          <Image
-            alt="Image Widget"
-            as="img"
-            avatar={false}
-            fluid={true}
-            onLoad={[Function]}
-            sizes={null}
-            src="www.⚡️.net"
-            srcSet={null}
-            title="Image Title"
-            ui={true}
+          <figure
+            className="responsive-image is-circular"
           >
-            <img
+            <Image
               alt="Image Widget"
-              className="ui fluid image"
+              as="img"
+              avatar={false}
+              fluid={true}
               onLoad={[Function]}
               sizes={null}
               src="www.⚡️.net"
               srcSet={null}
               title="Image Title"
-            />
-          </Image>
-        </figure>
-      </ResponsiveImage>
+              ui={true}
+            >
+              <img
+                alt="Image Widget"
+                className="ui fluid image"
+                onLoad={[Function]}
+                sizes={null}
+                src="www.⚡️.net"
+                srcSet={null}
+                title="Image Title"
+              />
+            </Image>
+          </figure>
+        </ResponsiveImage>
+        <div />
+      </LazyLoader>
     </withLazyLoad(ResponsiveImage)>
   </div>
 </Thumbnail>
@@ -158,53 +202,75 @@ exports[`<Thumbnail /> if \`props.isSquare\` is true should render the right str
       hasRoundedCorners={false}
       imageUrl="www.⚡️.net"
       isCircular={false}
-      isLazyLoaded={false}
+      isLazyLoaded={true}
       isSquare={true}
     >
-      <ResponsiveImage
-        alternativeText="Image Widget"
-        hasRoundedCorners={false}
-        imageHeight={null}
-        imageNotFoundLabelText="Image not found!"
-        imageTitle="Image Title"
-        imageUrl="www.⚡️.net"
-        imageWidth={null}
-        isAvatar={false}
-        isCircular={false}
-        isFluid={false}
-        isLazyLoaded={false}
-        isSquare={true}
-        label={null}
-        sizes={null}
-        srcSet={null}
+      <LazyLoader
+        componentProps={
+          Object {
+            "alternativeText": undefined,
+            "hasRoundedCorners": false,
+            "isCircular": false,
+            "isLazyLoaded": true,
+            "isSquare": true,
+            "sizes": undefined,
+            "srcSet": undefined,
+          }
+        }
+        lazyComponent={[Function]}
+        lazyProps={
+          Object {
+            "imageUrl": "www.⚡️.net",
+          }
+        }
       >
-        <figure
-          className="responsive-image"
+        <div />
+        <ResponsiveImage
+          alternativeText="Image Widget"
+          hasRoundedCorners={false}
+          imageHeight={null}
+          imageNotFoundLabelText="Image not found!"
+          imageTitle="Image Title"
+          imageUrl="www.⚡️.net"
+          imageWidth={null}
+          isAvatar={false}
+          isCircular={false}
+          isFluid={false}
+          isLazyLoaded={true}
+          isSquare={true}
+          label={null}
+          sizes={null}
+          srcSet={null}
         >
-          <Image
-            alt="Image Widget"
-            as="img"
-            avatar={false}
-            fluid={true}
-            onLoad={[Function]}
-            sizes={null}
-            src="www.⚡️.net"
-            srcSet={null}
-            title="Image Title"
-            ui={true}
+          <figure
+            className="responsive-image"
           >
-            <img
+            <Image
               alt="Image Widget"
-              className="ui fluid image"
+              as="img"
+              avatar={false}
+              fluid={true}
               onLoad={[Function]}
               sizes={null}
               src="www.⚡️.net"
               srcSet={null}
               title="Image Title"
-            />
-          </Image>
-        </figure>
-      </ResponsiveImage>
+              ui={true}
+            >
+              <img
+                alt="Image Widget"
+                className="ui fluid image"
+                onLoad={[Function]}
+                sizes={null}
+                src="www.⚡️.net"
+                srcSet={null}
+                title="Image Title"
+              />
+            </Image>
+          </figure>
+        </ResponsiveImage>
+        <div />
+      </LazyLoader>
     </withLazyLoad(ResponsiveImage)>
   </div>
 </Thumbnail>
@@ -228,53 +294,75 @@ exports[`<Thumbnail /> if \`props.size\` is supplied should render the right str
       hasRoundedCorners={false}
       imageUrl="www.⚡️.net"
       isCircular={false}
-      isLazyLoaded={false}
+      isLazyLoaded={true}
       isSquare={false}
     >
-      <ResponsiveImage
-        alternativeText="Image Widget"
-        hasRoundedCorners={false}
-        imageHeight={null}
-        imageNotFoundLabelText="Image not found!"
-        imageTitle="Image Title"
-        imageUrl="www.⚡️.net"
-        imageWidth={null}
-        isAvatar={false}
-        isCircular={false}
-        isFluid={false}
-        isLazyLoaded={false}
-        isSquare={false}
-        label={null}
-        sizes={null}
-        srcSet={null}
+      <LazyLoader
+        componentProps={
+          Object {
+            "alternativeText": undefined,
+            "hasRoundedCorners": false,
+            "isCircular": false,
+            "isLazyLoaded": true,
+            "isSquare": false,
+            "sizes": undefined,
+            "srcSet": undefined,
+          }
+        }
+        lazyComponent={[Function]}
+        lazyProps={
+          Object {
+            "imageUrl": "www.⚡️.net",
+          }
+        }
       >
-        <figure
-          className="responsive-image"
+        <div />
+        <ResponsiveImage
+          alternativeText="Image Widget"
+          hasRoundedCorners={false}
+          imageHeight={null}
+          imageNotFoundLabelText="Image not found!"
+          imageTitle="Image Title"
+          imageUrl="www.⚡️.net"
+          imageWidth={null}
+          isAvatar={false}
+          isCircular={false}
+          isFluid={false}
+          isLazyLoaded={true}
+          isSquare={false}
+          label={null}
+          sizes={null}
+          srcSet={null}
         >
-          <Image
-            alt="Image Widget"
-            as="img"
-            avatar={false}
-            fluid={true}
-            onLoad={[Function]}
-            sizes={null}
-            src="www.⚡️.net"
-            srcSet={null}
-            title="Image Title"
-            ui={true}
+          <figure
+            className="responsive-image"
           >
-            <img
+            <Image
               alt="Image Widget"
-              className="ui fluid image"
+              as="img"
+              avatar={false}
+              fluid={true}
               onLoad={[Function]}
               sizes={null}
               src="www.⚡️.net"
               srcSet={null}
               title="Image Title"
-            />
-          </Image>
-        </figure>
-      </ResponsiveImage>
+              ui={true}
+            >
+              <img
+                alt="Image Widget"
+                className="ui fluid image"
+                onLoad={[Function]}
+                sizes={null}
+                src="www.⚡️.net"
+                srcSet={null}
+                title="Image Title"
+              />
+            </Image>
+          </figure>
+        </ResponsiveImage>
+        <div />
+      </LazyLoader>
     </withLazyLoad(ResponsiveImage)>
   </div>
 </Thumbnail>

--- a/src/components/property-page-widgets/HostProfile/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/HostProfile/__snapshots__/component.spec.js.snap
@@ -132,53 +132,75 @@ exports[`<HostProfile /> if \`props.email\` is defined should render the right s
                               hasRoundedCorners={false}
                               imageUrl="https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max"
                               isCircular={true}
-                              isLazyLoaded={false}
+                              isLazyLoaded={true}
                               isSquare={false}
                             >
-                              <ResponsiveImage
-                                alternativeText="Image Widget"
-                                hasRoundedCorners={false}
-                                imageHeight={null}
-                                imageNotFoundLabelText="Image not found!"
-                                imageTitle="Image Title"
-                                imageUrl="https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max"
-                                imageWidth={null}
-                                isAvatar={false}
-                                isCircular={true}
-                                isFluid={false}
-                                isLazyLoaded={false}
-                                isSquare={false}
-                                label={null}
-                                sizes={null}
-                                srcSet={null}
+                              <LazyLoader
+                                componentProps={
+                                  Object {
+                                    "alternativeText": undefined,
+                                    "hasRoundedCorners": false,
+                                    "isCircular": true,
+                                    "isLazyLoaded": true,
+                                    "isSquare": false,
+                                    "sizes": undefined,
+                                    "srcSet": undefined,
+                                  }
+                                }
+                                lazyComponent={[Function]}
+                                lazyProps={
+                                  Object {
+                                    "imageUrl": "https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max",
+                                  }
+                                }
                               >
-                                <figure
-                                  className="responsive-image is-circular"
+                                <div />
+                                <ResponsiveImage
+                                  alternativeText="Image Widget"
+                                  hasRoundedCorners={false}
+                                  imageHeight={null}
+                                  imageNotFoundLabelText="Image not found!"
+                                  imageTitle="Image Title"
+                                  imageUrl="https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max"
+                                  imageWidth={null}
+                                  isAvatar={false}
+                                  isCircular={true}
+                                  isFluid={false}
+                                  isLazyLoaded={true}
+                                  isSquare={false}
+                                  label={null}
+                                  sizes={null}
+                                  srcSet={null}
                                 >
-                                  <Image
-                                    alt="Image Widget"
-                                    as="img"
-                                    avatar={false}
-                                    fluid={true}
-                                    onLoad={[Function]}
-                                    sizes={null}
-                                    src="https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max"
-                                    srcSet={null}
-                                    title="Image Title"
-                                    ui={true}
+                                  <figure
+                                    className="responsive-image is-circular"
                                   >
-                                    <img
+                                    <Image
                                       alt="Image Widget"
-                                      className="ui fluid image"
+                                      as="img"
+                                      avatar={false}
+                                      fluid={true}
                                       onLoad={[Function]}
                                       sizes={null}
                                       src="https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max"
                                       srcSet={null}
                                       title="Image Title"
-                                    />
-                                  </Image>
-                                </figure>
-                              </ResponsiveImage>
+                                      ui={true}
+                                    >
+                                      <img
+                                        alt="Image Widget"
+                                        className="ui fluid image"
+                                        onLoad={[Function]}
+                                        sizes={null}
+                                        src="https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max"
+                                        srcSet={null}
+                                        title="Image Title"
+                                      />
+                                    </Image>
+                                  </figure>
+                                </ResponsiveImage>
+                                <div />
+                              </LazyLoader>
                             </withLazyLoad(ResponsiveImage)>
                           </div>
                         </Thumbnail>
@@ -463,53 +485,75 @@ exports[`<HostProfile /> if \`props.languages\` is defined should render the rig
                               hasRoundedCorners={false}
                               imageUrl="https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max"
                               isCircular={true}
-                              isLazyLoaded={false}
+                              isLazyLoaded={true}
                               isSquare={false}
                             >
-                              <ResponsiveImage
-                                alternativeText="Image Widget"
-                                hasRoundedCorners={false}
-                                imageHeight={null}
-                                imageNotFoundLabelText="Image not found!"
-                                imageTitle="Image Title"
-                                imageUrl="https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max"
-                                imageWidth={null}
-                                isAvatar={false}
-                                isCircular={true}
-                                isFluid={false}
-                                isLazyLoaded={false}
-                                isSquare={false}
-                                label={null}
-                                sizes={null}
-                                srcSet={null}
+                              <LazyLoader
+                                componentProps={
+                                  Object {
+                                    "alternativeText": undefined,
+                                    "hasRoundedCorners": false,
+                                    "isCircular": true,
+                                    "isLazyLoaded": true,
+                                    "isSquare": false,
+                                    "sizes": undefined,
+                                    "srcSet": undefined,
+                                  }
+                                }
+                                lazyComponent={[Function]}
+                                lazyProps={
+                                  Object {
+                                    "imageUrl": "https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max",
+                                  }
+                                }
                               >
-                                <figure
-                                  className="responsive-image is-circular"
+                                <div />
+                                <ResponsiveImage
+                                  alternativeText="Image Widget"
+                                  hasRoundedCorners={false}
+                                  imageHeight={null}
+                                  imageNotFoundLabelText="Image not found!"
+                                  imageTitle="Image Title"
+                                  imageUrl="https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max"
+                                  imageWidth={null}
+                                  isAvatar={false}
+                                  isCircular={true}
+                                  isFluid={false}
+                                  isLazyLoaded={true}
+                                  isSquare={false}
+                                  label={null}
+                                  sizes={null}
+                                  srcSet={null}
                                 >
-                                  <Image
-                                    alt="Image Widget"
-                                    as="img"
-                                    avatar={false}
-                                    fluid={true}
-                                    onLoad={[Function]}
-                                    sizes={null}
-                                    src="https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max"
-                                    srcSet={null}
-                                    title="Image Title"
-                                    ui={true}
+                                  <figure
+                                    className="responsive-image is-circular"
                                   >
-                                    <img
+                                    <Image
                                       alt="Image Widget"
-                                      className="ui fluid image"
+                                      as="img"
+                                      avatar={false}
+                                      fluid={true}
                                       onLoad={[Function]}
                                       sizes={null}
                                       src="https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max"
                                       srcSet={null}
                                       title="Image Title"
-                                    />
-                                  </Image>
-                                </figure>
-                              </ResponsiveImage>
+                                      ui={true}
+                                    >
+                                      <img
+                                        alt="Image Widget"
+                                        className="ui fluid image"
+                                        onLoad={[Function]}
+                                        sizes={null}
+                                        src="https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max"
+                                        srcSet={null}
+                                        title="Image Title"
+                                      />
+                                    </Image>
+                                  </figure>
+                                </ResponsiveImage>
+                                <div />
+                              </LazyLoader>
                             </withLazyLoad(ResponsiveImage)>
                           </div>
                         </Thumbnail>
@@ -787,53 +831,75 @@ exports[`<HostProfile /> if \`props.phone\` is defined should render the right s
                               hasRoundedCorners={false}
                               imageUrl="https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max"
                               isCircular={true}
-                              isLazyLoaded={false}
+                              isLazyLoaded={true}
                               isSquare={false}
                             >
-                              <ResponsiveImage
-                                alternativeText="Image Widget"
-                                hasRoundedCorners={false}
-                                imageHeight={null}
-                                imageNotFoundLabelText="Image not found!"
-                                imageTitle="Image Title"
-                                imageUrl="https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max"
-                                imageWidth={null}
-                                isAvatar={false}
-                                isCircular={true}
-                                isFluid={false}
-                                isLazyLoaded={false}
-                                isSquare={false}
-                                label={null}
-                                sizes={null}
-                                srcSet={null}
+                              <LazyLoader
+                                componentProps={
+                                  Object {
+                                    "alternativeText": undefined,
+                                    "hasRoundedCorners": false,
+                                    "isCircular": true,
+                                    "isLazyLoaded": true,
+                                    "isSquare": false,
+                                    "sizes": undefined,
+                                    "srcSet": undefined,
+                                  }
+                                }
+                                lazyComponent={[Function]}
+                                lazyProps={
+                                  Object {
+                                    "imageUrl": "https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max",
+                                  }
+                                }
                               >
-                                <figure
-                                  className="responsive-image is-circular"
+                                <div />
+                                <ResponsiveImage
+                                  alternativeText="Image Widget"
+                                  hasRoundedCorners={false}
+                                  imageHeight={null}
+                                  imageNotFoundLabelText="Image not found!"
+                                  imageTitle="Image Title"
+                                  imageUrl="https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max"
+                                  imageWidth={null}
+                                  isAvatar={false}
+                                  isCircular={true}
+                                  isFluid={false}
+                                  isLazyLoaded={true}
+                                  isSquare={false}
+                                  label={null}
+                                  sizes={null}
+                                  srcSet={null}
                                 >
-                                  <Image
-                                    alt="Image Widget"
-                                    as="img"
-                                    avatar={false}
-                                    fluid={true}
-                                    onLoad={[Function]}
-                                    sizes={null}
-                                    src="https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max"
-                                    srcSet={null}
-                                    title="Image Title"
-                                    ui={true}
+                                  <figure
+                                    className="responsive-image is-circular"
                                   >
-                                    <img
+                                    <Image
                                       alt="Image Widget"
-                                      className="ui fluid image"
+                                      as="img"
+                                      avatar={false}
+                                      fluid={true}
                                       onLoad={[Function]}
                                       sizes={null}
                                       src="https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max"
                                       srcSet={null}
                                       title="Image Title"
-                                    />
-                                  </Image>
-                                </figure>
-                              </ResponsiveImage>
+                                      ui={true}
+                                    >
+                                      <img
+                                        alt="Image Widget"
+                                        className="ui fluid image"
+                                        onLoad={[Function]}
+                                        sizes={null}
+                                        src="https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max"
+                                        srcSet={null}
+                                        title="Image Title"
+                                      />
+                                    </Image>
+                                  </figure>
+                                </ResponsiveImage>
+                                <div />
+                              </LazyLoader>
                             </withLazyLoad(ResponsiveImage)>
                           </div>
                         </Thumbnail>
@@ -1115,53 +1181,75 @@ exports[`<HostProfile /> should render the right structure 1`] = `
                               hasRoundedCorners={false}
                               imageUrl="https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max"
                               isCircular={true}
-                              isLazyLoaded={false}
+                              isLazyLoaded={true}
                               isSquare={false}
                             >
-                              <ResponsiveImage
-                                alternativeText="Image Widget"
-                                hasRoundedCorners={false}
-                                imageHeight={null}
-                                imageNotFoundLabelText="Image not found!"
-                                imageTitle="Image Title"
-                                imageUrl="https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max"
-                                imageWidth={null}
-                                isAvatar={false}
-                                isCircular={true}
-                                isFluid={false}
-                                isLazyLoaded={false}
-                                isSquare={false}
-                                label={null}
-                                sizes={null}
-                                srcSet={null}
+                              <LazyLoader
+                                componentProps={
+                                  Object {
+                                    "alternativeText": undefined,
+                                    "hasRoundedCorners": false,
+                                    "isCircular": true,
+                                    "isLazyLoaded": true,
+                                    "isSquare": false,
+                                    "sizes": undefined,
+                                    "srcSet": undefined,
+                                  }
+                                }
+                                lazyComponent={[Function]}
+                                lazyProps={
+                                  Object {
+                                    "imageUrl": "https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max",
+                                  }
+                                }
                               >
-                                <figure
-                                  className="responsive-image is-circular"
+                                <div />
+                                <ResponsiveImage
+                                  alternativeText="Image Widget"
+                                  hasRoundedCorners={false}
+                                  imageHeight={null}
+                                  imageNotFoundLabelText="Image not found!"
+                                  imageTitle="Image Title"
+                                  imageUrl="https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max"
+                                  imageWidth={null}
+                                  isAvatar={false}
+                                  isCircular={true}
+                                  isFluid={false}
+                                  isLazyLoaded={true}
+                                  isSquare={false}
+                                  label={null}
+                                  sizes={null}
+                                  srcSet={null}
                                 >
-                                  <Image
-                                    alt="Image Widget"
-                                    as="img"
-                                    avatar={false}
-                                    fluid={true}
-                                    onLoad={[Function]}
-                                    sizes={null}
-                                    src="https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max"
-                                    srcSet={null}
-                                    title="Image Title"
-                                    ui={true}
+                                  <figure
+                                    className="responsive-image is-circular"
                                   >
-                                    <img
+                                    <Image
                                       alt="Image Widget"
-                                      className="ui fluid image"
+                                      as="img"
+                                      avatar={false}
+                                      fluid={true}
                                       onLoad={[Function]}
                                       sizes={null}
                                       src="https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max"
                                       srcSet={null}
                                       title="Image Title"
-                                    />
-                                  </Image>
-                                </figure>
-                              </ResponsiveImage>
+                                      ui={true}
+                                    >
+                                      <img
+                                        alt="Image Widget"
+                                        className="ui fluid image"
+                                        onLoad={[Function]}
+                                        sizes={null}
+                                        src="https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max"
+                                        srcSet={null}
+                                        title="Image Title"
+                                      />
+                                    </Image>
+                                  </figure>
+                                </ResponsiveImage>
+                                <div />
+                              </LazyLoader>
                             </withLazyLoad(ResponsiveImage)>
                           </div>
                         </Thumbnail>

--- a/src/components/property-page-widgets/Pictures/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Pictures/__snapshots__/component.spec.js.snap
@@ -162,53 +162,75 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                               hasRoundedCorners={false}
                               imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
                               isCircular={false}
-                              isLazyLoaded={false}
+                              isLazyLoaded={true}
                               isSquare={false}
                             >
-                              <ResponsiveImage
-                                alternativeText="Image Widget"
-                                hasRoundedCorners={false}
-                                imageHeight={null}
-                                imageNotFoundLabelText="Image not found!"
-                                imageTitle="Image Title"
-                                imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
-                                imageWidth={null}
-                                isAvatar={false}
-                                isCircular={false}
-                                isFluid={false}
-                                isLazyLoaded={false}
-                                isSquare={false}
-                                label={null}
-                                sizes={null}
-                                srcSet={null}
+                              <LazyLoader
+                                componentProps={
+                                  Object {
+                                    "alternativeText": undefined,
+                                    "hasRoundedCorners": false,
+                                    "isCircular": false,
+                                    "isLazyLoaded": true,
+                                    "isSquare": false,
+                                    "sizes": undefined,
+                                    "srcSet": undefined,
+                                  }
+                                }
+                                lazyComponent={[Function]}
+                                lazyProps={
+                                  Object {
+                                    "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max",
+                                  }
+                                }
                               >
-                                <figure
-                                  className="responsive-image"
+                                <div />
+                                <ResponsiveImage
+                                  alternativeText="Image Widget"
+                                  hasRoundedCorners={false}
+                                  imageHeight={null}
+                                  imageNotFoundLabelText="Image not found!"
+                                  imageTitle="Image Title"
+                                  imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                  imageWidth={null}
+                                  isAvatar={false}
+                                  isCircular={false}
+                                  isFluid={false}
+                                  isLazyLoaded={true}
+                                  isSquare={false}
+                                  label={null}
+                                  sizes={null}
+                                  srcSet={null}
                                 >
-                                  <Image
-                                    alt="Image Widget"
-                                    as="img"
-                                    avatar={false}
-                                    fluid={true}
-                                    onLoad={[Function]}
-                                    sizes={null}
-                                    src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
-                                    srcSet={null}
-                                    title="Image Title"
-                                    ui={true}
+                                  <figure
+                                    className="responsive-image"
                                   >
-                                    <img
+                                    <Image
                                       alt="Image Widget"
-                                      className="ui fluid image"
+                                      as="img"
+                                      avatar={false}
+                                      fluid={true}
                                       onLoad={[Function]}
                                       sizes={null}
                                       src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
                                       srcSet={null}
                                       title="Image Title"
-                                    />
-                                  </Image>
-                                </figure>
-                              </ResponsiveImage>
+                                      ui={true}
+                                    >
+                                      <img
+                                        alt="Image Widget"
+                                        className="ui fluid image"
+                                        onLoad={[Function]}
+                                        sizes={null}
+                                        src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                        srcSet={null}
+                                        title="Image Title"
+                                      />
+                                    </Image>
+                                  </figure>
+                                </ResponsiveImage>
+                                <div />
+                              </LazyLoader>
                             </withLazyLoad(ResponsiveImage)>
                             <Paragraph
                               size="medium"
@@ -252,53 +274,75 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                               hasRoundedCorners={true}
                               imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
                               isCircular={false}
-                              isLazyLoaded={false}
+                              isLazyLoaded={true}
                               isSquare={true}
                             >
-                              <ResponsiveImage
-                                alternativeText="Image Widget"
-                                hasRoundedCorners={true}
-                                imageHeight={null}
-                                imageNotFoundLabelText="Image not found!"
-                                imageTitle="Image Title"
-                                imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
-                                imageWidth={null}
-                                isAvatar={false}
-                                isCircular={false}
-                                isFluid={false}
-                                isLazyLoaded={false}
-                                isSquare={true}
-                                label={null}
-                                sizes={null}
-                                srcSet={null}
+                              <LazyLoader
+                                componentProps={
+                                  Object {
+                                    "alternativeText": undefined,
+                                    "hasRoundedCorners": true,
+                                    "isCircular": false,
+                                    "isLazyLoaded": true,
+                                    "isSquare": true,
+                                    "sizes": undefined,
+                                    "srcSet": undefined,
+                                  }
+                                }
+                                lazyComponent={[Function]}
+                                lazyProps={
+                                  Object {
+                                    "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max",
+                                  }
+                                }
                               >
-                                <figure
-                                  className="responsive-image is-rounded"
+                                <div />
+                                <ResponsiveImage
+                                  alternativeText="Image Widget"
+                                  hasRoundedCorners={true}
+                                  imageHeight={null}
+                                  imageNotFoundLabelText="Image not found!"
+                                  imageTitle="Image Title"
+                                  imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                  imageWidth={null}
+                                  isAvatar={false}
+                                  isCircular={false}
+                                  isFluid={false}
+                                  isLazyLoaded={true}
+                                  isSquare={true}
+                                  label={null}
+                                  sizes={null}
+                                  srcSet={null}
                                 >
-                                  <Image
-                                    alt="Image Widget"
-                                    as="img"
-                                    avatar={false}
-                                    fluid={true}
-                                    onLoad={[Function]}
-                                    sizes={null}
-                                    src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
-                                    srcSet={null}
-                                    title="Image Title"
-                                    ui={true}
+                                  <figure
+                                    className="responsive-image is-rounded"
                                   >
-                                    <img
+                                    <Image
                                       alt="Image Widget"
-                                      className="ui fluid image"
+                                      as="img"
+                                      avatar={false}
+                                      fluid={true}
                                       onLoad={[Function]}
                                       sizes={null}
                                       src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
                                       srcSet={null}
                                       title="Image Title"
-                                    />
-                                  </Image>
-                                </figure>
-                              </ResponsiveImage>
+                                      ui={true}
+                                    >
+                                      <img
+                                        alt="Image Widget"
+                                        className="ui fluid image"
+                                        onLoad={[Function]}
+                                        sizes={null}
+                                        src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                        srcSet={null}
+                                        title="Image Title"
+                                      />
+                                    </Image>
+                                  </figure>
+                                </ResponsiveImage>
+                                <div />
+                              </LazyLoader>
                             </withLazyLoad(ResponsiveImage)>
                             <Paragraph
                               size="medium"
@@ -372,53 +416,75 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                               hasRoundedCorners={false}
                               imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
                               isCircular={false}
-                              isLazyLoaded={false}
+                              isLazyLoaded={true}
                               isSquare={false}
                             >
-                              <ResponsiveImage
-                                alternativeText="Image Widget"
-                                hasRoundedCorners={false}
-                                imageHeight={null}
-                                imageNotFoundLabelText="Image not found!"
-                                imageTitle="Image Title"
-                                imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
-                                imageWidth={null}
-                                isAvatar={false}
-                                isCircular={false}
-                                isFluid={false}
-                                isLazyLoaded={false}
-                                isSquare={false}
-                                label={null}
-                                sizes={null}
-                                srcSet={null}
+                              <LazyLoader
+                                componentProps={
+                                  Object {
+                                    "alternativeText": undefined,
+                                    "hasRoundedCorners": false,
+                                    "isCircular": false,
+                                    "isLazyLoaded": true,
+                                    "isSquare": false,
+                                    "sizes": undefined,
+                                    "srcSet": undefined,
+                                  }
+                                }
+                                lazyComponent={[Function]}
+                                lazyProps={
+                                  Object {
+                                    "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max",
+                                  }
+                                }
                               >
-                                <figure
-                                  className="responsive-image"
+                                <div />
+                                <ResponsiveImage
+                                  alternativeText="Image Widget"
+                                  hasRoundedCorners={false}
+                                  imageHeight={null}
+                                  imageNotFoundLabelText="Image not found!"
+                                  imageTitle="Image Title"
+                                  imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                  imageWidth={null}
+                                  isAvatar={false}
+                                  isCircular={false}
+                                  isFluid={false}
+                                  isLazyLoaded={true}
+                                  isSquare={false}
+                                  label={null}
+                                  sizes={null}
+                                  srcSet={null}
                                 >
-                                  <Image
-                                    alt="Image Widget"
-                                    as="img"
-                                    avatar={false}
-                                    fluid={true}
-                                    onLoad={[Function]}
-                                    sizes={null}
-                                    src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
-                                    srcSet={null}
-                                    title="Image Title"
-                                    ui={true}
+                                  <figure
+                                    className="responsive-image"
                                   >
-                                    <img
+                                    <Image
                                       alt="Image Widget"
-                                      className="ui fluid image"
+                                      as="img"
+                                      avatar={false}
+                                      fluid={true}
                                       onLoad={[Function]}
                                       sizes={null}
                                       src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
                                       srcSet={null}
                                       title="Image Title"
-                                    />
-                                  </Image>
-                                </figure>
-                              </ResponsiveImage>
+                                      ui={true}
+                                    >
+                                      <img
+                                        alt="Image Widget"
+                                        className="ui fluid image"
+                                        onLoad={[Function]}
+                                        sizes={null}
+                                        src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                        srcSet={null}
+                                        title="Image Title"
+                                      />
+                                    </Image>
+                                  </figure>
+                                </ResponsiveImage>
+                                <div />
+                              </LazyLoader>
                             </withLazyLoad(ResponsiveImage)>
                             <Paragraph
                               size="medium"
@@ -462,53 +528,75 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                               hasRoundedCorners={true}
                               imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
                               isCircular={false}
-                              isLazyLoaded={false}
+                              isLazyLoaded={true}
                               isSquare={true}
                             >
-                              <ResponsiveImage
-                                alternativeText="Image Widget"
-                                hasRoundedCorners={true}
-                                imageHeight={null}
-                                imageNotFoundLabelText="Image not found!"
-                                imageTitle="Image Title"
-                                imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
-                                imageWidth={null}
-                                isAvatar={false}
-                                isCircular={false}
-                                isFluid={false}
-                                isLazyLoaded={false}
-                                isSquare={true}
-                                label={null}
-                                sizes={null}
-                                srcSet={null}
+                              <LazyLoader
+                                componentProps={
+                                  Object {
+                                    "alternativeText": undefined,
+                                    "hasRoundedCorners": true,
+                                    "isCircular": false,
+                                    "isLazyLoaded": true,
+                                    "isSquare": true,
+                                    "sizes": undefined,
+                                    "srcSet": undefined,
+                                  }
+                                }
+                                lazyComponent={[Function]}
+                                lazyProps={
+                                  Object {
+                                    "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max",
+                                  }
+                                }
                               >
-                                <figure
-                                  className="responsive-image is-rounded"
+                                <div />
+                                <ResponsiveImage
+                                  alternativeText="Image Widget"
+                                  hasRoundedCorners={true}
+                                  imageHeight={null}
+                                  imageNotFoundLabelText="Image not found!"
+                                  imageTitle="Image Title"
+                                  imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                  imageWidth={null}
+                                  isAvatar={false}
+                                  isCircular={false}
+                                  isFluid={false}
+                                  isLazyLoaded={true}
+                                  isSquare={true}
+                                  label={null}
+                                  sizes={null}
+                                  srcSet={null}
                                 >
-                                  <Image
-                                    alt="Image Widget"
-                                    as="img"
-                                    avatar={false}
-                                    fluid={true}
-                                    onLoad={[Function]}
-                                    sizes={null}
-                                    src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
-                                    srcSet={null}
-                                    title="Image Title"
-                                    ui={true}
+                                  <figure
+                                    className="responsive-image is-rounded"
                                   >
-                                    <img
+                                    <Image
                                       alt="Image Widget"
-                                      className="ui fluid image"
+                                      as="img"
+                                      avatar={false}
+                                      fluid={true}
                                       onLoad={[Function]}
                                       sizes={null}
                                       src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
                                       srcSet={null}
                                       title="Image Title"
-                                    />
-                                  </Image>
-                                </figure>
-                              </ResponsiveImage>
+                                      ui={true}
+                                    >
+                                      <img
+                                        alt="Image Widget"
+                                        className="ui fluid image"
+                                        onLoad={[Function]}
+                                        sizes={null}
+                                        src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                        srcSet={null}
+                                        title="Image Title"
+                                      />
+                                    </Image>
+                                  </figure>
+                                </ResponsiveImage>
+                                <div />
+                              </LazyLoader>
                             </withLazyLoad(ResponsiveImage)>
                             <Paragraph
                               size="medium"
@@ -582,53 +670,75 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                               hasRoundedCorners={false}
                               imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
                               isCircular={false}
-                              isLazyLoaded={false}
+                              isLazyLoaded={true}
                               isSquare={false}
                             >
-                              <ResponsiveImage
-                                alternativeText="Image Widget"
-                                hasRoundedCorners={false}
-                                imageHeight={null}
-                                imageNotFoundLabelText="Image not found!"
-                                imageTitle="Image Title"
-                                imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
-                                imageWidth={null}
-                                isAvatar={false}
-                                isCircular={false}
-                                isFluid={false}
-                                isLazyLoaded={false}
-                                isSquare={false}
-                                label={null}
-                                sizes={null}
-                                srcSet={null}
+                              <LazyLoader
+                                componentProps={
+                                  Object {
+                                    "alternativeText": undefined,
+                                    "hasRoundedCorners": false,
+                                    "isCircular": false,
+                                    "isLazyLoaded": true,
+                                    "isSquare": false,
+                                    "sizes": undefined,
+                                    "srcSet": undefined,
+                                  }
+                                }
+                                lazyComponent={[Function]}
+                                lazyProps={
+                                  Object {
+                                    "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max",
+                                  }
+                                }
                               >
-                                <figure
-                                  className="responsive-image"
+                                <div />
+                                <ResponsiveImage
+                                  alternativeText="Image Widget"
+                                  hasRoundedCorners={false}
+                                  imageHeight={null}
+                                  imageNotFoundLabelText="Image not found!"
+                                  imageTitle="Image Title"
+                                  imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                  imageWidth={null}
+                                  isAvatar={false}
+                                  isCircular={false}
+                                  isFluid={false}
+                                  isLazyLoaded={true}
+                                  isSquare={false}
+                                  label={null}
+                                  sizes={null}
+                                  srcSet={null}
                                 >
-                                  <Image
-                                    alt="Image Widget"
-                                    as="img"
-                                    avatar={false}
-                                    fluid={true}
-                                    onLoad={[Function]}
-                                    sizes={null}
-                                    src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
-                                    srcSet={null}
-                                    title="Image Title"
-                                    ui={true}
+                                  <figure
+                                    className="responsive-image"
                                   >
-                                    <img
+                                    <Image
                                       alt="Image Widget"
-                                      className="ui fluid image"
+                                      as="img"
+                                      avatar={false}
+                                      fluid={true}
                                       onLoad={[Function]}
                                       sizes={null}
                                       src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
                                       srcSet={null}
                                       title="Image Title"
-                                    />
-                                  </Image>
-                                </figure>
-                              </ResponsiveImage>
+                                      ui={true}
+                                    >
+                                      <img
+                                        alt="Image Widget"
+                                        className="ui fluid image"
+                                        onLoad={[Function]}
+                                        sizes={null}
+                                        src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                        srcSet={null}
+                                        title="Image Title"
+                                      />
+                                    </Image>
+                                  </figure>
+                                </ResponsiveImage>
+                                <div />
+                              </LazyLoader>
                             </withLazyLoad(ResponsiveImage)>
                             <Paragraph
                               size="medium"
@@ -672,53 +782,75 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                               hasRoundedCorners={true}
                               imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
                               isCircular={false}
-                              isLazyLoaded={false}
+                              isLazyLoaded={true}
                               isSquare={true}
                             >
-                              <ResponsiveImage
-                                alternativeText="Image Widget"
-                                hasRoundedCorners={true}
-                                imageHeight={null}
-                                imageNotFoundLabelText="Image not found!"
-                                imageTitle="Image Title"
-                                imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
-                                imageWidth={null}
-                                isAvatar={false}
-                                isCircular={false}
-                                isFluid={false}
-                                isLazyLoaded={false}
-                                isSquare={true}
-                                label={null}
-                                sizes={null}
-                                srcSet={null}
+                              <LazyLoader
+                                componentProps={
+                                  Object {
+                                    "alternativeText": undefined,
+                                    "hasRoundedCorners": true,
+                                    "isCircular": false,
+                                    "isLazyLoaded": true,
+                                    "isSquare": true,
+                                    "sizes": undefined,
+                                    "srcSet": undefined,
+                                  }
+                                }
+                                lazyComponent={[Function]}
+                                lazyProps={
+                                  Object {
+                                    "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max",
+                                  }
+                                }
                               >
-                                <figure
-                                  className="responsive-image is-rounded"
+                                <div />
+                                <ResponsiveImage
+                                  alternativeText="Image Widget"
+                                  hasRoundedCorners={true}
+                                  imageHeight={null}
+                                  imageNotFoundLabelText="Image not found!"
+                                  imageTitle="Image Title"
+                                  imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                  imageWidth={null}
+                                  isAvatar={false}
+                                  isCircular={false}
+                                  isFluid={false}
+                                  isLazyLoaded={true}
+                                  isSquare={true}
+                                  label={null}
+                                  sizes={null}
+                                  srcSet={null}
                                 >
-                                  <Image
-                                    alt="Image Widget"
-                                    as="img"
-                                    avatar={false}
-                                    fluid={true}
-                                    onLoad={[Function]}
-                                    sizes={null}
-                                    src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
-                                    srcSet={null}
-                                    title="Image Title"
-                                    ui={true}
+                                  <figure
+                                    className="responsive-image is-rounded"
                                   >
-                                    <img
+                                    <Image
                                       alt="Image Widget"
-                                      className="ui fluid image"
+                                      as="img"
+                                      avatar={false}
+                                      fluid={true}
                                       onLoad={[Function]}
                                       sizes={null}
                                       src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
                                       srcSet={null}
                                       title="Image Title"
-                                    />
-                                  </Image>
-                                </figure>
-                              </ResponsiveImage>
+                                      ui={true}
+                                    >
+                                      <img
+                                        alt="Image Widget"
+                                        className="ui fluid image"
+                                        onLoad={[Function]}
+                                        sizes={null}
+                                        src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                        srcSet={null}
+                                        title="Image Title"
+                                      />
+                                    </Image>
+                                  </figure>
+                                </ResponsiveImage>
+                                <div />
+                              </LazyLoader>
                             </withLazyLoad(ResponsiveImage)>
                             <Paragraph
                               size="medium"
@@ -792,53 +924,75 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                               hasRoundedCorners={false}
                               imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
                               isCircular={false}
-                              isLazyLoaded={false}
+                              isLazyLoaded={true}
                               isSquare={false}
                             >
-                              <ResponsiveImage
-                                alternativeText="Image Widget"
-                                hasRoundedCorners={false}
-                                imageHeight={null}
-                                imageNotFoundLabelText="Image not found!"
-                                imageTitle="Image Title"
-                                imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
-                                imageWidth={null}
-                                isAvatar={false}
-                                isCircular={false}
-                                isFluid={false}
-                                isLazyLoaded={false}
-                                isSquare={false}
-                                label={null}
-                                sizes={null}
-                                srcSet={null}
+                              <LazyLoader
+                                componentProps={
+                                  Object {
+                                    "alternativeText": undefined,
+                                    "hasRoundedCorners": false,
+                                    "isCircular": false,
+                                    "isLazyLoaded": true,
+                                    "isSquare": false,
+                                    "sizes": undefined,
+                                    "srcSet": undefined,
+                                  }
+                                }
+                                lazyComponent={[Function]}
+                                lazyProps={
+                                  Object {
+                                    "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max",
+                                  }
+                                }
                               >
-                                <figure
-                                  className="responsive-image"
+                                <div />
+                                <ResponsiveImage
+                                  alternativeText="Image Widget"
+                                  hasRoundedCorners={false}
+                                  imageHeight={null}
+                                  imageNotFoundLabelText="Image not found!"
+                                  imageTitle="Image Title"
+                                  imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                  imageWidth={null}
+                                  isAvatar={false}
+                                  isCircular={false}
+                                  isFluid={false}
+                                  isLazyLoaded={true}
+                                  isSquare={false}
+                                  label={null}
+                                  sizes={null}
+                                  srcSet={null}
                                 >
-                                  <Image
-                                    alt="Image Widget"
-                                    as="img"
-                                    avatar={false}
-                                    fluid={true}
-                                    onLoad={[Function]}
-                                    sizes={null}
-                                    src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
-                                    srcSet={null}
-                                    title="Image Title"
-                                    ui={true}
+                                  <figure
+                                    className="responsive-image"
                                   >
-                                    <img
+                                    <Image
                                       alt="Image Widget"
-                                      className="ui fluid image"
+                                      as="img"
+                                      avatar={false}
+                                      fluid={true}
                                       onLoad={[Function]}
                                       sizes={null}
                                       src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
                                       srcSet={null}
                                       title="Image Title"
-                                    />
-                                  </Image>
-                                </figure>
-                              </ResponsiveImage>
+                                      ui={true}
+                                    >
+                                      <img
+                                        alt="Image Widget"
+                                        className="ui fluid image"
+                                        onLoad={[Function]}
+                                        sizes={null}
+                                        src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                        srcSet={null}
+                                        title="Image Title"
+                                      />
+                                    </Image>
+                                  </figure>
+                                </ResponsiveImage>
+                                <div />
+                              </LazyLoader>
                             </withLazyLoad(ResponsiveImage)>
                             <Paragraph
                               size="medium"
@@ -882,53 +1036,75 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                               hasRoundedCorners={true}
                               imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
                               isCircular={false}
-                              isLazyLoaded={false}
+                              isLazyLoaded={true}
                               isSquare={true}
                             >
-                              <ResponsiveImage
-                                alternativeText="Image Widget"
-                                hasRoundedCorners={true}
-                                imageHeight={null}
-                                imageNotFoundLabelText="Image not found!"
-                                imageTitle="Image Title"
-                                imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
-                                imageWidth={null}
-                                isAvatar={false}
-                                isCircular={false}
-                                isFluid={false}
-                                isLazyLoaded={false}
-                                isSquare={true}
-                                label={null}
-                                sizes={null}
-                                srcSet={null}
+                              <LazyLoader
+                                componentProps={
+                                  Object {
+                                    "alternativeText": undefined,
+                                    "hasRoundedCorners": true,
+                                    "isCircular": false,
+                                    "isLazyLoaded": true,
+                                    "isSquare": true,
+                                    "sizes": undefined,
+                                    "srcSet": undefined,
+                                  }
+                                }
+                                lazyComponent={[Function]}
+                                lazyProps={
+                                  Object {
+                                    "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max",
+                                  }
+                                }
                               >
-                                <figure
-                                  className="responsive-image is-rounded"
+                                <div />
+                                <ResponsiveImage
+                                  alternativeText="Image Widget"
+                                  hasRoundedCorners={true}
+                                  imageHeight={null}
+                                  imageNotFoundLabelText="Image not found!"
+                                  imageTitle="Image Title"
+                                  imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                  imageWidth={null}
+                                  isAvatar={false}
+                                  isCircular={false}
+                                  isFluid={false}
+                                  isLazyLoaded={true}
+                                  isSquare={true}
+                                  label={null}
+                                  sizes={null}
+                                  srcSet={null}
                                 >
-                                  <Image
-                                    alt="Image Widget"
-                                    as="img"
-                                    avatar={false}
-                                    fluid={true}
-                                    onLoad={[Function]}
-                                    sizes={null}
-                                    src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
-                                    srcSet={null}
-                                    title="Image Title"
-                                    ui={true}
+                                  <figure
+                                    className="responsive-image is-rounded"
                                   >
-                                    <img
+                                    <Image
                                       alt="Image Widget"
-                                      className="ui fluid image"
+                                      as="img"
+                                      avatar={false}
+                                      fluid={true}
                                       onLoad={[Function]}
                                       sizes={null}
                                       src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
                                       srcSet={null}
                                       title="Image Title"
-                                    />
-                                  </Image>
-                                </figure>
-                              </ResponsiveImage>
+                                      ui={true}
+                                    >
+                                      <img
+                                        alt="Image Widget"
+                                        className="ui fluid image"
+                                        onLoad={[Function]}
+                                        sizes={null}
+                                        src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                        srcSet={null}
+                                        title="Image Title"
+                                      />
+                                    </Image>
+                                  </figure>
+                                </ResponsiveImage>
+                                <div />
+                              </LazyLoader>
                             </withLazyLoad(ResponsiveImage)>
                             <Paragraph
                               size="medium"
@@ -1002,53 +1178,75 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                               hasRoundedCorners={false}
                               imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
                               isCircular={false}
-                              isLazyLoaded={false}
+                              isLazyLoaded={true}
                               isSquare={false}
                             >
-                              <ResponsiveImage
-                                alternativeText="Image Widget"
-                                hasRoundedCorners={false}
-                                imageHeight={null}
-                                imageNotFoundLabelText="Image not found!"
-                                imageTitle="Image Title"
-                                imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
-                                imageWidth={null}
-                                isAvatar={false}
-                                isCircular={false}
-                                isFluid={false}
-                                isLazyLoaded={false}
-                                isSquare={false}
-                                label={null}
-                                sizes={null}
-                                srcSet={null}
+                              <LazyLoader
+                                componentProps={
+                                  Object {
+                                    "alternativeText": undefined,
+                                    "hasRoundedCorners": false,
+                                    "isCircular": false,
+                                    "isLazyLoaded": true,
+                                    "isSquare": false,
+                                    "sizes": undefined,
+                                    "srcSet": undefined,
+                                  }
+                                }
+                                lazyComponent={[Function]}
+                                lazyProps={
+                                  Object {
+                                    "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max",
+                                  }
+                                }
                               >
-                                <figure
-                                  className="responsive-image"
+                                <div />
+                                <ResponsiveImage
+                                  alternativeText="Image Widget"
+                                  hasRoundedCorners={false}
+                                  imageHeight={null}
+                                  imageNotFoundLabelText="Image not found!"
+                                  imageTitle="Image Title"
+                                  imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                  imageWidth={null}
+                                  isAvatar={false}
+                                  isCircular={false}
+                                  isFluid={false}
+                                  isLazyLoaded={true}
+                                  isSquare={false}
+                                  label={null}
+                                  sizes={null}
+                                  srcSet={null}
                                 >
-                                  <Image
-                                    alt="Image Widget"
-                                    as="img"
-                                    avatar={false}
-                                    fluid={true}
-                                    onLoad={[Function]}
-                                    sizes={null}
-                                    src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
-                                    srcSet={null}
-                                    title="Image Title"
-                                    ui={true}
+                                  <figure
+                                    className="responsive-image"
                                   >
-                                    <img
+                                    <Image
                                       alt="Image Widget"
-                                      className="ui fluid image"
+                                      as="img"
+                                      avatar={false}
+                                      fluid={true}
                                       onLoad={[Function]}
                                       sizes={null}
                                       src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
                                       srcSet={null}
                                       title="Image Title"
-                                    />
-                                  </Image>
-                                </figure>
-                              </ResponsiveImage>
+                                      ui={true}
+                                    >
+                                      <img
+                                        alt="Image Widget"
+                                        className="ui fluid image"
+                                        onLoad={[Function]}
+                                        sizes={null}
+                                        src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                        srcSet={null}
+                                        title="Image Title"
+                                      />
+                                    </Image>
+                                  </figure>
+                                </ResponsiveImage>
+                                <div />
+                              </LazyLoader>
                             </withLazyLoad(ResponsiveImage)>
                             <Paragraph
                               size="medium"
@@ -1092,53 +1290,75 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                               hasRoundedCorners={true}
                               imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
                               isCircular={false}
-                              isLazyLoaded={false}
+                              isLazyLoaded={true}
                               isSquare={true}
                             >
-                              <ResponsiveImage
-                                alternativeText="Image Widget"
-                                hasRoundedCorners={true}
-                                imageHeight={null}
-                                imageNotFoundLabelText="Image not found!"
-                                imageTitle="Image Title"
-                                imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
-                                imageWidth={null}
-                                isAvatar={false}
-                                isCircular={false}
-                                isFluid={false}
-                                isLazyLoaded={false}
-                                isSquare={true}
-                                label={null}
-                                sizes={null}
-                                srcSet={null}
+                              <LazyLoader
+                                componentProps={
+                                  Object {
+                                    "alternativeText": undefined,
+                                    "hasRoundedCorners": true,
+                                    "isCircular": false,
+                                    "isLazyLoaded": true,
+                                    "isSquare": true,
+                                    "sizes": undefined,
+                                    "srcSet": undefined,
+                                  }
+                                }
+                                lazyComponent={[Function]}
+                                lazyProps={
+                                  Object {
+                                    "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max",
+                                  }
+                                }
                               >
-                                <figure
-                                  className="responsive-image is-rounded"
+                                <div />
+                                <ResponsiveImage
+                                  alternativeText="Image Widget"
+                                  hasRoundedCorners={true}
+                                  imageHeight={null}
+                                  imageNotFoundLabelText="Image not found!"
+                                  imageTitle="Image Title"
+                                  imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                  imageWidth={null}
+                                  isAvatar={false}
+                                  isCircular={false}
+                                  isFluid={false}
+                                  isLazyLoaded={true}
+                                  isSquare={true}
+                                  label={null}
+                                  sizes={null}
+                                  srcSet={null}
                                 >
-                                  <Image
-                                    alt="Image Widget"
-                                    as="img"
-                                    avatar={false}
-                                    fluid={true}
-                                    onLoad={[Function]}
-                                    sizes={null}
-                                    src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
-                                    srcSet={null}
-                                    title="Image Title"
-                                    ui={true}
+                                  <figure
+                                    className="responsive-image is-rounded"
                                   >
-                                    <img
+                                    <Image
                                       alt="Image Widget"
-                                      className="ui fluid image"
+                                      as="img"
+                                      avatar={false}
+                                      fluid={true}
                                       onLoad={[Function]}
                                       sizes={null}
                                       src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
                                       srcSet={null}
                                       title="Image Title"
-                                    />
-                                  </Image>
-                                </figure>
-                              </ResponsiveImage>
+                                      ui={true}
+                                    >
+                                      <img
+                                        alt="Image Widget"
+                                        className="ui fluid image"
+                                        onLoad={[Function]}
+                                        sizes={null}
+                                        src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                        srcSet={null}
+                                        title="Image Title"
+                                      />
+                                    </Image>
+                                  </figure>
+                                </ResponsiveImage>
+                                <div />
+                              </LazyLoader>
                             </withLazyLoad(ResponsiveImage)>
                             <Paragraph
                               size="medium"

--- a/src/components/property-page-widgets/PropertyPageHero/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/PropertyPageHero/__snapshots__/component.spec.js.snap
@@ -89,55 +89,77 @@ exports[`PropertyPageHero if there are fewer than two items in \`galleryImages\`
           <withLazyLoad(ResponsiveImage)
             imageUrl="some url"
             isFluid={true}
-            isLazyLoaded={false}
+            isLazyLoaded={true}
             placeholderImageUrl={null}
             sizes={null}
             srcSet={null}
           >
-            <ResponsiveImage
-              alternativeText="Image Widget"
-              hasRoundedCorners={false}
-              imageHeight={null}
-              imageNotFoundLabelText="Image not found!"
-              imageTitle="Image Title"
-              imageUrl="some url"
-              imageWidth={null}
-              isAvatar={false}
-              isCircular={false}
-              isFluid={true}
-              isLazyLoaded={false}
-              label={null}
-              placeholderImageUrl={null}
-              sizes={null}
-              srcSet={null}
+            <LazyLoader
+              componentProps={
+                Object {
+                  "imageHeight": undefined,
+                  "imageWidth": undefined,
+                  "isFluid": true,
+                  "isLazyLoaded": true,
+                  "placeholderImageUrl": null,
+                  "sizes": null,
+                  "srcSet": null,
+                }
+              }
+              lazyComponent={[Function]}
+              lazyProps={
+                Object {
+                  "imageUrl": "some url",
+                }
+              }
             >
-              <figure
-                className="responsive-image is-fluid"
+              <div />
+              <ResponsiveImage
+                alternativeText="Image Widget"
+                hasRoundedCorners={false}
+                imageHeight={null}
+                imageNotFoundLabelText="Image not found!"
+                imageTitle="Image Title"
+                imageUrl="some url"
+                imageWidth={null}
+                isAvatar={false}
+                isCircular={false}
+                isFluid={true}
+                isLazyLoaded={true}
+                label={null}
+                placeholderImageUrl={null}
+                sizes={null}
+                srcSet={null}
               >
-                <Image
-                  alt="Image Widget"
-                  as="img"
-                  avatar={false}
-                  fluid={true}
-                  onLoad={[Function]}
-                  sizes={null}
-                  src="some url"
-                  srcSet={null}
-                  title="Image Title"
-                  ui={true}
+                <figure
+                  className="responsive-image is-fluid"
                 >
-                  <img
+                  <Image
                     alt="Image Widget"
-                    className="ui fluid image"
+                    as="img"
+                    avatar={false}
+                    fluid={true}
                     onLoad={[Function]}
                     sizes={null}
                     src="some url"
                     srcSet={null}
                     title="Image Title"
-                  />
-                </Image>
-              </figure>
-            </ResponsiveImage>
+                    ui={true}
+                  >
+                    <img
+                      alt="Image Widget"
+                      className="ui fluid image"
+                      onLoad={[Function]}
+                      sizes={null}
+                      src="some url"
+                      srcSet={null}
+                      title="Image Title"
+                    />
+                  </Image>
+                </figure>
+              </ResponsiveImage>
+              <div />
+            </LazyLoader>
           </withLazyLoad(ResponsiveImage)>
           <Header
             activeNavigationItemIndex={1}
@@ -411,55 +433,77 @@ exports[`PropertyPageHero should render the right structure 1`] = `
           <withLazyLoad(ResponsiveImage)
             imageUrl="some url"
             isFluid={true}
-            isLazyLoaded={false}
+            isLazyLoaded={true}
             placeholderImageUrl={null}
             sizes={null}
             srcSet={null}
           >
-            <ResponsiveImage
-              alternativeText="Image Widget"
-              hasRoundedCorners={false}
-              imageHeight={null}
-              imageNotFoundLabelText="Image not found!"
-              imageTitle="Image Title"
-              imageUrl="some url"
-              imageWidth={null}
-              isAvatar={false}
-              isCircular={false}
-              isFluid={true}
-              isLazyLoaded={false}
-              label={null}
-              placeholderImageUrl={null}
-              sizes={null}
-              srcSet={null}
+            <LazyLoader
+              componentProps={
+                Object {
+                  "imageHeight": undefined,
+                  "imageWidth": undefined,
+                  "isFluid": true,
+                  "isLazyLoaded": true,
+                  "placeholderImageUrl": null,
+                  "sizes": null,
+                  "srcSet": null,
+                }
+              }
+              lazyComponent={[Function]}
+              lazyProps={
+                Object {
+                  "imageUrl": "some url",
+                }
+              }
             >
-              <figure
-                className="responsive-image is-fluid"
+              <div />
+              <ResponsiveImage
+                alternativeText="Image Widget"
+                hasRoundedCorners={false}
+                imageHeight={null}
+                imageNotFoundLabelText="Image not found!"
+                imageTitle="Image Title"
+                imageUrl="some url"
+                imageWidth={null}
+                isAvatar={false}
+                isCircular={false}
+                isFluid={true}
+                isLazyLoaded={true}
+                label={null}
+                placeholderImageUrl={null}
+                sizes={null}
+                srcSet={null}
               >
-                <Image
-                  alt="Image Widget"
-                  as="img"
-                  avatar={false}
-                  fluid={true}
-                  onLoad={[Function]}
-                  sizes={null}
-                  src="some url"
-                  srcSet={null}
-                  title="Image Title"
-                  ui={true}
+                <figure
+                  className="responsive-image is-fluid"
                 >
-                  <img
+                  <Image
                     alt="Image Widget"
-                    className="ui fluid image"
+                    as="img"
+                    avatar={false}
+                    fluid={true}
                     onLoad={[Function]}
                     sizes={null}
                     src="some url"
                     srcSet={null}
                     title="Image Title"
-                  />
-                </Image>
-              </figure>
-            </ResponsiveImage>
+                    ui={true}
+                  >
+                    <img
+                      alt="Image Widget"
+                      className="ui fluid image"
+                      onLoad={[Function]}
+                      sizes={null}
+                      src="some url"
+                      srcSet={null}
+                      title="Image Title"
+                    />
+                  </Image>
+                </figure>
+              </ResponsiveImage>
+              <div />
+            </LazyLoader>
           </withLazyLoad(ResponsiveImage)>
           <Header
             activeNavigationItemIndex={1}

--- a/src/utils/with-lazy-load/__snapshots__/withLazyLoad.spec.js.snap
+++ b/src/utils/with-lazy-load/__snapshots__/withLazyLoad.spec.js.snap
@@ -1,17 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`withLazyLoad WrapperComponent should pass the right props to \`Component\` 1`] = `
-<withLazyLoad(🚜)
-  isLazyLoaded={false}
-  lazyProp="😴"
-  other="otherProps"
->
-  <🚜
-    isLazyLoaded={false}
-    lazyProp="😴"
-    other="otherProps"
-  >
-    <div />
-  </🚜>
-</withLazyLoad(🚜)>
+<LazyLoader
+  componentProps={
+    Object {
+      "isLazyLoaded": true,
+      "other": "otherProps",
+    }
+  }
+  lazyComponent={[Function]}
+  lazyProps={
+    Object {
+      "lazyProp": "😴",
+    }
+  }
+/>
 `;

--- a/src/utils/with-lazy-load/withLazyLoad.js
+++ b/src/utils/with-lazy-load/withLazyLoad.js
@@ -15,7 +15,7 @@ export const withLazyLoad = (...lazyPropsKeys) => WrappedComponent =>
     static displayName = `withLazyLoad(${WrappedComponent.displayName})`;
 
     static defaultProps = {
-      isLazyLoaded: false,
+      isLazyLoaded: true,
     };
 
     static propTypes = {

--- a/src/utils/with-lazy-load/withLazyLoad.spec.js
+++ b/src/utils/with-lazy-load/withLazyLoad.spec.js
@@ -1,7 +1,7 @@
 jest.mock('../../components/layout/LazyLoader');
 
 import React from 'react';
-import { mount } from 'enzyme';
+import { shallow } from 'enzyme';
 import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
 
 import { LazyLoader } from 'layout/LazyLoader';
@@ -15,7 +15,7 @@ Component.displayName = DISPLAY_NAME;
 
 const props = { lazyProp: '😴', other: 'otherProps' };
 const getHOC = () =>
-  mount(React.createElement(withLazyLoad('lazyProp')(Component), props));
+  shallow(React.createElement(withLazyLoad('lazyProp')(Component), props));
 
 LazyLoader.mockImplementation(() => <div />);
 


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-2253)

### What **one** thing does this PR do?

Makes all `ResponsiveImage` components to have lazyload by default. 

## Lazy Load on fast 3G throttling. 

### Featured Property
![featured_properties](https://user-images.githubusercontent.com/33876435/58699901-f4ffff80-839e-11e9-8c9e-3f246dc5567f.gif)

### Featured RoomType
![featured_roomtype](https://user-images.githubusercontent.com/33876435/58700554-a7849200-83a0-11e9-89e4-b3ae0c6fc9ff.gif)

### Hero
![hero](https://user-images.githubusercontent.com/33876435/58699918-034e1b80-839f-11e9-980a-316ef0e78401.gif)

### Host Profile
![host_profile](https://user-images.githubusercontent.com/33876435/58699928-0c3eed00-839f-11e9-8be9-2444ea53ba60.gif)

### Pictures
![pictures](https://user-images.githubusercontent.com/33876435/58699943-195bdc00-839f-11e9-8748-8f41cd418bc6.gif)

### Responsive Image
![responsive_image](https://user-images.githubusercontent.com/33876435/58699969-2082ea00-839f-11e9-8fc4-33abd8fe52a1.gif)

### Promotion 
![promotion](https://user-images.githubusercontent.com/33876435/58700384-25946900-83a0-11e9-8945-89ee54c9896c.gif)

### Thumbnail
![thumbnail](https://user-images.githubusercontent.com/33876435/59090285-aa393700-890c-11e9-8662-7190eb777bdf.gif)

### Homepage Hero
![homepage_hero](https://user-images.githubusercontent.com/33876435/58700638-ea466a00-83a0-11e9-9012-954f39cd1b14.gif)

### PropertyPageHero
![propertypage_](https://user-images.githubusercontent.com/33876435/58700801-6771df00-83a1-11e9-89e8-13e8c919894a.gif)


