### PR TITLE
TE-2364 HTML: set overflow to auto rather than scroll to hide scrollbar where pos…

### DIFF
--- a/src/styles/semantic/definitions/lodgify-ui-components/html.less
+++ b/src/styles/semantic/definitions/lodgify-ui-components/html.less
@@ -13,7 +13,7 @@
 -----------------------*/
 
 .html-container {
-  overflow-x: scroll;
+  overflow-x: auto;
 
   > img {
     max-width: @htmlContainerImmediateImageChildMaxWidth;


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-X)

### What **one** thing does this PR do?
`HTML`: set overflow to auto rather than scroll to hide scrollbar where possible

### Any other notes
The fix I did for TE-2364 had an unintended consequence for content which already respects the width of the `.html-container` element. This change puts us in a better position in each case.
