### PR TITLE
TE-2407 Logo subtitle font

### DIFF
--- a/src/styles/semantic/themes/livingstone/globals/site.overrides
+++ b/src/styles/semantic/themes/livingstone/globals/site.overrides
@@ -17,6 +17,13 @@ input::placeholder,
   font-family: @bodyFont;
 }
 
+.has-sub-text {
+
+  p {
+    font-family: var(@subtitleFontIdentifier, @subtitleFontDefault) !important;
+  }
+}
+
 /*-------------------
       Base Sizes
 --------------------*/


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-2407)

### What **one** thing does this PR do?
Logo sub title text takes the sub title font variable value. It is the only text which uses this variable.

### Any other notes
![Kapture 2019-06-27 at 13 11 03](https://user-images.githubusercontent.com/10498995/60261982-68812800-98dd-11e9-9e4c-954ff253fabd.gif)
