### PR TITLE
TE-2326 Add `PropertySearchResultList`

### DIFF
--- a/src/components/general-widgets/PropertySearchResult/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/PropertySearchResult/__snapshots__/component.spec.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<PropertySearchResult /> should render the right structure 1`] = `
+<div>
+  Property search result
+</div>
+`;

--- a/src/components/general-widgets/PropertySearchResult/component.js
+++ b/src/components/general-widgets/PropertySearchResult/component.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+/**
+ * JUST A DUMMY
+ */
+// eslint-disable-next-line jsdoc/require-jsdoc
+export const Component = () => <div>Property search result</div>;
+
+Component.displayName = 'PropertySearchResult';

--- a/src/components/general-widgets/PropertySearchResult/component.spec.js
+++ b/src/components/general-widgets/PropertySearchResult/component.spec.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
+
+import { Component as PropertySearchResult } from './component';
+
+const getPropertySearchResult = () => shallow(<PropertySearchResult />);
+
+describe('<PropertySearchResult />', () => {
+  it('should render the right structure', () => {
+    const actual = getPropertySearchResult();
+
+    expect(actual).toMatchSnapshot();
+  });
+
+  it('should have `displayName` `PropertySearchResult`', () => {
+    expectComponentToHaveDisplayName(
+      PropertySearchResult,
+      'PropertySearchResult'
+    );
+  });
+});

--- a/src/components/general-widgets/PropertySearchResult/index.js
+++ b/src/components/general-widgets/PropertySearchResult/index.js
@@ -1,0 +1,1 @@
+export { Component as PropertySearchResult } from './component';

--- a/src/components/general-widgets/PropertySearchResultList/Readme.md
+++ b/src/components/general-widgets/PropertySearchResultList/Readme.md
@@ -1,0 +1,29 @@
+```jsx
+const propertySearchResults = [ {}, {}, {}, {} ];
+
+<PropertySearchResultList
+  propertySearchResults={propertySearchResults}
+/>
+```
+### Content
+
+#### Results count text
+
+```jsx
+const propertySearchResults = [ {}, {}, {}, {} ];
+
+<PropertySearchResultList
+  propertySearchResults={propertySearchResults}
+  resultsCountText="properties found"
+/>
+```
+
+### States
+
+#### Showing placeholder
+
+```jsx
+<PropertySearchResultList
+  isShowingPlaceholder
+/>
+```

--- a/src/components/general-widgets/PropertySearchResultList/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/PropertySearchResultList/__snapshots__/component.spec.js.snap
@@ -1,0 +1,269 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<PropertySearchResultList /> by default should render the right structure 1`] = `
+<PropertySearchResultList
+  isShowingPlaceholder={false}
+  propertySearchResults={
+    Array [
+      Object {},
+      Object {},
+    ]
+  }
+  resultsCountText="results"
+>
+  <Heading
+    className={null}
+    hasMargin={true}
+    isColorInverted={false}
+    size="small"
+    textAlign={null}
+  >
+    <Header
+      as="h4"
+      className=""
+      inverted={false}
+      textAlign={null}
+    >
+      <h4
+        className="ui header"
+      >
+        2 results
+      </h4>
+    </Header>
+  </Heading>
+  <FlexContainer
+    alignContent={null}
+    alignItems={null}
+    flexDirection={null}
+    flexWrap="wrap"
+    justifyContent={null}
+  >
+    <div
+      className="flex-container"
+      style={
+        Object {
+          "alignContent": null,
+          "alignItems": null,
+          "display": "flex",
+          "flexDirection": null,
+          "flexGrow": "1",
+          "flexWrap": "wrap",
+          "height": "100%",
+          "justifyContent": null,
+        }
+      }
+    >
+      <PropertySearchResult
+        key="0"
+      >
+        <div>
+          Property search result
+        </div>
+      </PropertySearchResult>
+      <PropertySearchResult
+        key="1"
+      >
+        <div>
+          Property search result
+        </div>
+      </PropertySearchResult>
+    </div>
+  </FlexContainer>
+</PropertySearchResultList>
+`;
+
+exports[`<PropertySearchResultList /> if \`props.isShowingPlaceholder\` is true should render the right structure 1`] = `
+<PropertySearchResultList
+  isShowingPlaceholder={true}
+  propertySearchResults={
+    Array [
+      Object {},
+      Object {},
+    ]
+  }
+  resultsCountText="results"
+>
+  <Divider
+    className=""
+    hasLine={false}
+    size="small"
+  >
+    <Divider
+      className="is-size-small"
+      hidden={true}
+      section={false}
+    >
+      <div
+        className="ui hidden divider is-size-small"
+      />
+    </Divider>
+  </Divider>
+  <TextPlaceholder
+    isFluid={true}
+    length="short"
+  >
+    <div
+      className="placeholder text short fluid"
+    />
+  </TextPlaceholder>
+  <Divider
+    className=""
+    hasLine={false}
+    size="small"
+  >
+    <Divider
+      className="is-size-small"
+      hidden={true}
+      section={false}
+    >
+      <div
+        className="ui hidden divider is-size-small"
+      />
+    </Divider>
+  </Divider>
+  <FlexContainer
+    alignContent={null}
+    alignItems={null}
+    flexDirection={null}
+    flexWrap="wrap"
+    justifyContent={null}
+  >
+    <div
+      className="flex-container"
+      style={
+        Object {
+          "alignContent": null,
+          "alignItems": null,
+          "display": "flex",
+          "flexDirection": null,
+          "flexGrow": "1",
+          "flexWrap": "wrap",
+          "height": "100%",
+          "justifyContent": null,
+        }
+      }
+    >
+      <PropertySearchResult
+        isShowingPlaceholder={true}
+        key="placeholder0"
+      >
+        <div>
+          Property search result
+        </div>
+      </PropertySearchResult>
+      <PropertySearchResult
+        isShowingPlaceholder={true}
+        key="placeholder1"
+      >
+        <div>
+          Property search result
+        </div>
+      </PropertySearchResult>
+      <PropertySearchResult
+        isShowingPlaceholder={true}
+        key="placeholder2"
+      >
+        <div>
+          Property search result
+        </div>
+      </PropertySearchResult>
+      <PropertySearchResult
+        isShowingPlaceholder={true}
+        key="placeholder3"
+      >
+        <div>
+          Property search result
+        </div>
+      </PropertySearchResult>
+      <PropertySearchResult
+        isShowingPlaceholder={true}
+        key="placeholder4"
+      >
+        <div>
+          Property search result
+        </div>
+      </PropertySearchResult>
+      <PropertySearchResult
+        isShowingPlaceholder={true}
+        key="placeholder5"
+      >
+        <div>
+          Property search result
+        </div>
+      </PropertySearchResult>
+    </div>
+  </FlexContainer>
+</PropertySearchResultList>
+`;
+
+exports[`<PropertySearchResultList /> if \`props.resultsCountText\` is passed should render the right structure 1`] = `
+<PropertySearchResultList
+  isShowingPlaceholder={false}
+  propertySearchResults={
+    Array [
+      Object {},
+      Object {},
+    ]
+  }
+  resultsCountText="My god I love Cliff Richard"
+>
+  <Heading
+    className={null}
+    hasMargin={true}
+    isColorInverted={false}
+    size="small"
+    textAlign={null}
+  >
+    <Header
+      as="h4"
+      className=""
+      inverted={false}
+      textAlign={null}
+    >
+      <h4
+        className="ui header"
+      >
+        2 My god I love Cliff Richard
+      </h4>
+    </Header>
+  </Heading>
+  <FlexContainer
+    alignContent={null}
+    alignItems={null}
+    flexDirection={null}
+    flexWrap="wrap"
+    justifyContent={null}
+  >
+    <div
+      className="flex-container"
+      style={
+        Object {
+          "alignContent": null,
+          "alignItems": null,
+          "display": "flex",
+          "flexDirection": null,
+          "flexGrow": "1",
+          "flexWrap": "wrap",
+          "height": "100%",
+          "justifyContent": null,
+        }
+      }
+    >
+      <PropertySearchResult
+        key="0"
+      >
+        <div>
+          Property search result
+        </div>
+      </PropertySearchResult>
+      <PropertySearchResult
+        key="1"
+      >
+        <div>
+          Property search result
+        </div>
+      </PropertySearchResult>
+    </div>
+  </FlexContainer>
+</PropertySearchResultList>
+`;

--- a/src/components/general-widgets/PropertySearchResultList/component.js
+++ b/src/components/general-widgets/PropertySearchResultList/component.js
@@ -1,0 +1,68 @@
+import React, { Fragment } from 'react';
+import PropTypes from 'prop-types';
+
+import { Divider } from 'elements/Divider';
+import { TextPlaceholder } from 'elements/TextPlaceholder';
+import { Heading } from 'typography/Heading';
+import { FlexContainer } from 'layout/FlexContainer';
+import { PropertySearchResult } from 'general-widgets/PropertySearchResult';
+import { buildKeyFromStrings } from 'utils/build-key-from-strings';
+import { RESULTS } from 'utils/default-strings';
+
+import { PLACEHOLDERS } from './constants';
+
+/**
+ * The standard widget for displaying a list of property search results.
+ */
+// eslint-disable-next-line jsdoc/require-jsdoc
+export const Component = ({
+  isShowingPlaceholder,
+  propertySearchResults,
+  resultsCountText,
+}) =>
+  isShowingPlaceholder ? (
+    <Fragment>
+      <Divider size="small" />
+      <TextPlaceholder length="short" />
+      <Divider size="small" />
+      <FlexContainer flexWrap="wrap">
+        {PLACEHOLDERS.map(({ placeholderName }, index) => (
+          <PropertySearchResult
+            isShowingPlaceholder
+            key={buildKeyFromStrings(placeholderName, index)}
+          />
+        ))}
+      </FlexContainer>
+    </Fragment>
+  ) : (
+    <Fragment>
+      <Heading size="small">
+        {`${propertySearchResults.length} ${resultsCountText}`}
+      </Heading>
+      <FlexContainer flexWrap="wrap">
+        {propertySearchResults.map((propertySearchResult, index) => (
+          <PropertySearchResult
+            key={buildKeyFromStrings(propertySearchResult.propertyName, index)}
+            {...propertySearchResult}
+          />
+        ))}
+      </FlexContainer>
+    </Fragment>
+  );
+
+Component.displayName = 'PropertySearchResultList';
+
+Component.defaultProps = {
+  propertySearchResults: [],
+  resultsCountText: RESULTS,
+  isShowingPlaceholder: false,
+};
+
+Component.propTypes = {
+  /** Is the component showing placeholders to reserve space for content which will appear. */
+  isShowingPlaceholder: PropTypes.bool,
+  /** An array of [`PropertySearchResult`](#/PropertySearchResult) props objects. */
+  propertySearchResults: PropTypes.arrayOf(PropTypes.object),
+  /** The text to display alongside the results count. */
+  resultsCountText: PropTypes.string,
+};

--- a/src/components/general-widgets/PropertySearchResultList/component.spec.js
+++ b/src/components/general-widgets/PropertySearchResultList/component.spec.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
+
+import { Component as PropertySearchResultList } from './component';
+
+const propertySearchResults = [{}, {}];
+
+const getPropertySearchResultList = otherProps =>
+  mount(
+    <PropertySearchResultList
+      propertySearchResults={propertySearchResults}
+      {...otherProps}
+    />
+  );
+
+describe('<PropertySearchResultList />', () => {
+  describe('by default', () => {
+    it('should render the right structure', () => {
+      const actual = getPropertySearchResultList();
+
+      expect(actual).toMatchSnapshot();
+    });
+  });
+
+  describe('if `props.isShowingPlaceholder` is true', () => {
+    it('should render the right structure', () => {
+      const actual = getPropertySearchResultList({
+        isShowingPlaceholder: true,
+      });
+
+      expect(actual).toMatchSnapshot();
+    });
+  });
+
+  describe('if `props.resultsCountText` is passed', () => {
+    it('should render the right structure', () => {
+      const resultsCountText = 'My god I love Cliff Richard';
+      const actual = getPropertySearchResultList({ resultsCountText });
+
+      expect(actual).toMatchSnapshot();
+    });
+  });
+
+  it('should have `displayName` `PropertySearchResultList`', () => {
+    expectComponentToHaveDisplayName(
+      PropertySearchResultList,
+      'PropertySearchResultList'
+    );
+  });
+});

--- a/src/components/general-widgets/PropertySearchResultList/constants.js
+++ b/src/components/general-widgets/PropertySearchResultList/constants.js
@@ -1,0 +1,9 @@
+const PLACEHOLDER_DATA = {
+  placeholderName: 'placeholder',
+};
+
+const NUMBER_OF_PLACEHOLDERS = 6;
+
+export const PLACEHOLDERS = Array(NUMBER_OF_PLACEHOLDERS).fill(
+  PLACEHOLDER_DATA
+);

--- a/src/components/general-widgets/PropertySearchResultList/index.js
+++ b/src/components/general-widgets/PropertySearchResultList/index.js
@@ -1,0 +1,1 @@
+export { Component as PropertySearchResultList } from './component';

--- a/src/utils/default-strings/constants.js
+++ b/src/utils/default-strings/constants.js
@@ -54,6 +54,7 @@ export const PROPERTIES = 'Properties';
 export const PROPERTY = 'Property';
 export const PROPERTY_PICTURES = 'Property pictures';
 export const PROPERTY_URL_TARGET = '_self';
+export const RESULTS = 'results';
 export const REVIEWS = 'Reviews';
 export const ROOM = 'Room';
 export const ROOM_AMENITIES = 'Room Amenities';


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-X)

### What **one** thing does this PR do?
Adds `PropertySearchResultList` consuming dummy `PropertySearchResult`s

<img width="599" alt="Screenshot 2019-06-06 at 12 19 21" src="https://user-images.githubusercontent.com/8591501/59029120-57e90f00-8855-11e9-84e4-da09fa6e43d4.png">

