### PR TITLE
TE-2340 Implement `PropertySearchResultList` on `all-properties` page

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,6 +42,12 @@ export { HTML } from './components/general-widgets/HTML';
 export { OwnerLogin } from './components/general-widgets/OwnerLogin';
 export { OwnerSignUp } from './components/general-widgets/OwnerSignUp';
 export { Promotion } from './components/general-widgets/Promotion';
+export {
+  PropertySearchResult,
+} from './components/general-widgets/PropertySearchResult';
+export {
+  PropertySearchResultList,
+} from './components/general-widgets/PropertySearchResultList';
 export { Review } from './components/general-widgets/Review';
 export { SearchBar } from './components/general-widgets/SearchBar';
 


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-2340)

### What **one** thing does this PR do?
Exposes `PropertySearchResultList`and `PropertySearchResult` so they can be consumed in `templates-ssr`

