### PR TITLE
TE-2343 Fix icon and width of SearchBar Guests NumberInput

### DIFF
--- a/src/components/general-widgets/Contact/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/Contact/__snapshots__/component.spec.js.snap
@@ -341,6 +341,7 @@ exports[`<Contact /> if \`isPrivacyConsentRequired\` is \`truthy\` should render
                         <NumberInput
                           autoComplete={null}
                           error={false}
+                          icon={null}
                           isValid={false}
                           label="Guests"
                           min={1}
@@ -1141,6 +1142,7 @@ exports[`<Contact /> if \`propertyOptions\` and \`roomOptions\` are passed shoul
                         <NumberInput
                           autoComplete={null}
                           error={false}
+                          icon={null}
                           isValid={false}
                           label="Guests"
                           min={1}
@@ -2383,6 +2385,7 @@ exports[`<Contact /> if \`props.propertyOptions\` is passed should have the corr
                         <NumberInput
                           autoComplete={null}
                           error={false}
+                          icon={null}
                           isValid={false}
                           label="Guests"
                           min={1}
@@ -3363,6 +3366,7 @@ exports[`<Contact /> if \`props.roomOptions\` is passed should have the correct 
                         <NumberInput
                           autoComplete={null}
                           error={false}
+                          icon={null}
                           isValid={false}
                           label="Guests"
                           min={1}
@@ -4287,6 +4291,7 @@ exports[`<Contact /> should have the correct structure 1`] = `
                         <NumberInput
                           autoComplete={null}
                           error={false}
+                          icon={null}
                           isValid={false}
                           label="Guests"
                           min={1}

--- a/src/components/general-widgets/HomepageHero/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/HomepageHero/__snapshots__/component.spec.js.snap
@@ -902,15 +902,30 @@ exports[`HomepageHero should render the right structure 1`] = `
                                                 </div>
                                               </FormField>
                                               <FormField
-                                                width="two"
+                                                width="three"
                                               >
                                                 <div
-                                                  className="two wide field"
+                                                  className="three wide field"
                                                 >
                                                   <NumberInput
                                                     autoComplete={null}
                                                     error={false}
-                                                    icon="users"
+                                                    icon={
+                                                      <Icon
+                                                        color={null}
+                                                        hasBorder={false}
+                                                        isButton={false}
+                                                        isCircular={false}
+                                                        isColorInverted={false}
+                                                        isDisabled={false}
+                                                        isLabelLeft={false}
+                                                        labelText={null}
+                                                        labelWeight={null}
+                                                        name="users"
+                                                        path={null}
+                                                        size={null}
+                                                      />
+                                                    }
                                                     isValid={false}
                                                     label="Guests"
                                                     min={0}
@@ -921,7 +936,22 @@ exports[`HomepageHero should render the right structure 1`] = `
                                                     <InputController
                                                       adaptOnChangeEvent={[Function]}
                                                       error={false}
-                                                      icon={null}
+                                                      icon={
+                                                        <Icon
+                                                          color={null}
+                                                          hasBorder={false}
+                                                          isButton={false}
+                                                          isCircular={false}
+                                                          isColorInverted={false}
+                                                          isDisabled={false}
+                                                          isLabelLeft={false}
+                                                          labelText={null}
+                                                          labelWeight={null}
+                                                          name="users"
+                                                          path={null}
+                                                          size={null}
+                                                        />
+                                                      }
                                                       initialValue=""
                                                       inputOnChangeFunctionName="onChange"
                                                       isFluid={false}
@@ -935,11 +965,11 @@ exports[`HomepageHero should render the right structure 1`] = `
                                                       <Input
                                                         className=""
                                                         fluid={false}
-                                                        iconPosition={null}
+                                                        iconPosition="left"
                                                         type="text"
                                                       >
                                                         <div
-                                                          className="ui input"
+                                                          className="ui left icon input"
                                                         >
                                                           <input
                                                             autoComplete={null}
@@ -957,6 +987,34 @@ exports[`HomepageHero should render the right structure 1`] = `
                                                           >
                                                             Guests
                                                           </label>
+                                                          <Icon
+                                                            color={null}
+                                                            hasBorder={false}
+                                                            isButton={false}
+                                                            isCircular={false}
+                                                            isColorInverted={false}
+                                                            isDisabled={false}
+                                                            isLabelLeft={false}
+                                                            key=".4"
+                                                            labelText={null}
+                                                            labelWeight={null}
+                                                            name="users"
+                                                            path={null}
+                                                            size={null}
+                                                          >
+                                                            <i
+                                                              className="icon"
+                                                            >
+                                                              <svg
+                                                                viewBox="0 0 24 24"
+                                                              >
+                                                                <path
+                                                                  d="M18.63,8.88h-.08a4,4,0,1,0-4.18,0h-.08a2.2,2.2,0,0,0-2.2,2.2v9.35a2.1,2.1,0,0,0,2.1,2.1h4.54a2.11,2.11,0,0,0,2.11-2.1V11.08A2.21,2.21,0,0,0,18.63,8.88Zm-5.18-3.4a3,3,0,1,1,3,3A3,3,0,0,1,13.45,5.48Zm6.39,15a1.11,1.11,0,0,1-1.11,1.1H14.19a1.1,1.1,0,0,1-1.1-1.1V11.08a1.2,1.2,0,0,1,1.2-1.2h4.34a1.21,1.21,0,0,1,1.21,1.2ZM9,11.89a3.27,3.27,0,1,0-3.77,0,2.21,2.21,0,0,0-2.09,2.19v6.24a2.12,2.12,0,0,0,2.11,2.11H9a2.11,2.11,0,0,0,2.1-2.11V14.08A2.21,2.21,0,0,0,9,11.89ZM7.13,7A2.27,2.27,0,1,1,4.87,9.24,2.27,2.27,0,0,1,7.13,7Zm3,13.35A1.11,1.11,0,0,1,9,21.43H5.27a1.11,1.11,0,0,1-1.11-1.11V14.08a1.21,1.21,0,0,1,1.21-1.2H8.9a1.2,1.2,0,0,1,1.2,1.2Z"
+                                                                  fill="currentColor"
+                                                                />
+                                                              </svg>
+                                                            </i>
+                                                          </Icon>
                                                         </div>
                                                       </Input>
                                                     </InputController>

--- a/src/components/general-widgets/SearchBar/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/SearchBar/__snapshots__/component.spec.js.snap
@@ -72,9 +72,10 @@ exports[`<SearchBar /> by default should render the right structure 1`] = `
           >
             <FormField
               className="location-dropdown"
+              width="three"
             >
               <div
-                className="field location-dropdown"
+                className="three wide field location-dropdown"
               >
                 <Dropdown
                   error={false}
@@ -556,15 +557,30 @@ exports[`<SearchBar /> by default should render the right structure 1`] = `
               </div>
             </FormField>
             <FormField
-              width="two"
+              width="three"
             >
               <div
-                className="two wide field"
+                className="three wide field"
               >
                 <NumberInput
                   autoComplete={null}
                   error={false}
-                  icon="users"
+                  icon={
+                    <Icon
+                      color={null}
+                      hasBorder={false}
+                      isButton={false}
+                      isCircular={false}
+                      isColorInverted={false}
+                      isDisabled={false}
+                      isLabelLeft={false}
+                      labelText={null}
+                      labelWeight={null}
+                      name="users"
+                      path={null}
+                      size={null}
+                    />
+                  }
                   isValid={false}
                   label="Guests"
                   min={0}
@@ -575,7 +591,22 @@ exports[`<SearchBar /> by default should render the right structure 1`] = `
                   <InputController
                     adaptOnChangeEvent={[Function]}
                     error={false}
-                    icon={null}
+                    icon={
+                      <Icon
+                        color={null}
+                        hasBorder={false}
+                        isButton={false}
+                        isCircular={false}
+                        isColorInverted={false}
+                        isDisabled={false}
+                        isLabelLeft={false}
+                        labelText={null}
+                        labelWeight={null}
+                        name="users"
+                        path={null}
+                        size={null}
+                      />
+                    }
                     initialValue=""
                     inputOnChangeFunctionName="onChange"
                     isFluid={false}
@@ -589,11 +620,11 @@ exports[`<SearchBar /> by default should render the right structure 1`] = `
                     <Input
                       className=""
                       fluid={false}
-                      iconPosition={null}
+                      iconPosition="left"
                       type="text"
                     >
                       <div
-                        className="ui input"
+                        className="ui left icon input"
                       >
                         <input
                           autoComplete={null}
@@ -611,6 +642,34 @@ exports[`<SearchBar /> by default should render the right structure 1`] = `
                         >
                           Guests
                         </label>
+                        <Icon
+                          color={null}
+                          hasBorder={false}
+                          isButton={false}
+                          isCircular={false}
+                          isColorInverted={false}
+                          isDisabled={false}
+                          isLabelLeft={false}
+                          key=".4"
+                          labelText={null}
+                          labelWeight={null}
+                          name="users"
+                          path={null}
+                          size={null}
+                        >
+                          <i
+                            className="icon"
+                          >
+                            <svg
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M18.63,8.88h-.08a4,4,0,1,0-4.18,0h-.08a2.2,2.2,0,0,0-2.2,2.2v9.35a2.1,2.1,0,0,0,2.1,2.1h4.54a2.11,2.11,0,0,0,2.11-2.1V11.08A2.21,2.21,0,0,0,18.63,8.88Zm-5.18-3.4a3,3,0,1,1,3,3A3,3,0,0,1,13.45,5.48Zm6.39,15a1.11,1.11,0,0,1-1.11,1.1H14.19a1.1,1.1,0,0,1-1.1-1.1V11.08a1.2,1.2,0,0,1,1.2-1.2h4.34a1.21,1.21,0,0,1,1.21,1.2ZM9,11.89a3.27,3.27,0,1,0-3.77,0,2.21,2.21,0,0,0-2.09,2.19v6.24a2.12,2.12,0,0,0,2.11,2.11H9a2.11,2.11,0,0,0,2.1-2.11V14.08A2.21,2.21,0,0,0,9,11.89ZM7.13,7A2.27,2.27,0,1,1,4.87,9.24,2.27,2.27,0,0,1,7.13,7Zm3,13.35A1.11,1.11,0,0,1,9,21.43H5.27a1.11,1.11,0,0,1-1.11-1.11V14.08a1.21,1.21,0,0,1,1.21-1.2H8.9a1.2,1.2,0,0,1,1.2,1.2Z"
+                                fill="currentColor"
+                              />
+                            </svg>
+                          </i>
+                        </Icon>
                       </div>
                     </Input>
                   </InputController>
@@ -1139,9 +1198,10 @@ exports[`<SearchBar /> if \`props.isFixed\` is true should render the right stru
                                   >
                                     <FormField
                                       className="location-dropdown"
+                                      width="three"
                                     >
                                       <div
-                                        className="field location-dropdown"
+                                        className="three wide field location-dropdown"
                                       >
                                         <Dropdown
                                           error={false}
@@ -1623,15 +1683,30 @@ exports[`<SearchBar /> if \`props.isFixed\` is true should render the right stru
                                       </div>
                                     </FormField>
                                     <FormField
-                                      width="two"
+                                      width="three"
                                     >
                                       <div
-                                        className="two wide field"
+                                        className="three wide field"
                                       >
                                         <NumberInput
                                           autoComplete={null}
                                           error={false}
-                                          icon="users"
+                                          icon={
+                                            <Icon
+                                              color={null}
+                                              hasBorder={false}
+                                              isButton={false}
+                                              isCircular={false}
+                                              isColorInverted={false}
+                                              isDisabled={false}
+                                              isLabelLeft={false}
+                                              labelText={null}
+                                              labelWeight={null}
+                                              name="users"
+                                              path={null}
+                                              size={null}
+                                            />
+                                          }
                                           isValid={false}
                                           label="Guests"
                                           min={0}
@@ -1642,7 +1717,22 @@ exports[`<SearchBar /> if \`props.isFixed\` is true should render the right stru
                                           <InputController
                                             adaptOnChangeEvent={[Function]}
                                             error={false}
-                                            icon={null}
+                                            icon={
+                                              <Icon
+                                                color={null}
+                                                hasBorder={false}
+                                                isButton={false}
+                                                isCircular={false}
+                                                isColorInverted={false}
+                                                isDisabled={false}
+                                                isLabelLeft={false}
+                                                labelText={null}
+                                                labelWeight={null}
+                                                name="users"
+                                                path={null}
+                                                size={null}
+                                              />
+                                            }
                                             initialValue=""
                                             inputOnChangeFunctionName="onChange"
                                             isFluid={false}
@@ -1656,11 +1746,11 @@ exports[`<SearchBar /> if \`props.isFixed\` is true should render the right stru
                                             <Input
                                               className=""
                                               fluid={false}
-                                              iconPosition={null}
+                                              iconPosition="left"
                                               type="text"
                                             >
                                               <div
-                                                className="ui input"
+                                                className="ui left icon input"
                                               >
                                                 <input
                                                   autoComplete={null}
@@ -1678,6 +1768,34 @@ exports[`<SearchBar /> if \`props.isFixed\` is true should render the right stru
                                                 >
                                                   Guests
                                                 </label>
+                                                <Icon
+                                                  color={null}
+                                                  hasBorder={false}
+                                                  isButton={false}
+                                                  isCircular={false}
+                                                  isColorInverted={false}
+                                                  isDisabled={false}
+                                                  isLabelLeft={false}
+                                                  key=".4"
+                                                  labelText={null}
+                                                  labelWeight={null}
+                                                  name="users"
+                                                  path={null}
+                                                  size={null}
+                                                >
+                                                  <i
+                                                    className="icon"
+                                                  >
+                                                    <svg
+                                                      viewBox="0 0 24 24"
+                                                    >
+                                                      <path
+                                                        d="M18.63,8.88h-.08a4,4,0,1,0-4.18,0h-.08a2.2,2.2,0,0,0-2.2,2.2v9.35a2.1,2.1,0,0,0,2.1,2.1h4.54a2.11,2.11,0,0,0,2.11-2.1V11.08A2.21,2.21,0,0,0,18.63,8.88Zm-5.18-3.4a3,3,0,1,1,3,3A3,3,0,0,1,13.45,5.48Zm6.39,15a1.11,1.11,0,0,1-1.11,1.1H14.19a1.1,1.1,0,0,1-1.1-1.1V11.08a1.2,1.2,0,0,1,1.2-1.2h4.34a1.21,1.21,0,0,1,1.21,1.2ZM9,11.89a3.27,3.27,0,1,0-3.77,0,2.21,2.21,0,0,0-2.09,2.19v6.24a2.12,2.12,0,0,0,2.11,2.11H9a2.11,2.11,0,0,0,2.1-2.11V14.08A2.21,2.21,0,0,0,9,11.89ZM7.13,7A2.27,2.27,0,1,1,4.87,9.24,2.27,2.27,0,0,1,7.13,7Zm3,13.35A1.11,1.11,0,0,1,9,21.43H5.27a1.11,1.11,0,0,1-1.11-1.11V14.08a1.21,1.21,0,0,1,1.21-1.2H8.9a1.2,1.2,0,0,1,1.2,1.2Z"
+                                                        fill="currentColor"
+                                                      />
+                                                    </svg>
+                                                  </i>
+                                                </Icon>
                                               </div>
                                             </Input>
                                           </InputController>
@@ -1894,9 +2012,10 @@ exports[`<SearchBar /> if \`props.isShowingSummary\` is true should render the r
             </FormField>
             <FormField
               className="location-dropdown"
+              width="three"
             >
               <div
-                className="field location-dropdown"
+                className="three wide field location-dropdown"
               >
                 <Dropdown
                   error={false}
@@ -2378,15 +2497,30 @@ exports[`<SearchBar /> if \`props.isShowingSummary\` is true should render the r
               </div>
             </FormField>
             <FormField
-              width="two"
+              width="three"
             >
               <div
-                className="two wide field"
+                className="three wide field"
               >
                 <NumberInput
                   autoComplete={null}
                   error={false}
-                  icon="users"
+                  icon={
+                    <Icon
+                      color={null}
+                      hasBorder={false}
+                      isButton={false}
+                      isCircular={false}
+                      isColorInverted={false}
+                      isDisabled={false}
+                      isLabelLeft={false}
+                      labelText={null}
+                      labelWeight={null}
+                      name="users"
+                      path={null}
+                      size={null}
+                    />
+                  }
                   isValid={false}
                   label="Guests"
                   min={0}
@@ -2397,7 +2531,22 @@ exports[`<SearchBar /> if \`props.isShowingSummary\` is true should render the r
                   <InputController
                     adaptOnChangeEvent={[Function]}
                     error={false}
-                    icon={null}
+                    icon={
+                      <Icon
+                        color={null}
+                        hasBorder={false}
+                        isButton={false}
+                        isCircular={false}
+                        isColorInverted={false}
+                        isDisabled={false}
+                        isLabelLeft={false}
+                        labelText={null}
+                        labelWeight={null}
+                        name="users"
+                        path={null}
+                        size={null}
+                      />
+                    }
                     initialValue=""
                     inputOnChangeFunctionName="onChange"
                     isFluid={false}
@@ -2411,11 +2560,11 @@ exports[`<SearchBar /> if \`props.isShowingSummary\` is true should render the r
                     <Input
                       className=""
                       fluid={false}
-                      iconPosition={null}
+                      iconPosition="left"
                       type="text"
                     >
                       <div
-                        className="ui input"
+                        className="ui left icon input"
                       >
                         <input
                           autoComplete={null}
@@ -2433,6 +2582,34 @@ exports[`<SearchBar /> if \`props.isShowingSummary\` is true should render the r
                         >
                           Guests
                         </label>
+                        <Icon
+                          color={null}
+                          hasBorder={false}
+                          isButton={false}
+                          isCircular={false}
+                          isColorInverted={false}
+                          isDisabled={false}
+                          isLabelLeft={false}
+                          key=".4"
+                          labelText={null}
+                          labelWeight={null}
+                          name="users"
+                          path={null}
+                          size={null}
+                        >
+                          <i
+                            className="icon"
+                          >
+                            <svg
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M18.63,8.88h-.08a4,4,0,1,0-4.18,0h-.08a2.2,2.2,0,0,0-2.2,2.2v9.35a2.1,2.1,0,0,0,2.1,2.1h4.54a2.11,2.11,0,0,0,2.11-2.1V11.08A2.21,2.21,0,0,0,18.63,8.88Zm-5.18-3.4a3,3,0,1,1,3,3A3,3,0,0,1,13.45,5.48Zm6.39,15a1.11,1.11,0,0,1-1.11,1.1H14.19a1.1,1.1,0,0,1-1.1-1.1V11.08a1.2,1.2,0,0,1,1.2-1.2h4.34a1.21,1.21,0,0,1,1.21,1.2ZM9,11.89a3.27,3.27,0,1,0-3.77,0,2.21,2.21,0,0,0-2.09,2.19v6.24a2.12,2.12,0,0,0,2.11,2.11H9a2.11,2.11,0,0,0,2.1-2.11V14.08A2.21,2.21,0,0,0,9,11.89ZM7.13,7A2.27,2.27,0,1,1,4.87,9.24,2.27,2.27,0,0,1,7.13,7Zm3,13.35A1.11,1.11,0,0,1,9,21.43H5.27a1.11,1.11,0,0,1-1.11-1.11V14.08a1.21,1.21,0,0,1,1.21-1.2H8.9a1.2,1.2,0,0,1,1.2,1.2Z"
+                                fill="currentColor"
+                              />
+                            </svg>
+                          </i>
+                        </Icon>
                       </div>
                     </Input>
                   </InputController>
@@ -2731,15 +2908,30 @@ exports[`<SearchBar /> if \`props.locationOptions\` is not passed should render 
               </div>
             </FormField>
             <FormField
-              width="two"
+              width="three"
             >
               <div
-                className="two wide field"
+                className="three wide field"
               >
                 <NumberInput
                   autoComplete={null}
                   error={false}
-                  icon="users"
+                  icon={
+                    <Icon
+                      color={null}
+                      hasBorder={false}
+                      isButton={false}
+                      isCircular={false}
+                      isColorInverted={false}
+                      isDisabled={false}
+                      isLabelLeft={false}
+                      labelText={null}
+                      labelWeight={null}
+                      name="users"
+                      path={null}
+                      size={null}
+                    />
+                  }
                   isValid={false}
                   label="Guests"
                   min={0}
@@ -2750,7 +2942,22 @@ exports[`<SearchBar /> if \`props.locationOptions\` is not passed should render 
                   <InputController
                     adaptOnChangeEvent={[Function]}
                     error={false}
-                    icon={null}
+                    icon={
+                      <Icon
+                        color={null}
+                        hasBorder={false}
+                        isButton={false}
+                        isCircular={false}
+                        isColorInverted={false}
+                        isDisabled={false}
+                        isLabelLeft={false}
+                        labelText={null}
+                        labelWeight={null}
+                        name="users"
+                        path={null}
+                        size={null}
+                      />
+                    }
                     initialValue=""
                     inputOnChangeFunctionName="onChange"
                     isFluid={false}
@@ -2764,11 +2971,11 @@ exports[`<SearchBar /> if \`props.locationOptions\` is not passed should render 
                     <Input
                       className=""
                       fluid={false}
-                      iconPosition={null}
+                      iconPosition="left"
                       type="text"
                     >
                       <div
-                        className="ui input"
+                        className="ui left icon input"
                       >
                         <input
                           autoComplete={null}
@@ -2786,6 +2993,34 @@ exports[`<SearchBar /> if \`props.locationOptions\` is not passed should render 
                         >
                           Guests
                         </label>
+                        <Icon
+                          color={null}
+                          hasBorder={false}
+                          isButton={false}
+                          isCircular={false}
+                          isColorInverted={false}
+                          isDisabled={false}
+                          isLabelLeft={false}
+                          key=".4"
+                          labelText={null}
+                          labelWeight={null}
+                          name="users"
+                          path={null}
+                          size={null}
+                        >
+                          <i
+                            className="icon"
+                          >
+                            <svg
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M18.63,8.88h-.08a4,4,0,1,0-4.18,0h-.08a2.2,2.2,0,0,0-2.2,2.2v9.35a2.1,2.1,0,0,0,2.1,2.1h4.54a2.11,2.11,0,0,0,2.11-2.1V11.08A2.21,2.21,0,0,0,18.63,8.88Zm-5.18-3.4a3,3,0,1,1,3,3A3,3,0,0,1,13.45,5.48Zm6.39,15a1.11,1.11,0,0,1-1.11,1.1H14.19a1.1,1.1,0,0,1-1.1-1.1V11.08a1.2,1.2,0,0,1,1.2-1.2h4.34a1.21,1.21,0,0,1,1.21,1.2ZM9,11.89a3.27,3.27,0,1,0-3.77,0,2.21,2.21,0,0,0-2.09,2.19v6.24a2.12,2.12,0,0,0,2.11,2.11H9a2.11,2.11,0,0,0,2.1-2.11V14.08A2.21,2.21,0,0,0,9,11.89ZM7.13,7A2.27,2.27,0,1,1,4.87,9.24,2.27,2.27,0,0,1,7.13,7Zm3,13.35A1.11,1.11,0,0,1,9,21.43H5.27a1.11,1.11,0,0,1-1.11-1.11V14.08a1.21,1.21,0,0,1,1.21-1.2H8.9a1.2,1.2,0,0,1,1.2,1.2Z"
+                                fill="currentColor"
+                              />
+                            </svg>
+                          </i>
+                        </Icon>
                       </div>
                     </Input>
                   </InputController>
@@ -2928,9 +3163,10 @@ exports[`<SearchBar /> if \`props.searchButton\` is passed should render the rig
           >
             <FormField
               className="location-dropdown"
+              width="three"
             >
               <div
-                className="field location-dropdown"
+                className="three wide field location-dropdown"
               >
                 <Dropdown
                   error={false}
@@ -3412,15 +3648,30 @@ exports[`<SearchBar /> if \`props.searchButton\` is passed should render the rig
               </div>
             </FormField>
             <FormField
-              width="two"
+              width="three"
             >
               <div
-                className="two wide field"
+                className="three wide field"
               >
                 <NumberInput
                   autoComplete={null}
                   error={false}
-                  icon="users"
+                  icon={
+                    <Icon
+                      color={null}
+                      hasBorder={false}
+                      isButton={false}
+                      isCircular={false}
+                      isColorInverted={false}
+                      isDisabled={false}
+                      isLabelLeft={false}
+                      labelText={null}
+                      labelWeight={null}
+                      name="users"
+                      path={null}
+                      size={null}
+                    />
+                  }
                   isValid={false}
                   label="Guests"
                   min={0}
@@ -3431,7 +3682,22 @@ exports[`<SearchBar /> if \`props.searchButton\` is passed should render the rig
                   <InputController
                     adaptOnChangeEvent={[Function]}
                     error={false}
-                    icon={null}
+                    icon={
+                      <Icon
+                        color={null}
+                        hasBorder={false}
+                        isButton={false}
+                        isCircular={false}
+                        isColorInverted={false}
+                        isDisabled={false}
+                        isLabelLeft={false}
+                        labelText={null}
+                        labelWeight={null}
+                        name="users"
+                        path={null}
+                        size={null}
+                      />
+                    }
                     initialValue=""
                     inputOnChangeFunctionName="onChange"
                     isFluid={false}
@@ -3445,11 +3711,11 @@ exports[`<SearchBar /> if \`props.searchButton\` is passed should render the rig
                     <Input
                       className=""
                       fluid={false}
-                      iconPosition={null}
+                      iconPosition="left"
                       type="text"
                     >
                       <div
-                        className="ui input"
+                        className="ui left icon input"
                       >
                         <input
                           autoComplete={null}
@@ -3467,6 +3733,34 @@ exports[`<SearchBar /> if \`props.searchButton\` is passed should render the rig
                         >
                           Guests
                         </label>
+                        <Icon
+                          color={null}
+                          hasBorder={false}
+                          isButton={false}
+                          isCircular={false}
+                          isColorInverted={false}
+                          isDisabled={false}
+                          isLabelLeft={false}
+                          key=".4"
+                          labelText={null}
+                          labelWeight={null}
+                          name="users"
+                          path={null}
+                          size={null}
+                        >
+                          <i
+                            className="icon"
+                          >
+                            <svg
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M18.63,8.88h-.08a4,4,0,1,0-4.18,0h-.08a2.2,2.2,0,0,0-2.2,2.2v9.35a2.1,2.1,0,0,0,2.1,2.1h4.54a2.11,2.11,0,0,0,2.11-2.1V11.08A2.21,2.21,0,0,0,18.63,8.88Zm-5.18-3.4a3,3,0,1,1,3,3A3,3,0,0,1,13.45,5.48Zm6.39,15a1.11,1.11,0,0,1-1.11,1.1H14.19a1.1,1.1,0,0,1-1.1-1.1V11.08a1.2,1.2,0,0,1,1.2-1.2h4.34a1.21,1.21,0,0,1,1.21,1.2ZM9,11.89a3.27,3.27,0,1,0-3.77,0,2.21,2.21,0,0,0-2.09,2.19v6.24a2.12,2.12,0,0,0,2.11,2.11H9a2.11,2.11,0,0,0,2.1-2.11V14.08A2.21,2.21,0,0,0,9,11.89ZM7.13,7A2.27,2.27,0,1,1,4.87,9.24,2.27,2.27,0,0,1,7.13,7Zm3,13.35A1.11,1.11,0,0,1,9,21.43H5.27a1.11,1.11,0,0,1-1.11-1.11V14.08a1.21,1.21,0,0,1,1.21-1.2H8.9a1.2,1.2,0,0,1,1.2,1.2Z"
+                                fill="currentColor"
+                              />
+                            </svg>
+                          </i>
+                        </Icon>
                       </div>
                     </Input>
                   </InputController>

--- a/src/components/general-widgets/SearchBar/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/SearchBar/__snapshots__/component.spec.js.snap
@@ -72,10 +72,9 @@ exports[`<SearchBar /> by default should render the right structure 1`] = `
           >
             <FormField
               className="location-dropdown"
-              width="three"
             >
               <div
-                className="three wide field location-dropdown"
+                className="field location-dropdown"
               >
                 <Dropdown
                   error={false}
@@ -1198,10 +1197,9 @@ exports[`<SearchBar /> if \`props.isFixed\` is true should render the right stru
                                   >
                                     <FormField
                                       className="location-dropdown"
-                                      width="three"
                                     >
                                       <div
-                                        className="three wide field location-dropdown"
+                                        className="field location-dropdown"
                                       >
                                         <Dropdown
                                           error={false}
@@ -2012,10 +2010,9 @@ exports[`<SearchBar /> if \`props.isShowingSummary\` is true should render the r
             </FormField>
             <FormField
               className="location-dropdown"
-              width="three"
             >
               <div
-                className="three wide field location-dropdown"
+                className="field location-dropdown"
               >
                 <Dropdown
                   error={false}
@@ -3163,10 +3160,9 @@ exports[`<SearchBar /> if \`props.searchButton\` is passed should render the rig
           >
             <FormField
               className="location-dropdown"
-              width="three"
             >
               <div
-                className="three wide field location-dropdown"
+                className="field location-dropdown"
               >
                 <Dropdown
                   error={false}

--- a/src/components/general-widgets/SearchBar/utils/__snapshots__/getFormFieldMarkup.spec.js.snap
+++ b/src/components/general-widgets/SearchBar/utils/__snapshots__/getFormFieldMarkup.spec.js.snap
@@ -22,6 +22,7 @@ exports[`getFormFieldMarkup if \`props.locationOptions\` size is greater than 0 
   </FormField>
   <FormField
     className="location-dropdown"
+    width="three"
   >
     <Dropdown
       error={false}
@@ -58,12 +59,27 @@ exports[`getFormFieldMarkup if \`props.locationOptions\` size is greater than 0 
     />
   </FormField>
   <FormField
-    width="two"
+    width="three"
   >
     <NumberInput
       autoComplete={null}
       error={false}
-      icon="users"
+      icon={
+        <Icon
+          color={null}
+          hasBorder={false}
+          isButton={false}
+          isCircular={false}
+          isColorInverted={false}
+          isDisabled={false}
+          isLabelLeft={false}
+          labelText={null}
+          labelWeight={null}
+          name="users"
+          path={null}
+          size={null}
+        />
+      }
       isValid={false}
       label="Guests"
       min={0}
@@ -113,12 +129,27 @@ exports[`getFormFieldMarkup should render the right structure\` 1`] = `
     />
   </FormField>
   <FormField
-    width="two"
+    width="three"
   >
     <NumberInput
       autoComplete={null}
       error={false}
-      icon="users"
+      icon={
+        <Icon
+          color={null}
+          hasBorder={false}
+          isButton={false}
+          isCircular={false}
+          isColorInverted={false}
+          isDisabled={false}
+          isLabelLeft={false}
+          labelText={null}
+          labelWeight={null}
+          name="users"
+          path={null}
+          size={null}
+        />
+      }
       isValid={false}
       label="Guests"
       min={0}

--- a/src/components/general-widgets/SearchBar/utils/__snapshots__/getFormFieldMarkup.spec.js.snap
+++ b/src/components/general-widgets/SearchBar/utils/__snapshots__/getFormFieldMarkup.spec.js.snap
@@ -22,7 +22,6 @@ exports[`getFormFieldMarkup if \`props.locationOptions\` size is greater than 0 
   </FormField>
   <FormField
     className="location-dropdown"
-    width="three"
   >
     <Dropdown
       error={false}

--- a/src/components/general-widgets/SearchBar/utils/getFormFieldMarkup.js
+++ b/src/components/general-widgets/SearchBar/utils/getFormFieldMarkup.js
@@ -44,7 +44,7 @@ export const getFormFieldMarkup = (
   const summaryColumnWidth = areColumnsStacked ? 'twelve' : 'three';
   const datePickerColumnWidth = areColumnsStacked ? 'twelve' : 'seven';
   const buttonColumnWidth = areColumnsStacked ? 'twelve' : 'four';
-  const guestInputColumnWidth = areColumnsStacked ? 'twelve' : 'two';
+  const guestInputColumnWidth = areColumnsStacked ? 'twelve' : 'three';
 
   return (
     <Fragment>
@@ -86,7 +86,7 @@ export const getFormFieldMarkup = (
       </Form.Field>
       <Form.Field width={guestInputColumnWidth}>
         <NumberInput
-          icon={ICON_NAMES.USERS}
+          icon={<Icon name={ICON_NAMES.USERS} />}
           label="Guests"
           min={0}
           name="guests"

--- a/src/components/inputs/NumberInput/__snapshots__/component.spec.js.snap
+++ b/src/components/inputs/NumberInput/__snapshots__/component.spec.js.snap
@@ -4,6 +4,7 @@ exports[`<NumberInput /> should render the right structure 1`] = `
 <NumberInput
   autoComplete={null}
   error={false}
+  icon={null}
   isValid={false}
   label=""
   name=""

--- a/src/components/inputs/NumberInput/component.js
+++ b/src/components/inputs/NumberInput/component.js
@@ -10,6 +10,7 @@ import { InputController } from '../InputController';
 export const Component = ({
   autoComplete,
   error,
+  icon,
   isValid,
   label,
   max,
@@ -21,6 +22,7 @@ export const Component = ({
 }) => (
   <InputController
     error={error}
+    icon={icon}
     isValid={isValid}
     label={label}
     name={name}
@@ -43,6 +45,7 @@ Component.displayName = 'NumberInput';
 Component.defaultProps = {
   autoComplete: null,
   error: false,
+  icon: null,
   isValid: false,
   label: '',
   min: undefined,
@@ -58,6 +61,8 @@ Component.propTypes = {
   autoComplete: PropTypes.string,
   /** Is the number input in an error state. */
   error: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+  /** An icon to display in the input */
+  icon: PropTypes.element,
   /** Is the number input in a valid state. */
   isValid: PropTypes.bool,
   /** The visible label for the number input. */

--- a/src/components/property-page-widgets/PropertyPageSearchBar/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/PropertyPageSearchBar/__snapshots__/component.spec.js.snap
@@ -447,15 +447,30 @@ exports[`<PropertyPageSearchBar /> if \`isShowingPlaceholder\` === true should h
                                               </div>
                                             </FormField>
                                             <FormField
-                                              width="two"
+                                              width="three"
                                             >
                                               <div
-                                                className="two wide field"
+                                                className="three wide field"
                                               >
                                                 <NumberInput
                                                   autoComplete={null}
                                                   error={false}
-                                                  icon="users"
+                                                  icon={
+                                                    <Icon
+                                                      color={null}
+                                                      hasBorder={false}
+                                                      isButton={false}
+                                                      isCircular={false}
+                                                      isColorInverted={false}
+                                                      isDisabled={false}
+                                                      isLabelLeft={false}
+                                                      labelText={null}
+                                                      labelWeight={null}
+                                                      name="users"
+                                                      path={null}
+                                                      size={null}
+                                                    />
+                                                  }
                                                   isValid={false}
                                                   label="Guests"
                                                   min={0}
@@ -466,7 +481,22 @@ exports[`<PropertyPageSearchBar /> if \`isShowingPlaceholder\` === true should h
                                                   <InputController
                                                     adaptOnChangeEvent={[Function]}
                                                     error={false}
-                                                    icon={null}
+                                                    icon={
+                                                      <Icon
+                                                        color={null}
+                                                        hasBorder={false}
+                                                        isButton={false}
+                                                        isCircular={false}
+                                                        isColorInverted={false}
+                                                        isDisabled={false}
+                                                        isLabelLeft={false}
+                                                        labelText={null}
+                                                        labelWeight={null}
+                                                        name="users"
+                                                        path={null}
+                                                        size={null}
+                                                      />
+                                                    }
                                                     initialValue=""
                                                     inputOnChangeFunctionName="onChange"
                                                     isFluid={false}
@@ -480,11 +510,11 @@ exports[`<PropertyPageSearchBar /> if \`isShowingPlaceholder\` === true should h
                                                     <Input
                                                       className=""
                                                       fluid={false}
-                                                      iconPosition={null}
+                                                      iconPosition="left"
                                                       type="text"
                                                     >
                                                       <div
-                                                        className="ui input"
+                                                        className="ui left icon input"
                                                       >
                                                         <input
                                                           autoComplete={null}
@@ -502,6 +532,34 @@ exports[`<PropertyPageSearchBar /> if \`isShowingPlaceholder\` === true should h
                                                         >
                                                           Guests
                                                         </label>
+                                                        <Icon
+                                                          color={null}
+                                                          hasBorder={false}
+                                                          isButton={false}
+                                                          isCircular={false}
+                                                          isColorInverted={false}
+                                                          isDisabled={false}
+                                                          isLabelLeft={false}
+                                                          key=".4"
+                                                          labelText={null}
+                                                          labelWeight={null}
+                                                          name="users"
+                                                          path={null}
+                                                          size={null}
+                                                        >
+                                                          <i
+                                                            className="icon"
+                                                          >
+                                                            <svg
+                                                              viewBox="0 0 24 24"
+                                                            >
+                                                              <path
+                                                                d="M18.63,8.88h-.08a4,4,0,1,0-4.18,0h-.08a2.2,2.2,0,0,0-2.2,2.2v9.35a2.1,2.1,0,0,0,2.1,2.1h4.54a2.11,2.11,0,0,0,2.11-2.1V11.08A2.21,2.21,0,0,0,18.63,8.88Zm-5.18-3.4a3,3,0,1,1,3,3A3,3,0,0,1,13.45,5.48Zm6.39,15a1.11,1.11,0,0,1-1.11,1.1H14.19a1.1,1.1,0,0,1-1.1-1.1V11.08a1.2,1.2,0,0,1,1.2-1.2h4.34a1.21,1.21,0,0,1,1.21,1.2ZM9,11.89a3.27,3.27,0,1,0-3.77,0,2.21,2.21,0,0,0-2.09,2.19v6.24a2.12,2.12,0,0,0,2.11,2.11H9a2.11,2.11,0,0,0,2.1-2.11V14.08A2.21,2.21,0,0,0,9,11.89ZM7.13,7A2.27,2.27,0,1,1,4.87,9.24,2.27,2.27,0,0,1,7.13,7Zm3,13.35A1.11,1.11,0,0,1,9,21.43H5.27a1.11,1.11,0,0,1-1.11-1.11V14.08a1.21,1.21,0,0,1,1.21-1.2H8.9a1.2,1.2,0,0,1,1.2,1.2Z"
+                                                                fill="currentColor"
+                                                              />
+                                                            </svg>
+                                                          </i>
+                                                        </Icon>
                                                       </div>
                                                     </Input>
                                                   </InputController>
@@ -1530,15 +1588,30 @@ exports[`<PropertyPageSearchBar /> should have the right structure 1`] = `
                                               </div>
                                             </FormField>
                                             <FormField
-                                              width="two"
+                                              width="three"
                                             >
                                               <div
-                                                className="two wide field"
+                                                className="three wide field"
                                               >
                                                 <NumberInput
                                                   autoComplete={null}
                                                   error={false}
-                                                  icon="users"
+                                                  icon={
+                                                    <Icon
+                                                      color={null}
+                                                      hasBorder={false}
+                                                      isButton={false}
+                                                      isCircular={false}
+                                                      isColorInverted={false}
+                                                      isDisabled={false}
+                                                      isLabelLeft={false}
+                                                      labelText={null}
+                                                      labelWeight={null}
+                                                      name="users"
+                                                      path={null}
+                                                      size={null}
+                                                    />
+                                                  }
                                                   isValid={false}
                                                   label="Guests"
                                                   min={0}
@@ -1549,7 +1622,22 @@ exports[`<PropertyPageSearchBar /> should have the right structure 1`] = `
                                                   <InputController
                                                     adaptOnChangeEvent={[Function]}
                                                     error={false}
-                                                    icon={null}
+                                                    icon={
+                                                      <Icon
+                                                        color={null}
+                                                        hasBorder={false}
+                                                        isButton={false}
+                                                        isCircular={false}
+                                                        isColorInverted={false}
+                                                        isDisabled={false}
+                                                        isLabelLeft={false}
+                                                        labelText={null}
+                                                        labelWeight={null}
+                                                        name="users"
+                                                        path={null}
+                                                        size={null}
+                                                      />
+                                                    }
                                                     initialValue=""
                                                     inputOnChangeFunctionName="onChange"
                                                     isFluid={false}
@@ -1563,11 +1651,11 @@ exports[`<PropertyPageSearchBar /> should have the right structure 1`] = `
                                                     <Input
                                                       className=""
                                                       fluid={false}
-                                                      iconPosition={null}
+                                                      iconPosition="left"
                                                       type="text"
                                                     >
                                                       <div
-                                                        className="ui input"
+                                                        className="ui left icon input"
                                                       >
                                                         <input
                                                           autoComplete={null}
@@ -1585,6 +1673,34 @@ exports[`<PropertyPageSearchBar /> should have the right structure 1`] = `
                                                         >
                                                           Guests
                                                         </label>
+                                                        <Icon
+                                                          color={null}
+                                                          hasBorder={false}
+                                                          isButton={false}
+                                                          isCircular={false}
+                                                          isColorInverted={false}
+                                                          isDisabled={false}
+                                                          isLabelLeft={false}
+                                                          key=".4"
+                                                          labelText={null}
+                                                          labelWeight={null}
+                                                          name="users"
+                                                          path={null}
+                                                          size={null}
+                                                        >
+                                                          <i
+                                                            className="icon"
+                                                          >
+                                                            <svg
+                                                              viewBox="0 0 24 24"
+                                                            >
+                                                              <path
+                                                                d="M18.63,8.88h-.08a4,4,0,1,0-4.18,0h-.08a2.2,2.2,0,0,0-2.2,2.2v9.35a2.1,2.1,0,0,0,2.1,2.1h4.54a2.11,2.11,0,0,0,2.11-2.1V11.08A2.21,2.21,0,0,0,18.63,8.88Zm-5.18-3.4a3,3,0,1,1,3,3A3,3,0,0,1,13.45,5.48Zm6.39,15a1.11,1.11,0,0,1-1.11,1.1H14.19a1.1,1.1,0,0,1-1.1-1.1V11.08a1.2,1.2,0,0,1,1.2-1.2h4.34a1.21,1.21,0,0,1,1.21,1.2ZM9,11.89a3.27,3.27,0,1,0-3.77,0,2.21,2.21,0,0,0-2.09,2.19v6.24a2.12,2.12,0,0,0,2.11,2.11H9a2.11,2.11,0,0,0,2.1-2.11V14.08A2.21,2.21,0,0,0,9,11.89ZM7.13,7A2.27,2.27,0,1,1,4.87,9.24,2.27,2.27,0,0,1,7.13,7Zm3,13.35A1.11,1.11,0,0,1,9,21.43H5.27a1.11,1.11,0,0,1-1.11-1.11V14.08a1.21,1.21,0,0,1,1.21-1.2H8.9a1.2,1.2,0,0,1,1.2,1.2Z"
+                                                                fill="currentColor"
+                                                              />
+                                                            </svg>
+                                                          </i>
+                                                        </Icon>
                                                       </div>
                                                     </Input>
                                                   </InputController>

--- a/src/styles/semantic/themes/livingstone/elements/input.overrides
+++ b/src/styles/semantic/themes/livingstone/elements/input.overrides
@@ -28,6 +28,14 @@
     in `node_modules/semantic-ui-less/definitions/elements/input.less`
   */
   &.left.icon {
+    min-width: @iconMinWidth;
+
+    &:not(.dirty) > label {
+      width: @labelWidth;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
 
     & > i.icon {
       padding: @iconPadding;

--- a/src/styles/semantic/themes/livingstone/elements/input.variables
+++ b/src/styles/semantic/themes/livingstone/elements/input.variables
@@ -14,6 +14,7 @@
 
 /* Icon Input */
 @iconPadding: @8px @10px;
+@iconMinWidth: 80px;
 
 @flagIconXOffset: -(@7px);
 @flagIconYOffset: -(@5px);
@@ -26,6 +27,7 @@
 
 /* Labeled Input */
 @labelColor: @greySix;
+@labelWidth: 40%;
 @checkboxLabelColor: @black;
 @checkboxLabelLineHeight: @16px;
 @checkboxLabelLeftPosition: @22px;


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-2343)

### What **one** thing does this PR do?
Adds the missing `guests` icon to `SearchBar`.
### Before
<img width="717" alt="Screenshot 2019-06-11 at 17 13 24" src="https://user-images.githubusercontent.com/33876435/59285562-793f6600-8c6e-11e9-8f0d-1b60f33481df.png">

### After
<img width="832" alt="Screenshot 2019-06-11 at 17 45 04" src="https://user-images.githubusercontent.com/33876435/59287299-ab05fc00-8c71-11e9-869d-6986528b70aa.png">
<img width="973" alt="Screenshot 2019-06-11 at 17 53 21" src="https://user-images.githubusercontent.com/33876435/59287394-db4d9a80-8c71-11e9-865e-958c7c431d3e.png">


