### PR TITLE
TE-2393 "Lazy" images are being loaded on page load anyway

### DIFF
--- a/src/components/collections/Hero/__snapshots__/component.spec.js.snap
+++ b/src/components/collections/Hero/__snapshots__/component.spec.js.snap
@@ -78,7 +78,6 @@ exports[`<Hero /> by default should render the right structure 1`] = `
                 "imageWidth": undefined,
                 "isFluid": true,
                 "isLazyLoaded": true,
-                "placeholderImageUrl": null,
                 "sizes": "a load of sizes",
                 "srcSet": "a load of sources",
               }
@@ -87,6 +86,7 @@ exports[`<Hero /> by default should render the right structure 1`] = `
             lazyProps={
               Object {
                 "imageUrl": "https://darkpurple.com",
+                "placeholderImageUrl": null,
               }
             }
           >

--- a/src/components/general-widgets/FeaturedProperties/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/FeaturedProperties/__snapshots__/component.spec.js.snap
@@ -68,7 +68,6 @@ exports[`<FeaturedProperties /> by default should render the right structure 1`]
                 "alternativeText": undefined,
                 "isFluid": true,
                 "isLazyLoaded": true,
-                "placeholderImageUrl": undefined,
                 "sizes": undefined,
                 "srcSet": undefined,
               }
@@ -77,6 +76,7 @@ exports[`<FeaturedProperties /> by default should render the right structure 1`]
             lazyProps={
               Object {
                 "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
+                "placeholderImageUrl": undefined,
               }
             }
           >
@@ -403,7 +403,6 @@ exports[`<FeaturedProperties /> by default should render the right structure 1`]
                 "alternativeText": undefined,
                 "isFluid": true,
                 "isLazyLoaded": true,
-                "placeholderImageUrl": undefined,
                 "sizes": undefined,
                 "srcSet": undefined,
               }
@@ -412,6 +411,7 @@ exports[`<FeaturedProperties /> by default should render the right structure 1`]
             lazyProps={
               Object {
                 "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
+                "placeholderImageUrl": undefined,
               }
             }
           >
@@ -792,7 +792,6 @@ exports[`<FeaturedProperties /> if \`props.headingText\` is passed should render
                 "alternativeText": undefined,
                 "isFluid": true,
                 "isLazyLoaded": true,
-                "placeholderImageUrl": undefined,
                 "sizes": undefined,
                 "srcSet": undefined,
               }
@@ -801,6 +800,7 @@ exports[`<FeaturedProperties /> if \`props.headingText\` is passed should render
             lazyProps={
               Object {
                 "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
+                "placeholderImageUrl": undefined,
               }
             }
           >
@@ -1127,7 +1127,6 @@ exports[`<FeaturedProperties /> if \`props.headingText\` is passed should render
                 "alternativeText": undefined,
                 "isFluid": true,
                 "isLazyLoaded": true,
-                "placeholderImageUrl": undefined,
                 "sizes": undefined,
                 "srcSet": undefined,
               }
@@ -1136,6 +1135,7 @@ exports[`<FeaturedProperties /> if \`props.headingText\` is passed should render
             lazyProps={
               Object {
                 "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
+                "placeholderImageUrl": undefined,
               }
             }
           >

--- a/src/components/general-widgets/FeaturedRoomTypes/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/FeaturedRoomTypes/__snapshots__/component.spec.js.snap
@@ -67,7 +67,6 @@ exports[`<FeaturedRoomTypes /> by default should render the right structure 1`] 
                 "alternativeText": undefined,
                 "isFluid": true,
                 "isLazyLoaded": true,
-                "placeholderImageUrl": undefined,
                 "sizes": undefined,
                 "srcSet": undefined,
               }
@@ -76,6 +75,7 @@ exports[`<FeaturedRoomTypes /> by default should render the right structure 1`] 
             lazyProps={
               Object {
                 "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
+                "placeholderImageUrl": undefined,
               }
             }
           >
@@ -243,7 +243,6 @@ exports[`<FeaturedRoomTypes /> by default should render the right structure 1`] 
                 "alternativeText": undefined,
                 "isFluid": true,
                 "isLazyLoaded": true,
-                "placeholderImageUrl": undefined,
                 "sizes": undefined,
                 "srcSet": undefined,
               }
@@ -252,6 +251,7 @@ exports[`<FeaturedRoomTypes /> by default should render the right structure 1`] 
             lazyProps={
               Object {
                 "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
+                "placeholderImageUrl": undefined,
               }
             }
           >
@@ -747,7 +747,6 @@ exports[`<FeaturedRoomTypes /> if \`props.headingText\` is passed should render 
                 "alternativeText": undefined,
                 "isFluid": true,
                 "isLazyLoaded": true,
-                "placeholderImageUrl": undefined,
                 "sizes": undefined,
                 "srcSet": undefined,
               }
@@ -756,6 +755,7 @@ exports[`<FeaturedRoomTypes /> if \`props.headingText\` is passed should render 
             lazyProps={
               Object {
                 "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
+                "placeholderImageUrl": undefined,
               }
             }
           >
@@ -923,7 +923,6 @@ exports[`<FeaturedRoomTypes /> if \`props.headingText\` is passed should render 
                 "alternativeText": undefined,
                 "isFluid": true,
                 "isLazyLoaded": true,
-                "placeholderImageUrl": undefined,
                 "sizes": undefined,
                 "srcSet": undefined,
               }
@@ -932,6 +931,7 @@ exports[`<FeaturedRoomTypes /> if \`props.headingText\` is passed should render 
             lazyProps={
               Object {
                 "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
+                "placeholderImageUrl": undefined,
               }
             }
           >

--- a/src/components/general-widgets/HomepageHero/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/HomepageHero/__snapshots__/component.spec.js.snap
@@ -111,7 +111,6 @@ exports[`HomepageHero should render the right structure 1`] = `
                   "imageWidth": undefined,
                   "isFluid": true,
                   "isLazyLoaded": true,
-                  "placeholderImageUrl": null,
                   "sizes": "url",
                   "srcSet": "a load of sizes",
                 }
@@ -120,6 +119,7 @@ exports[`HomepageHero should render the right structure 1`] = `
               lazyProps={
                 Object {
                   "imageUrl": "bare sources",
+                  "placeholderImageUrl": null,
                 }
               }
             >

--- a/src/components/general-widgets/Promotion/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/Promotion/__snapshots__/component.spec.js.snap
@@ -75,7 +75,6 @@ exports[`The \`Promotion\` component if \`backgroundImageUrl\` prop is passed sh
                                 "imageHeight": undefined,
                                 "imageWidth": undefined,
                                 "isLazyLoaded": true,
-                                "placeholderImageUrl": null,
                                 "sizes": undefined,
                                 "srcSet": undefined,
                               }
@@ -84,6 +83,7 @@ exports[`The \`Promotion\` component if \`backgroundImageUrl\` prop is passed sh
                             lazyProps={
                               Object {
                                 "imageUrl": "testimage",
+                                "placeholderImageUrl": null,
                               }
                             }
                           >

--- a/src/components/media/FullBleed/__snapshots__/component.spec.js.snap
+++ b/src/components/media/FullBleed/__snapshots__/component.spec.js.snap
@@ -41,7 +41,6 @@ exports[`<FullBleed /> by default should have the right structure 1`] = `
               "imageWidth": undefined,
               "isFluid": true,
               "isLazyLoaded": true,
-              "placeholderImageUrl": null,
               "sizes": null,
               "srcSet": null,
             }
@@ -50,6 +49,7 @@ exports[`<FullBleed /> by default should have the right structure 1`] = `
           lazyProps={
             Object {
               "imageUrl": "🐱🐱",
+              "placeholderImageUrl": null,
             }
           }
         >
@@ -147,7 +147,6 @@ exports[`<FullBleed /> if \`hasGradient\` is passed should have the right struct
               "imageWidth": undefined,
               "isFluid": true,
               "isLazyLoaded": true,
-              "placeholderImageUrl": null,
               "sizes": null,
               "srcSet": null,
             }
@@ -156,6 +155,7 @@ exports[`<FullBleed /> if \`hasGradient\` is passed should have the right struct
           lazyProps={
             Object {
               "imageUrl": "🐱🐱",
+              "placeholderImageUrl": null,
             }
           }
         >
@@ -253,7 +253,6 @@ exports[`<FullBleed /> if \`props.children > 0\` should have the right structure
               "imageWidth": undefined,
               "isFluid": true,
               "isLazyLoaded": true,
-              "placeholderImageUrl": null,
               "sizes": null,
               "srcSet": null,
             }
@@ -262,6 +261,7 @@ exports[`<FullBleed /> if \`props.children > 0\` should have the right structure
           lazyProps={
             Object {
               "imageUrl": "🐱🐱",
+              "placeholderImageUrl": null,
             }
           }
         >

--- a/src/components/media/ResponsiveImage/__snapshots__/component.spec.js.snap
+++ b/src/components/media/ResponsiveImage/__snapshots__/component.spec.js.snap
@@ -26,6 +26,7 @@ exports[`<ResponsiveImage /> by default should have the right structure 1`] = `
     lazyProps={
       Object {
         "imageUrl": undefined,
+        "placeholderImageUrl": undefined,
       }
     }
   >
@@ -188,6 +189,7 @@ exports[`<ResponsiveImage /> if \`props.label\` is passed should have the right 
     lazyProps={
       Object {
         "imageUrl": undefined,
+        "placeholderImageUrl": undefined,
       }
     }
   >
@@ -283,7 +285,6 @@ exports[`<ResponsiveImage /> if \`props.placeholderImageUrl\` is passed should h
         "isFluid": true,
         "isLazyLoaded": true,
         "onLoad": [Function],
-        "placeholderImageUrl": "ayyy",
         "sources": Array [],
       }
     }
@@ -291,6 +292,7 @@ exports[`<ResponsiveImage /> if \`props.placeholderImageUrl\` is passed should h
     lazyProps={
       Object {
         "imageUrl": undefined,
+        "placeholderImageUrl": "ayyy",
       }
     }
   >

--- a/src/components/media/ResponsiveImage/component.js
+++ b/src/components/media/ResponsiveImage/component.js
@@ -10,6 +10,7 @@ import {
 } from 'utils/default-strings';
 import { Paragraph } from 'typography/Paragraph';
 
+import { IMAGE_URL, PLACEHOLDER_IMAGE_URL } from './constants';
 import { getImageMarkup } from './utils/getImageMarkup';
 import { getPlaceholderImageMarkup } from './utils/getPlaceholderImageMarkup';
 
@@ -137,4 +138,7 @@ Component.propTypes = {
   srcSet: PropTypes.string,
 };
 
-export const ComponentWithLazyLoad = withLazyLoad('imageUrl')(Component);
+export const ComponentWithLazyLoad = withLazyLoad(
+  IMAGE_URL,
+  PLACEHOLDER_IMAGE_URL
+)(Component);

--- a/src/components/media/ResponsiveImage/component.spec.js
+++ b/src/components/media/ResponsiveImage/component.spec.js
@@ -15,8 +15,8 @@ const props = {
 const getResponsiveImage = extraProps =>
   mount(<ResponsiveImage {...props} {...extraProps} />);
 
-const getWrappedResponsiveImage = () =>
-  getResponsiveImage().find('ResponsiveImage');
+const getWrappedResponsiveImage = extraProps =>
+  getResponsiveImage(extraProps).find('ResponsiveImage');
 
 describe('<ResponsiveImage />', () => {
   describe('by default', () => {
@@ -34,6 +34,35 @@ describe('<ResponsiveImage />', () => {
       });
 
       expect(actual).toMatchSnapshot();
+    });
+
+    it('should call the Image constructor', () => {
+      const wrapper = getWrappedResponsiveImage({
+        placeholderImageUrl: 'ayyy',
+      });
+
+      global.Image = jest.fn();
+
+      wrapper.instance().componentDidMount();
+
+      expect(global.Image).toHaveBeenCalled();
+    });
+
+    it('should call setState with the right arguments', () => {
+      const wrapper = getWrappedResponsiveImage({
+        placeholderImageUrl: 'ayyy',
+      });
+
+      global.Image = jest.fn(() => ({ complete: true }));
+
+      wrapper.instance().setState = jest.fn();
+      wrapper.update();
+      wrapper.instance().componentDidMount();
+
+      expect(wrapper.instance().setState).toHaveBeenCalledWith({
+        shouldImageLoad: true,
+        isImageLoaded: true,
+      });
     });
   });
 

--- a/src/components/media/ResponsiveImage/constants.js
+++ b/src/components/media/ResponsiveImage/constants.js
@@ -1,0 +1,2 @@
+export const IMAGE_URL = 'imageUrl';
+export const PLACEHOLDER_IMAGE_URL = 'placeholderImageUrl';

--- a/src/components/media/Thumbnail/__snapshots__/component.spec.js.snap
+++ b/src/components/media/Thumbnail/__snapshots__/component.spec.js.snap
@@ -37,6 +37,7 @@ exports[`<Thumbnail /> by default should render the right structure 1`] = `
         lazyProps={
           Object {
             "imageUrl": "www.⚡️.net",
+            "placeholderImageUrl": undefined,
           }
         }
       >
@@ -129,6 +130,7 @@ exports[`<Thumbnail /> if \`props.isCircular\` is true should render the right s
         lazyProps={
           Object {
             "imageUrl": "www.⚡️.net",
+            "placeholderImageUrl": undefined,
           }
         }
       >
@@ -221,6 +223,7 @@ exports[`<Thumbnail /> if \`props.isSquare\` is true should render the right str
         lazyProps={
           Object {
             "imageUrl": "www.⚡️.net",
+            "placeholderImageUrl": undefined,
           }
         }
       >
@@ -313,6 +316,7 @@ exports[`<Thumbnail /> if \`props.size\` is supplied should render the right str
         lazyProps={
           Object {
             "imageUrl": "www.⚡️.net",
+            "placeholderImageUrl": undefined,
           }
         }
       >

--- a/src/components/property-page-widgets/HostProfile/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/HostProfile/__snapshots__/component.spec.js.snap
@@ -151,6 +151,7 @@ exports[`<HostProfile /> if \`props.email\` is defined should render the right s
                                 lazyProps={
                                   Object {
                                     "imageUrl": "https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max",
+                                    "placeholderImageUrl": undefined,
                                   }
                                 }
                               >
@@ -504,6 +505,7 @@ exports[`<HostProfile /> if \`props.languages\` is defined should render the rig
                                 lazyProps={
                                   Object {
                                     "imageUrl": "https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max",
+                                    "placeholderImageUrl": undefined,
                                   }
                                 }
                               >
@@ -850,6 +852,7 @@ exports[`<HostProfile /> if \`props.phone\` is defined should render the right s
                                 lazyProps={
                                   Object {
                                     "imageUrl": "https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max",
+                                    "placeholderImageUrl": undefined,
                                   }
                                 }
                               >
@@ -1200,6 +1203,7 @@ exports[`<HostProfile /> should render the right structure 1`] = `
                                 lazyProps={
                                   Object {
                                     "imageUrl": "https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max",
+                                    "placeholderImageUrl": undefined,
                                   }
                                 }
                               >

--- a/src/components/property-page-widgets/Pictures/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Pictures/__snapshots__/component.spec.js.snap
@@ -181,6 +181,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                                 lazyProps={
                                   Object {
                                     "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max",
+                                    "placeholderImageUrl": undefined,
                                   }
                                 }
                               >
@@ -293,6 +294,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                                 lazyProps={
                                   Object {
                                     "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max",
+                                    "placeholderImageUrl": undefined,
                                   }
                                 }
                               >
@@ -435,6 +437,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                                 lazyProps={
                                   Object {
                                     "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max",
+                                    "placeholderImageUrl": undefined,
                                   }
                                 }
                               >
@@ -547,6 +550,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                                 lazyProps={
                                   Object {
                                     "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max",
+                                    "placeholderImageUrl": undefined,
                                   }
                                 }
                               >
@@ -689,6 +693,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                                 lazyProps={
                                   Object {
                                     "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max",
+                                    "placeholderImageUrl": undefined,
                                   }
                                 }
                               >
@@ -801,6 +806,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                                 lazyProps={
                                   Object {
                                     "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max",
+                                    "placeholderImageUrl": undefined,
                                   }
                                 }
                               >
@@ -943,6 +949,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                                 lazyProps={
                                   Object {
                                     "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max",
+                                    "placeholderImageUrl": undefined,
                                   }
                                 }
                               >
@@ -1055,6 +1062,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                                 lazyProps={
                                   Object {
                                     "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max",
+                                    "placeholderImageUrl": undefined,
                                   }
                                 }
                               >
@@ -1197,6 +1205,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                                 lazyProps={
                                   Object {
                                     "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max",
+                                    "placeholderImageUrl": undefined,
                                   }
                                 }
                               >
@@ -1309,6 +1318,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                                 lazyProps={
                                   Object {
                                     "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max",
+                                    "placeholderImageUrl": undefined,
                                   }
                                 }
                               >

--- a/src/components/property-page-widgets/PropertyPageHero/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/PropertyPageHero/__snapshots__/component.spec.js.snap
@@ -101,7 +101,6 @@ exports[`PropertyPageHero if there are fewer than two items in \`galleryImages\`
                   "imageWidth": undefined,
                   "isFluid": true,
                   "isLazyLoaded": true,
-                  "placeholderImageUrl": null,
                   "sizes": null,
                   "srcSet": null,
                 }
@@ -110,6 +109,7 @@ exports[`PropertyPageHero if there are fewer than two items in \`galleryImages\`
               lazyProps={
                 Object {
                   "imageUrl": "some url",
+                  "placeholderImageUrl": null,
                 }
               }
             >
@@ -447,7 +447,6 @@ exports[`PropertyPageHero should render the right structure 1`] = `
                   "imageWidth": undefined,
                   "isFluid": true,
                   "isLazyLoaded": true,
-                  "placeholderImageUrl": null,
                   "sizes": null,
                   "srcSet": null,
                 }
@@ -456,6 +455,7 @@ exports[`PropertyPageHero should render the right structure 1`] = `
               lazyProps={
                 Object {
                   "imageUrl": "some url",
+                  "placeholderImageUrl": null,
                 }
               }
             >


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-2393)

### What **one** thing does this PR do?
For `ResponsiveImage`, lazyLoads `placeholderImageUrl`, this preventing it from loading on page load. 


### Before
<img width="1169" alt="image (4)" src="https://user-images.githubusercontent.com/33876435/60445509-a0f76d80-9c1f-11e9-9e92-99e3cb515494.png">


### After
![cutcap](https://user-images.githubusercontent.com/33876435/60445277-334b4180-9c1f-11e9-8719-1b43464d3005.gif)

