### PR TITLE
TE-2378 DateRangePicker hover colours.

### DIFF
--- a/src/styles/semantic/definitions/third-party-components/react-dates-datepicker.less
+++ b/src/styles/semantic/definitions/third-party-components/react-dates-datepicker.less
@@ -142,11 +142,13 @@
       &.CalendarDay__default:hover,
       &.CalendarDay__selected_span,
       &.CalendarDay__hovered_span {
-        background: @pickerDayHoveredBackground;
+        background: @themeActionLighterColorDefault;
+        background: var(@themeActionLighterColorIdentifier, @themeActionLighterColorDefault);
         color: inherit;
 
         &.CalendarDay__blocked_calendar {
-          background: @pickerDayHoveredBackground;
+          background: @themeActionLighterColorDefault;
+          background: var(@themeActionLighterColorIdentifier, @themeActionLighterColorDefault);
           color: inherit;
 
           &:hover {
@@ -161,7 +163,8 @@
         &,
         &:active,
         &:hover {
-          background: @pickerDaySelectedBackground;
+          background: @themeActionColorDefault;
+          background: var(@themeActionColorIdentifier, @themeActionColorDefault);
           color: inherit;
         }
 
@@ -169,7 +172,8 @@
 
           &.CalendarDay__selected_start,
           &.CalendarDay__selected_end {
-            background: @pickerDaySelectedBackground;
+            background: @themeActionColorDefault;
+            background: var(@themeActionColorIdentifier, @themeActionColorDefault);
             color: inherit;
           }
         }
@@ -335,6 +339,7 @@
   }
 
   .DateRangePicker .DateRangePickerInput input.DateInput_input__focused {
+    border-bottom: @inputFocusedBorderBottomPrimary;
     border-bottom: @inputFocusedBorderBottom;
     margin-bottom: @inputFocusedMarginBottom;
     padding-bottom: @inputFocusedPaddingBottom;

--- a/src/styles/semantic/themes/default/third-party-components/react-dates-datepicker.variables
+++ b/src/styles/semantic/themes/default/third-party-components/react-dates-datepicker.variables
@@ -75,7 +75,8 @@
 
 /* Focus */
 @InputFocusedBorderBottomWidth: @3px;
-@inputFocusedBorderBottom: @InputFocusedBorderBottomWidth solid @primaryColor !important;
+@inputFocusedBorderBottomPrimary: @InputFocusedBorderBottomWidth solid @primaryColor !important;
+@inputFocusedBorderBottom: @InputFocusedBorderBottomWidth solid var(@themeActionColorIdentifier, @themeActionColorDefault) !important;
 @inputFocusedMarginBottom: -(@1px);
 @inputFocusedBorderBottomOffset: (@InputFocusedBorderBottomWidth + @inputFocusedMarginBottom);
 @inputFocusedPaddingBottom: (@verticalPadding - @inputBorderOffset - @inputFocusedBorderBottomOffset);

--- a/src/styles/semantic/themes/livingstone/modules/checkbox.overrides
+++ b/src/styles/semantic/themes/livingstone/modules/checkbox.overrides
@@ -11,6 +11,11 @@
     user-select: none;
   }
 
+  &.toggle input[type="checkbox"] + label:before {
+    background-color: @themeActionColorDefault !important;
+    background-color: var(@themeActionColorIdentifier, @themeActionColorDefault) !important;
+  }
+
   input {
 
     & ~ label {
@@ -29,6 +34,11 @@
 
     & ~ label {
       font-weight: bold;
+
+      &:before {
+        background-color: @themeActionColorDefault !important;
+        background-color: var(@themeActionColorIdentifier, @themeActionColorDefault) !important;
+      }
     }
   }
 


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-2378)

### What **one** thing does this PR do?
Configures `DateRangePicker` to take the theme colours if they're set.

### Any other notes

#### Active Start/End dates
<img width="1440" alt="Active-Start:End-Date" src="https://user-images.githubusercontent.com/33876435/60111738-d1965d80-976e-11e9-9140-29841859c122.png">

#### Selected Days
<img width="1430" alt="selected-day" src="https://user-images.githubusercontent.com/33876435/60111743-d1965d80-976e-11e9-9fec-f4e86e85fc20.png">

#### Selected Blocked Dates 
<img width="1440" alt="blocked-date-no-hover" src="https://user-images.githubusercontent.com/33876435/60111740-d1965d80-976e-11e9-8938-d46536144d71.png">

#### Selected Blocked Dates Hover
<img width="1440" alt="Blocked-Day-hover" src="https://user-images.githubusercontent.com/33876435/60111741-d1965d80-976e-11e9-94c0-440427697081.png">

#### Focussed input border
<img width="1461" alt="border-bottom" src="https://user-images.githubusercontent.com/33876435/60188058-f7833700-982e-11e9-92b9-6d44137453a8.png">

#### Checkboxes 
<img width="1461" alt="toggle" src="https://user-images.githubusercontent.com/33876435/60190421-e9371a00-9832-11e9-879f-d6b2c6b6f649.png">

<img width="1440" alt="checkbox" src="https://user-images.githubusercontent.com/33876435/60190510-079d1580-9833-11e9-916e-3d38e93f2171.png">

