### PR TITLE
TE-2199 TE-2204 TE-2206 ES6 modules FTW

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,37 +1,3 @@
 {
-  "env": {
-    "production": {
-      "comments": false,
-      "ignore": ["**/*.spec.js"],
-      "plugins": [
-        ["semantic-ui-react-transform-imports", {
-          "importType": "commonjs"
-        }]
-      ]
-    }
-  },
-  "presets": [ "@babel/react", "@babel/env" ],
-  "plugins": [
-    "@babel/plugin-proposal-object-rest-spread",
-    "@babel/plugin-proposal-class-properties",
-    "lodash",
-    ["module-resolver", {
-      "root": ["./src"],
-      "alias": {
-        "collections": "./src/components/collections",
-        "elements": "./src/components/elements",
-        "general-widgets": "./src/components/general-widgets",
-        "inputs": "./src/components/inputs",
-        "layout": "./src/components/layout",
-        "media": "./src/components/media",
-        "property-page-widgets": "./src/components/property-page-widgets",
-        "typography": "./src/components/typography",
-        "utils": "./src/utils"
-      }
-    }],
-    ["transform-react-remove-prop-types", {
-        "mode": "wrap"
-      }
-    ]
-  ]
+  "presets": ["./tools/babel/preset.js"]
 }

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   },
   "size-limit": [
     {
-      "limit": "276 KB",
-      "path": "lib/index.js"
+      "limit": "245 KB",
+      "path": "lib/es/index.js"
     }
   ],
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "@lodgify/ui",
   "version": "1.194.0",
   "description": "React components for building amazing websites with Lodgify",
-  "main": "lib/index.js",
+  "main": "lib/commonjs/index.js",
+  "module": "lib/es/index.js",
   "config": {
     "jest_config": "tools/jest/jest.config.js",
     "less_build_config": "tools/webpack/less.build.config.js",
@@ -25,9 +26,11 @@
     }
   ],
   "scripts": {
-    "build": "npm-run-all -p build:less build:js -s rm:build-orphan",
+    "build": "npm-run-all -s clean -p build:less build:commonjs build:es -s rm:build-orphan",
+    "build:commonjs": "BABEL_ENV=commonjs babel src/ -d lib/commonjs --ignore '**/*.spec.js'",
+    "build:es": "BABEL_ENV=es babel src/ -d lib/es --ignore '**/*.spec.js'",
     "build:less": "webpack --config $npm_package_config_less_build_config",
-    "build:js": "BABEL_ENV=production babel src/ -d lib/",
+    "clean": "rm -rf lib",
     "commit": "git-cz",
     "install:peers": "npm install react@^16.3.2 react-dom@^16.3.2 moment@^2.18.1 --no-save",
     "lint": "run-p lint:js:fix lint:less",

--- a/tools/babel/plugin-react-dates-transform-imports.js
+++ b/tools/babel/plugin-react-dates-transform-imports.js
@@ -1,0 +1,58 @@
+const PACKAGE_REGEX = /^((.*!)?react-dates)([/\\].*)?$/;
+
+const getIsReactComponentIdentifier = name => name[0].toUpperCase() === name[0];
+
+module.exports = ({
+  types: {
+    identifier,
+    importDeclaration,
+    importDefaultSpecifier,
+    importSpecifier,
+    stringLiteral,
+  },
+}) => ({
+  visitor: {
+    ImportDeclaration: (path, state) => {
+      const match = PACKAGE_REGEX.exec(path.node.source.value);
+
+      // Do nothing if the import statement is not from `react-dates`
+      if (!match) return;
+
+      const importLibraryName = match[1];
+      const importPathName = match[3] || '';
+      const importModuleType = state.opts.importType === 'es' ? 'esm' : 'lib';
+
+      // Do nothing if the import statement has already been replaced
+      if (importPathName.includes(importModuleType)) return;
+
+      // Add `esm` or `lib` directory if the imports reaches beyond the `react-dates` API
+      if (importPathName) {
+        path.replaceWith(
+          importDeclaration(
+            path.node.specifiers.map(({ local: { name } }) =>
+              importSpecifier(identifier(name), identifier(name))
+            ),
+            stringLiteral(
+              `${importLibraryName}/${importModuleType}${importPathName}`
+            )
+          )
+        );
+        return;
+      }
+
+      // Replace with default import from relevant `react-dates` file
+      path.replaceWithMultiple(
+        path.node.specifiers.map(({ local: { name } }) =>
+          importDeclaration(
+            [importDefaultSpecifier(identifier(name))],
+            stringLiteral(
+              `${importLibraryName}/${importModuleType}/${
+                getIsReactComponentIdentifier(name) ? 'components' : 'utils'
+              }/${name}`
+            )
+          )
+        )
+      );
+    },
+  },
+});

--- a/tools/babel/preset.js
+++ b/tools/babel/preset.js
@@ -21,6 +21,12 @@ module.exports = () => ({
         importType: isESBuild ? 'es' : 'commonjs',
       },
     ],
+    isProductionBuild && [
+      './tools/babel/plugin-react-dates-transform-imports',
+      {
+        importType: isESBuild ? 'es' : 'commonjs',
+      },
+    ],
     '@babel/plugin-proposal-object-rest-spread',
     '@babel/plugin-proposal-class-properties',
     'lodash',

--- a/tools/babel/preset.js
+++ b/tools/babel/preset.js
@@ -1,0 +1,51 @@
+const { BABEL_ENV } = process.env;
+
+const isProductionBuild = ['commonjs', 'es'].includes(BABEL_ENV);
+const isESBuild = BABEL_ENV === 'es';
+
+module.exports = () => ({
+  comments: isProductionBuild ? false : undefined,
+  presets: [
+    [
+      '@babel/env',
+      {
+        modules: isESBuild ? false : 'commonjs',
+      },
+    ],
+    '@babel/react',
+  ],
+  plugins: [
+    isProductionBuild && [
+      'semantic-ui-react-transform-imports',
+      {
+        importType: isESBuild ? 'es' : 'commonjs',
+      },
+    ],
+    '@babel/plugin-proposal-object-rest-spread',
+    '@babel/plugin-proposal-class-properties',
+    'lodash',
+    [
+      'module-resolver',
+      {
+        root: ['./src'],
+        alias: {
+          collections: './src/components/collections',
+          elements: './src/components/elements',
+          'general-widgets': './src/components/general-widgets',
+          inputs: './src/components/inputs',
+          layout: './src/components/layout',
+          media: './src/components/media',
+          'property-page-widgets': './src/components/property-page-widgets',
+          typography: './src/components/typography',
+          utils: './src/utils',
+        },
+      },
+    ],
+    [
+      'transform-react-remove-prop-types',
+      {
+        mode: 'wrap',
+      },
+    ],
+  ].filter(Boolean),
+});


### PR DESCRIPTION
[Related YouTrack issue TE-2199](https://youtrack.lodgify.net/issue/TE-2199)
[Related YouTrack issue TE-2204](https://youtrack.lodgify.net/issue/TE-2204)
[Related YouTrack issue TE-2206](https://youtrack.lodgify.net/issue/TE-2206)

### What **one** thing does this PR do?
1. Exposes the whole library as es6 modules at `lib/es`
2. Imports es6 modules from `semantic-ui-react`
3. Imports es6 modules from `react-dates`

### Transpiled imports from `react-dates` 

#### `lib/es` 
<img width="820" alt="es" src="https://user-images.githubusercontent.com/8591501/59019841-ab9d2d80-8840-11e9-80cf-e2760145d855.png">

#### `lib/commonjs` 
<img width="874" alt="common" src="https://user-images.githubusercontent.com/8591501/58980924-9ccb6200-87d1-11e9-870e-ac0becfb918f.png">

### Indicative size savings in `templates-ssr`

Looks like this shaves around 13% off our main bundle.

#### Before
<img width="313" alt="before" src="https://user-images.githubusercontent.com/8591501/58980931-9fc65280-87d1-11e9-99b7-aa1e1529efb9.png">

#### After
<img width="358" alt="after" src="https://user-images.githubusercontent.com/8591501/58980928-9e952580-87d1-11e9-9a99-66558576c188.png">

