### PR TITLE
TE-2406 Hero: show dropdown above other elements

### DIFF
--- a/src/styles/semantic/themes/livingstone/elements/segment.variables
+++ b/src/styles/semantic/themes/livingstone/elements/segment.variables
@@ -93,7 +93,7 @@
 @promotionContentLayerZIndex: @promotionAfterLayerZIndex + 1;
 
 /* Is Hero */
-@heroZIndex: @zIndexLevelOne;
+@heroZIndex: @zIndexLevelOne + 1;
 @heroImageZIndex: @heroZIndex + 1;
 @heroGradientZIndex: @heroImageZIndex + 1;
 @heroContentZIndex: @heroGradientZIndex + 1;


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-2406)

### What **one** thing does this PR do?
Bumps any `Hero` up one z-index so that its children show above `Hero`'s lower siblings.
