### PR TITLE
TE-2393 "Lazy" images are being loaded if component offset is zero

### DIFF
--- a/src/components/collections/Hero/__snapshots__/component.spec.js.snap
+++ b/src/components/collections/Hero/__snapshots__/component.spec.js.snap
@@ -97,14 +97,13 @@ exports[`<Hero /> by default should render the right structure 1`] = `
               imageHeight={null}
               imageNotFoundLabelText="Image not found!"
               imageTitle="Image Title"
-              imageUrl="https://darkpurple.com"
+              imageUrl=""
               imageWidth={null}
               isAvatar={false}
               isCircular={false}
               isFluid={true}
               isLazyLoaded={true}
               label={null}
-              placeholderImageUrl={null}
               sizes="a load of sizes"
               srcSet="a load of sources"
             >
@@ -118,20 +117,31 @@ exports[`<Hero /> by default should render the right structure 1`] = `
                   fluid={true}
                   onLoad={[Function]}
                   sizes="a load of sizes"
-                  src="https://darkpurple.com"
+                  src=""
                   srcSet="a load of sources"
                   title="Image Title"
                   ui={true}
                 >
-                  <img
+                  <div
                     alt="Image Widget"
                     className="ui fluid image"
                     onLoad={[Function]}
                     sizes="a load of sizes"
-                    src="https://darkpurple.com"
+                    src=""
                     srcSet="a load of sources"
                     title="Image Title"
-                  />
+                  >
+                    <Label
+                      content="Image not found!"
+                    >
+                      <div
+                        className="ui label"
+                        onClick={[Function]}
+                      >
+                        Image not found!
+                      </div>
+                    </Label>
+                  </div>
                 </Image>
               </figure>
             </ResponsiveImage>

--- a/src/components/general-widgets/FeaturedProperties/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/FeaturedProperties/__snapshots__/component.spec.js.snap
@@ -87,7 +87,7 @@ exports[`<FeaturedProperties /> by default should render the right structure 1`]
               imageHeight={null}
               imageNotFoundLabelText="Image not found!"
               imageTitle="Image Title"
-              imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
+              imageUrl=""
               imageWidth={null}
               isAvatar={false}
               isCircular={false}
@@ -107,20 +107,31 @@ exports[`<FeaturedProperties /> by default should render the right structure 1`]
                   fluid={true}
                   onLoad={[Function]}
                   sizes={null}
-                  src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
+                  src=""
                   srcSet={null}
                   title="Image Title"
                   ui={true}
                 >
-                  <img
+                  <div
                     alt="Image Widget"
                     className="ui fluid image"
                     onLoad={[Function]}
                     sizes={null}
-                    src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
+                    src=""
                     srcSet={null}
                     title="Image Title"
-                  />
+                  >
+                    <Label
+                      content="Image not found!"
+                    >
+                      <div
+                        className="ui label"
+                        onClick={[Function]}
+                      >
+                        Image not found!
+                      </div>
+                    </Label>
+                  </div>
                 </Image>
               </figure>
             </ResponsiveImage>
@@ -422,7 +433,7 @@ exports[`<FeaturedProperties /> by default should render the right structure 1`]
               imageHeight={null}
               imageNotFoundLabelText="Image not found!"
               imageTitle="Image Title"
-              imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
+              imageUrl=""
               imageWidth={null}
               isAvatar={false}
               isCircular={false}
@@ -442,20 +453,31 @@ exports[`<FeaturedProperties /> by default should render the right structure 1`]
                   fluid={true}
                   onLoad={[Function]}
                   sizes={null}
-                  src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
+                  src=""
                   srcSet={null}
                   title="Image Title"
                   ui={true}
                 >
-                  <img
+                  <div
                     alt="Image Widget"
                     className="ui fluid image"
                     onLoad={[Function]}
                     sizes={null}
-                    src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
+                    src=""
                     srcSet={null}
                     title="Image Title"
-                  />
+                  >
+                    <Label
+                      content="Image not found!"
+                    >
+                      <div
+                        className="ui label"
+                        onClick={[Function]}
+                      >
+                        Image not found!
+                      </div>
+                    </Label>
+                  </div>
                 </Image>
               </figure>
             </ResponsiveImage>
@@ -811,7 +833,7 @@ exports[`<FeaturedProperties /> if \`props.headingText\` is passed should render
               imageHeight={null}
               imageNotFoundLabelText="Image not found!"
               imageTitle="Image Title"
-              imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
+              imageUrl=""
               imageWidth={null}
               isAvatar={false}
               isCircular={false}
@@ -831,20 +853,31 @@ exports[`<FeaturedProperties /> if \`props.headingText\` is passed should render
                   fluid={true}
                   onLoad={[Function]}
                   sizes={null}
-                  src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
+                  src=""
                   srcSet={null}
                   title="Image Title"
                   ui={true}
                 >
-                  <img
+                  <div
                     alt="Image Widget"
                     className="ui fluid image"
                     onLoad={[Function]}
                     sizes={null}
-                    src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
+                    src=""
                     srcSet={null}
                     title="Image Title"
-                  />
+                  >
+                    <Label
+                      content="Image not found!"
+                    >
+                      <div
+                        className="ui label"
+                        onClick={[Function]}
+                      >
+                        Image not found!
+                      </div>
+                    </Label>
+                  </div>
                 </Image>
               </figure>
             </ResponsiveImage>
@@ -1146,7 +1179,7 @@ exports[`<FeaturedProperties /> if \`props.headingText\` is passed should render
               imageHeight={null}
               imageNotFoundLabelText="Image not found!"
               imageTitle="Image Title"
-              imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
+              imageUrl=""
               imageWidth={null}
               isAvatar={false}
               isCircular={false}
@@ -1166,20 +1199,31 @@ exports[`<FeaturedProperties /> if \`props.headingText\` is passed should render
                   fluid={true}
                   onLoad={[Function]}
                   sizes={null}
-                  src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
+                  src=""
                   srcSet={null}
                   title="Image Title"
                   ui={true}
                 >
-                  <img
+                  <div
                     alt="Image Widget"
                     className="ui fluid image"
                     onLoad={[Function]}
                     sizes={null}
-                    src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
+                    src=""
                     srcSet={null}
                     title="Image Title"
-                  />
+                  >
+                    <Label
+                      content="Image not found!"
+                    >
+                      <div
+                        className="ui label"
+                        onClick={[Function]}
+                      >
+                        Image not found!
+                      </div>
+                    </Label>
+                  </div>
                 </Image>
               </figure>
             </ResponsiveImage>

--- a/src/components/general-widgets/FeaturedRoomTypes/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/FeaturedRoomTypes/__snapshots__/component.spec.js.snap
@@ -86,7 +86,7 @@ exports[`<FeaturedRoomTypes /> by default should render the right structure 1`] 
               imageHeight={null}
               imageNotFoundLabelText="Image not found!"
               imageTitle="Image Title"
-              imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
+              imageUrl=""
               imageWidth={null}
               isAvatar={false}
               isCircular={false}
@@ -106,20 +106,31 @@ exports[`<FeaturedRoomTypes /> by default should render the right structure 1`] 
                   fluid={true}
                   onLoad={[Function]}
                   sizes={null}
-                  src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
+                  src=""
                   srcSet={null}
                   title="Image Title"
                   ui={true}
                 >
-                  <img
+                  <div
                     alt="Image Widget"
                     className="ui fluid image"
                     onLoad={[Function]}
                     sizes={null}
-                    src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
+                    src=""
                     srcSet={null}
                     title="Image Title"
-                  />
+                  >
+                    <Label
+                      content="Image not found!"
+                    >
+                      <div
+                        className="ui label"
+                        onClick={[Function]}
+                      >
+                        Image not found!
+                      </div>
+                    </Label>
+                  </div>
                 </Image>
               </figure>
             </ResponsiveImage>
@@ -262,7 +273,7 @@ exports[`<FeaturedRoomTypes /> by default should render the right structure 1`] 
               imageHeight={null}
               imageNotFoundLabelText="Image not found!"
               imageTitle="Image Title"
-              imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
+              imageUrl=""
               imageWidth={null}
               isAvatar={false}
               isCircular={false}
@@ -282,20 +293,31 @@ exports[`<FeaturedRoomTypes /> by default should render the right structure 1`] 
                   fluid={true}
                   onLoad={[Function]}
                   sizes={null}
-                  src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
+                  src=""
                   srcSet={null}
                   title="Image Title"
                   ui={true}
                 >
-                  <img
+                  <div
                     alt="Image Widget"
                     className="ui fluid image"
                     onLoad={[Function]}
                     sizes={null}
-                    src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
+                    src=""
                     srcSet={null}
                     title="Image Title"
-                  />
+                  >
+                    <Label
+                      content="Image not found!"
+                    >
+                      <div
+                        className="ui label"
+                        onClick={[Function]}
+                      >
+                        Image not found!
+                      </div>
+                    </Label>
+                  </div>
                 </Image>
               </figure>
             </ResponsiveImage>
@@ -766,7 +788,7 @@ exports[`<FeaturedRoomTypes /> if \`props.headingText\` is passed should render 
               imageHeight={null}
               imageNotFoundLabelText="Image not found!"
               imageTitle="Image Title"
-              imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
+              imageUrl=""
               imageWidth={null}
               isAvatar={false}
               isCircular={false}
@@ -786,20 +808,31 @@ exports[`<FeaturedRoomTypes /> if \`props.headingText\` is passed should render 
                   fluid={true}
                   onLoad={[Function]}
                   sizes={null}
-                  src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
+                  src=""
                   srcSet={null}
                   title="Image Title"
                   ui={true}
                 >
-                  <img
+                  <div
                     alt="Image Widget"
                     className="ui fluid image"
                     onLoad={[Function]}
                     sizes={null}
-                    src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
+                    src=""
                     srcSet={null}
                     title="Image Title"
-                  />
+                  >
+                    <Label
+                      content="Image not found!"
+                    >
+                      <div
+                        className="ui label"
+                        onClick={[Function]}
+                      >
+                        Image not found!
+                      </div>
+                    </Label>
+                  </div>
                 </Image>
               </figure>
             </ResponsiveImage>
@@ -942,7 +975,7 @@ exports[`<FeaturedRoomTypes /> if \`props.headingText\` is passed should render 
               imageHeight={null}
               imageNotFoundLabelText="Image not found!"
               imageTitle="Image Title"
-              imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
+              imageUrl=""
               imageWidth={null}
               isAvatar={false}
               isCircular={false}
@@ -962,20 +995,31 @@ exports[`<FeaturedRoomTypes /> if \`props.headingText\` is passed should render 
                   fluid={true}
                   onLoad={[Function]}
                   sizes={null}
-                  src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
+                  src=""
                   srcSet={null}
                   title="Image Title"
                   ui={true}
                 >
-                  <img
+                  <div
                     alt="Image Widget"
                     className="ui fluid image"
                     onLoad={[Function]}
                     sizes={null}
-                    src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
+                    src=""
                     srcSet={null}
                     title="Image Title"
-                  />
+                  >
+                    <Label
+                      content="Image not found!"
+                    >
+                      <div
+                        className="ui label"
+                        onClick={[Function]}
+                      >
+                        Image not found!
+                      </div>
+                    </Label>
+                  </div>
                 </Image>
               </figure>
             </ResponsiveImage>

--- a/src/components/general-widgets/HomepageHero/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/HomepageHero/__snapshots__/component.spec.js.snap
@@ -130,14 +130,13 @@ exports[`HomepageHero should render the right structure 1`] = `
                 imageHeight={null}
                 imageNotFoundLabelText="Image not found!"
                 imageTitle="Image Title"
-                imageUrl="bare sources"
+                imageUrl=""
                 imageWidth={null}
                 isAvatar={false}
                 isCircular={false}
                 isFluid={true}
                 isLazyLoaded={true}
                 label={null}
-                placeholderImageUrl={null}
                 sizes="url"
                 srcSet="a load of sizes"
               >
@@ -151,20 +150,31 @@ exports[`HomepageHero should render the right structure 1`] = `
                     fluid={true}
                     onLoad={[Function]}
                     sizes="url"
-                    src="bare sources"
+                    src=""
                     srcSet="a load of sizes"
                     title="Image Title"
                     ui={true}
                   >
-                    <img
+                    <div
                       alt="Image Widget"
                       className="ui fluid image"
                       onLoad={[Function]}
                       sizes="url"
-                      src="bare sources"
+                      src=""
                       srcSet="a load of sizes"
                       title="Image Title"
-                    />
+                    >
+                      <Label
+                        content="Image not found!"
+                      >
+                        <div
+                          className="ui label"
+                          onClick={[Function]}
+                        >
+                          Image not found!
+                        </div>
+                      </Label>
+                    </div>
                   </Image>
                 </figure>
               </ResponsiveImage>

--- a/src/components/general-widgets/Promotion/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/Promotion/__snapshots__/component.spec.js.snap
@@ -94,14 +94,13 @@ exports[`The \`Promotion\` component if \`backgroundImageUrl\` prop is passed sh
                               imageHeight={null}
                               imageNotFoundLabelText="Image not found!"
                               imageTitle="Image Title"
-                              imageUrl="testimage"
+                              imageUrl=""
                               imageWidth={null}
                               isAvatar={false}
                               isCircular={false}
                               isFluid={false}
                               isLazyLoaded={true}
                               label={null}
-                              placeholderImageUrl={null}
                               sizes={null}
                               srcSet={null}
                             >
@@ -115,20 +114,31 @@ exports[`The \`Promotion\` component if \`backgroundImageUrl\` prop is passed sh
                                   fluid={true}
                                   onLoad={[Function]}
                                   sizes={null}
-                                  src="testimage"
+                                  src=""
                                   srcSet={null}
                                   title="Image Title"
                                   ui={true}
                                 >
-                                  <img
+                                  <div
                                     alt="Image Widget"
                                     className="ui fluid image"
                                     onLoad={[Function]}
                                     sizes={null}
-                                    src="testimage"
+                                    src=""
                                     srcSet={null}
                                     title="Image Title"
-                                  />
+                                  >
+                                    <Label
+                                      content="Image not found!"
+                                    >
+                                      <div
+                                        className="ui label"
+                                        onClick={[Function]}
+                                      >
+                                        Image not found!
+                                      </div>
+                                    </Label>
+                                  </div>
                                 </Image>
                               </figure>
                             </ResponsiveImage>

--- a/src/components/layout/LazyLoader/utils/getIsBottomComponentVisible.js
+++ b/src/components/layout/LazyLoader/utils/getIsBottomComponentVisible.js
@@ -8,5 +8,10 @@ import { HEIGHT_OFF_SET } from './constants';
  * @param {number} windowHeight
  * @return {boolean}
  */
-export const getIsBottomComponentVisible = ({ bottom }, windowHeight) =>
-  bottom + HEIGHT_OFF_SET > -windowHeight && bottom - windowHeight / 2 <= 0;
+export const getIsBottomComponentVisible = ({ bottom }, windowHeight) => {
+  if (bottom === 0) return false;
+
+  return (
+    bottom + HEIGHT_OFF_SET > -windowHeight && bottom - windowHeight / 2 <= 0
+  );
+};

--- a/src/components/layout/LazyLoader/utils/getIsBottomComponentVisible.spec.js
+++ b/src/components/layout/LazyLoader/utils/getIsBottomComponentVisible.spec.js
@@ -22,4 +22,12 @@ describe('`getIsBottomComponentVisible`', () => {
       expect(actual).toBe(false);
     });
   });
+
+  describe('when bottom offset is zero', () => {
+    it('should return false', () => {
+      const actual = getIsBottomComponentVisible({ bottom: 0 }, 1000);
+
+      expect(actual).toBe(false);
+    });
+  });
 });

--- a/src/components/layout/LazyLoader/utils/getIsTopComponentVisible.js
+++ b/src/components/layout/LazyLoader/utils/getIsTopComponentVisible.js
@@ -8,5 +8,8 @@ import { HEIGHT_OFF_SET } from './constants';
  * @param {number} windowHeight
  * @return {boolean}
  */
-export const getIsTopComponentVisible = ({ top }, windowHeight) =>
-  top - HEIGHT_OFF_SET <= windowHeight && top > -windowHeight / 2;
+export const getIsTopComponentVisible = ({ top }, windowHeight) => {
+  if (top === 0) return false;
+
+  return top - HEIGHT_OFF_SET <= windowHeight && top > -windowHeight / 2;
+};

--- a/src/components/layout/LazyLoader/utils/getIsTopComponentVisible.spec.js
+++ b/src/components/layout/LazyLoader/utils/getIsTopComponentVisible.spec.js
@@ -22,4 +22,12 @@ describe('getIsVisible', () => {
       expect(actual).toBe(false);
     });
   });
+
+  describe('when top offset is zero', () => {
+    it('should return false', () => {
+      const actual = getIsTopComponentVisible({ top: 0 }, 1000);
+
+      expect(actual).toBe(false);
+    });
+  });
 });

--- a/src/components/media/FullBleed/__snapshots__/component.spec.js.snap
+++ b/src/components/media/FullBleed/__snapshots__/component.spec.js.snap
@@ -60,14 +60,13 @@ exports[`<FullBleed /> by default should have the right structure 1`] = `
             imageHeight={null}
             imageNotFoundLabelText="Image not found!"
             imageTitle="Image Title"
-            imageUrl="🐱🐱"
+            imageUrl=""
             imageWidth={null}
             isAvatar={false}
             isCircular={false}
             isFluid={true}
             isLazyLoaded={true}
             label={null}
-            placeholderImageUrl={null}
             sizes={null}
             srcSet={null}
           >
@@ -81,20 +80,31 @@ exports[`<FullBleed /> by default should have the right structure 1`] = `
                 fluid={true}
                 onLoad={[Function]}
                 sizes={null}
-                src="🐱🐱"
+                src=""
                 srcSet={null}
                 title="Image Title"
                 ui={true}
               >
-                <img
+                <div
                   alt="Image Widget"
                   className="ui fluid image"
                   onLoad={[Function]}
                   sizes={null}
-                  src="🐱🐱"
+                  src=""
                   srcSet={null}
                   title="Image Title"
-                />
+                >
+                  <Label
+                    content="Image not found!"
+                  >
+                    <div
+                      className="ui label"
+                      onClick={[Function]}
+                    >
+                      Image not found!
+                    </div>
+                  </Label>
+                </div>
               </Image>
             </figure>
           </ResponsiveImage>
@@ -166,14 +176,13 @@ exports[`<FullBleed /> if \`hasGradient\` is passed should have the right struct
             imageHeight={null}
             imageNotFoundLabelText="Image not found!"
             imageTitle="Image Title"
-            imageUrl="🐱🐱"
+            imageUrl=""
             imageWidth={null}
             isAvatar={false}
             isCircular={false}
             isFluid={true}
             isLazyLoaded={true}
             label={null}
-            placeholderImageUrl={null}
             sizes={null}
             srcSet={null}
           >
@@ -187,20 +196,31 @@ exports[`<FullBleed /> if \`hasGradient\` is passed should have the right struct
                 fluid={true}
                 onLoad={[Function]}
                 sizes={null}
-                src="🐱🐱"
+                src=""
                 srcSet={null}
                 title="Image Title"
                 ui={true}
               >
-                <img
+                <div
                   alt="Image Widget"
                   className="ui fluid image"
                   onLoad={[Function]}
                   sizes={null}
-                  src="🐱🐱"
+                  src=""
                   srcSet={null}
                   title="Image Title"
-                />
+                >
+                  <Label
+                    content="Image not found!"
+                  >
+                    <div
+                      className="ui label"
+                      onClick={[Function]}
+                    >
+                      Image not found!
+                    </div>
+                  </Label>
+                </div>
               </Image>
             </figure>
           </ResponsiveImage>
@@ -272,14 +292,13 @@ exports[`<FullBleed /> if \`props.children > 0\` should have the right structure
             imageHeight={null}
             imageNotFoundLabelText="Image not found!"
             imageTitle="Image Title"
-            imageUrl="🐱🐱"
+            imageUrl=""
             imageWidth={null}
             isAvatar={false}
             isCircular={false}
             isFluid={true}
             isLazyLoaded={true}
             label={null}
-            placeholderImageUrl={null}
             sizes={null}
             srcSet={null}
           >
@@ -293,20 +312,31 @@ exports[`<FullBleed /> if \`props.children > 0\` should have the right structure
                 fluid={true}
                 onLoad={[Function]}
                 sizes={null}
-                src="🐱🐱"
+                src=""
                 srcSet={null}
                 title="Image Title"
                 ui={true}
               >
-                <img
+                <div
                   alt="Image Widget"
                   className="ui fluid image"
                   onLoad={[Function]}
                   sizes={null}
-                  src="🐱🐱"
+                  src=""
                   srcSet={null}
                   title="Image Title"
-                />
+                >
+                  <Label
+                    content="Image not found!"
+                  >
+                    <div
+                      className="ui label"
+                      onClick={[Function]}
+                    >
+                      Image not found!
+                    </div>
+                  </Label>
+                </div>
               </Image>
             </figure>
           </ResponsiveImage>

--- a/src/components/media/ResponsiveImage/__snapshots__/component.spec.js.snap
+++ b/src/components/media/ResponsiveImage/__snapshots__/component.spec.js.snap
@@ -1,371 +1,259 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<ResponsiveImage /> by default should have the right structure 1`] = `
-<withLazyLoad(ResponsiveImage)
+<ResponsiveImage
   alternativeText="Alternative Text 😝"
+  hasRoundedCorners={false}
+  imageHeight={null}
+  imageNotFoundLabelText="Image not found!"
   imageTitle="ResponsiveImage title"
+  imageUrl=""
+  imageWidth={null}
   isAvatar={false}
+  isCircular={false}
   isFluid={true}
   isLazyLoaded={true}
+  label={null}
   onLoad={[Function]}
+  sizes={null}
   sources={Array []}
+  srcSet={null}
 >
-  <LazyLoader
-    componentProps={
-      Object {
-        "alternativeText": "Alternative Text 😝",
-        "imageTitle": "ResponsiveImage title",
-        "isAvatar": false,
-        "isFluid": true,
-        "isLazyLoaded": true,
-        "onLoad": [Function],
-        "sources": Array [],
-      }
-    }
-    lazyComponent={[Function]}
-    lazyProps={
-      Object {
-        "imageUrl": undefined,
-        "placeholderImageUrl": undefined,
-      }
-    }
+  <figure
+    className="responsive-image is-fluid"
   >
-    <div />
-    <ResponsiveImage
-      alternativeText="Alternative Text 😝"
-      hasRoundedCorners={false}
-      imageHeight={null}
-      imageNotFoundLabelText="Image not found!"
-      imageTitle="ResponsiveImage title"
-      imageUrl=""
-      imageWidth={null}
-      isAvatar={false}
-      isCircular={false}
-      isFluid={true}
-      isLazyLoaded={true}
-      label={null}
+    <Image
+      alt="Alternative Text 😝"
+      as="img"
+      avatar={false}
+      fluid={true}
       onLoad={[Function]}
       sizes={null}
-      sources={Array []}
+      src=""
       srcSet={null}
+      title="ResponsiveImage title"
+      ui={true}
     >
-      <figure
-        className="responsive-image is-fluid"
-      >
-        <Image
-          alt="Alternative Text 😝"
-          as="img"
-          avatar={false}
-          fluid={true}
-          onLoad={[Function]}
-          sizes={null}
-          src=""
-          srcSet={null}
-          title="ResponsiveImage title"
-          ui={true}
-        >
-          <div
-            alt="Alternative Text 😝"
-            className="ui fluid image"
-            onLoad={[Function]}
-            sizes={null}
-            src=""
-            srcSet={null}
-            title="ResponsiveImage title"
-          >
-            <Label
-              content="Image not found!"
-            >
-              <div
-                className="ui label"
-                onClick={[Function]}
-              >
-                Image not found!
-              </div>
-            </Label>
-          </div>
-        </Image>
-      </figure>
-    </ResponsiveImage>
-    <div />
-  </LazyLoader>
-</withLazyLoad(ResponsiveImage)>
-`;
-
-exports[`<ResponsiveImage /> if \`props.isLazyLoaded\` is false should have the right structure 1`] = `
-<withLazyLoad(ResponsiveImage)
-  alternativeText="Alternative Text 😝"
-  imageTitle="ResponsiveImage title"
-  isAvatar={false}
-  isFluid={true}
-  isLazyLoaded={false}
-  onLoad={[Function]}
-  sources={Array []}
->
-  <ResponsiveImage
-    alternativeText="Alternative Text 😝"
-    hasRoundedCorners={false}
-    imageHeight={null}
-    imageNotFoundLabelText="Image not found!"
-    imageTitle="ResponsiveImage title"
-    imageUrl=""
-    imageWidth={null}
-    isAvatar={false}
-    isCircular={false}
-    isFluid={true}
-    isLazyLoaded={false}
-    label={null}
-    onLoad={[Function]}
-    sizes={null}
-    sources={Array []}
-    srcSet={null}
-  >
-    <figure
-      className="responsive-image is-fluid"
-    >
-      <Image
+      <div
         alt="Alternative Text 😝"
-        as="img"
-        avatar={false}
-        fluid={true}
+        className="ui fluid image"
         onLoad={[Function]}
         sizes={null}
         src=""
         srcSet={null}
         title="ResponsiveImage title"
-        ui={true}
       >
-        <div
-          alt="Alternative Text 😝"
-          className="ui fluid image"
-          onLoad={[Function]}
-          sizes={null}
-          src=""
-          srcSet={null}
-          title="ResponsiveImage title"
+        <Label
+          content="Image not found!"
         >
-          <Label
-            content="Image not found!"
+          <div
+            className="ui label"
+            onClick={[Function]}
           >
-            <div
-              className="ui label"
-              onClick={[Function]}
-            >
-              Image not found!
-            </div>
-          </Label>
-        </div>
-      </Image>
-    </figure>
-  </ResponsiveImage>
-</withLazyLoad(ResponsiveImage)>
+            Image not found!
+          </div>
+        </Label>
+      </div>
+    </Image>
+  </figure>
+</ResponsiveImage>
+`;
+
+exports[`<ResponsiveImage /> if \`props.isLazyLoaded\` is false should have the right structure 1`] = `
+<ResponsiveImage
+  alternativeText="Alternative Text 😝"
+  hasRoundedCorners={false}
+  imageHeight={null}
+  imageNotFoundLabelText="Image not found!"
+  imageTitle="ResponsiveImage title"
+  imageUrl=""
+  imageWidth={null}
+  isAvatar={false}
+  isCircular={false}
+  isFluid={true}
+  isLazyLoaded={false}
+  label={null}
+  onLoad={[Function]}
+  sizes={null}
+  sources={Array []}
+  srcSet={null}
+>
+  <figure
+    className="responsive-image is-fluid"
+  >
+    <Image
+      alt="Alternative Text 😝"
+      as="img"
+      avatar={false}
+      fluid={true}
+      onLoad={[Function]}
+      sizes={null}
+      src=""
+      srcSet={null}
+      title="ResponsiveImage title"
+      ui={true}
+    >
+      <div
+        alt="Alternative Text 😝"
+        className="ui fluid image"
+        onLoad={[Function]}
+        sizes={null}
+        src=""
+        srcSet={null}
+        title="ResponsiveImage title"
+      >
+        <Label
+          content="Image not found!"
+        >
+          <div
+            className="ui label"
+            onClick={[Function]}
+          >
+            Image not found!
+          </div>
+        </Label>
+      </div>
+    </Image>
+  </figure>
+</ResponsiveImage>
 `;
 
 exports[`<ResponsiveImage /> if \`props.label\` is passed should have the right structure 1`] = `
-<withLazyLoad(ResponsiveImage)
+<ResponsiveImage
   alternativeText="Alternative Text 😝"
+  hasRoundedCorners={false}
+  imageHeight={null}
+  imageNotFoundLabelText="Image not found!"
   imageTitle="ResponsiveImage title"
+  imageUrl=""
+  imageWidth={null}
   isAvatar={false}
+  isCircular={false}
   isFluid={true}
   isLazyLoaded={true}
   label="🔷"
   onLoad={[Function]}
+  sizes={null}
   sources={Array []}
+  srcSet={null}
 >
-  <LazyLoader
-    componentProps={
-      Object {
-        "alternativeText": "Alternative Text 😝",
-        "imageTitle": "ResponsiveImage title",
-        "isAvatar": false,
-        "isFluid": true,
-        "isLazyLoaded": true,
-        "label": "🔷",
-        "onLoad": [Function],
-        "sources": Array [],
-      }
-    }
-    lazyComponent={[Function]}
-    lazyProps={
-      Object {
-        "imageUrl": undefined,
-        "placeholderImageUrl": undefined,
-      }
-    }
+  <figure
+    className="responsive-image is-fluid"
   >
-    <div />
-    <ResponsiveImage
-      alternativeText="Alternative Text 😝"
-      hasRoundedCorners={false}
-      imageHeight={null}
-      imageNotFoundLabelText="Image not found!"
-      imageTitle="ResponsiveImage title"
-      imageUrl=""
-      imageWidth={null}
-      isAvatar={false}
-      isCircular={false}
-      isFluid={true}
-      isLazyLoaded={true}
-      label="🔷"
+    <Image
+      alt="Alternative Text 😝"
+      as="img"
+      avatar={false}
+      fluid={true}
       onLoad={[Function]}
       sizes={null}
-      sources={Array []}
+      src=""
       srcSet={null}
+      title="ResponsiveImage title"
+      ui={true}
     >
-      <figure
-        className="responsive-image is-fluid"
+      <div
+        alt="Alternative Text 😝"
+        className="ui fluid image"
+        onLoad={[Function]}
+        sizes={null}
+        src=""
+        srcSet={null}
+        title="ResponsiveImage title"
       >
-        <Image
-          alt="Alternative Text 😝"
-          as="img"
-          avatar={false}
-          fluid={true}
-          onLoad={[Function]}
-          sizes={null}
-          src=""
-          srcSet={null}
-          title="ResponsiveImage title"
-          ui={true}
+        <Label
+          content="Image not found!"
         >
           <div
-            alt="Alternative Text 😝"
-            className="ui fluid image"
-            onLoad={[Function]}
-            sizes={null}
-            src=""
-            srcSet={null}
-            title="ResponsiveImage title"
+            className="ui label"
+            onClick={[Function]}
           >
-            <Label
-              content="Image not found!"
-            >
-              <div
-                className="ui label"
-                onClick={[Function]}
-              >
-                Image not found!
-              </div>
-            </Label>
+            Image not found!
           </div>
-        </Image>
-        <Paragraph
-          size="medium"
-          weight={null}
-        >
-          <p
-            className=""
-          >
-            🔷
-          </p>
-        </Paragraph>
-      </figure>
-    </ResponsiveImage>
-    <div />
-  </LazyLoader>
-</withLazyLoad(ResponsiveImage)>
+        </Label>
+      </div>
+    </Image>
+    <Paragraph
+      size="medium"
+      weight={null}
+    >
+      <p
+        className=""
+      >
+        🔷
+      </p>
+    </Paragraph>
+  </figure>
+</ResponsiveImage>
 `;
 
 exports[`<ResponsiveImage /> if \`props.placeholderImageUrl\` is passed should have the right structure 1`] = `
-<withLazyLoad(ResponsiveImage)
+<ResponsiveImage
   alternativeText="Alternative Text 😝"
+  hasRoundedCorners={false}
+  imageHeight={null}
+  imageNotFoundLabelText="Image not found!"
   imageTitle="ResponsiveImage title"
+  imageUrl=""
+  imageWidth={null}
   isAvatar={false}
+  isCircular={false}
   isFluid={true}
   isLazyLoaded={true}
+  label={null}
   onLoad={[Function]}
   placeholderImageUrl="ayyy"
+  sizes={null}
   sources={Array []}
+  srcSet={null}
 >
-  <LazyLoader
-    componentProps={
-      Object {
-        "alternativeText": "Alternative Text 😝",
-        "imageTitle": "ResponsiveImage title",
-        "isAvatar": false,
-        "isFluid": true,
-        "isLazyLoaded": true,
-        "onLoad": [Function],
-        "sources": Array [],
-      }
-    }
-    lazyComponent={[Function]}
-    lazyProps={
-      Object {
-        "imageUrl": undefined,
-        "placeholderImageUrl": "ayyy",
-      }
-    }
+  <figure
+    className="responsive-image has-blurred-children has-placeholder is-fluid"
   >
-    <div />
-    <ResponsiveImage
-      alternativeText="Alternative Text 😝"
-      hasRoundedCorners={false}
-      imageHeight={null}
-      imageNotFoundLabelText="Image not found!"
-      imageTitle="ResponsiveImage title"
-      imageUrl=""
-      imageWidth={null}
-      isAvatar={false}
-      isCircular={false}
-      isFluid={true}
-      isLazyLoaded={true}
-      label={null}
+    <Image
+      alt="Alternative Text 😝"
+      as="img"
+      avatar={false}
+      fluid={true}
       onLoad={[Function]}
-      placeholderImageUrl="ayyy"
       sizes={null}
-      sources={Array []}
+      src=""
       srcSet={null}
+      title="ResponsiveImage title"
+      ui={true}
     >
-      <figure
-        className="responsive-image has-blurred-children has-placeholder is-fluid"
+      <div
+        alt="Alternative Text 😝"
+        className="ui fluid image"
+        onLoad={[Function]}
+        sizes={null}
+        src=""
+        srcSet={null}
+        title="ResponsiveImage title"
       >
-        <Image
-          alt="Alternative Text 😝"
-          as="img"
-          avatar={false}
-          fluid={true}
-          onLoad={[Function]}
-          sizes={null}
-          src=""
-          srcSet={null}
-          title="ResponsiveImage title"
-          ui={true}
+        <Label
+          content="Image not found!"
         >
           <div
-            alt="Alternative Text 😝"
-            className="ui fluid image"
-            onLoad={[Function]}
-            sizes={null}
-            src=""
-            srcSet={null}
-            title="ResponsiveImage title"
+            className="ui label"
+            onClick={[Function]}
           >
-            <Label
-              content="Image not found!"
-            >
-              <div
-                className="ui label"
-                onClick={[Function]}
-              >
-                Image not found!
-              </div>
-            </Label>
+            Image not found!
           </div>
-        </Image>
-        <Image
-          as="img"
-          fluid={true}
-          src="ayyy"
-          ui={true}
-        >
-          <img
-            className="ui fluid image"
-            src="ayyy"
-          />
-        </Image>
-      </figure>
-    </ResponsiveImage>
-    <div />
-  </LazyLoader>
-</withLazyLoad(ResponsiveImage)>
+        </Label>
+      </div>
+    </Image>
+    <Image
+      as="img"
+      fluid={true}
+      src="ayyy"
+      ui={true}
+    >
+      <img
+        className="ui fluid image"
+        src="ayyy"
+      />
+    </Image>
+  </figure>
+</ResponsiveImage>
 `;

--- a/src/components/media/ResponsiveImage/component.spec.js
+++ b/src/components/media/ResponsiveImage/component.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 
 import { ComponentWithLazyLoad as ResponsiveImage } from './component';
 
@@ -12,16 +12,18 @@ const props = {
   imageTitle: 'ResponsiveImage title',
 };
 
-const getResponsiveImage = extraProps =>
-  mount(<ResponsiveImage {...props} {...extraProps} />);
+const getResponsiveImage = () => shallow(<ResponsiveImage {...props} />);
 
-const getWrappedResponsiveImage = extraProps =>
-  getResponsiveImage(extraProps).find('ResponsiveImage');
+const getWrappedResponsiveImage = extraProps => {
+  const Child = getResponsiveImage().prop('lazyComponent');
+
+  return mount(<Child {...props} {...extraProps} />);
+};
 
 describe('<ResponsiveImage />', () => {
   describe('by default', () => {
     it('should have the right structure', () => {
-      const actual = getResponsiveImage();
+      const actual = getWrappedResponsiveImage();
 
       expect(actual).toMatchSnapshot();
     });
@@ -29,7 +31,7 @@ describe('<ResponsiveImage />', () => {
 
   describe('if `props.placeholderImageUrl` is passed', () => {
     it('should have the right structure', () => {
-      const actual = getResponsiveImage({
+      const actual = getWrappedResponsiveImage({
         placeholderImageUrl: 'ayyy',
       });
 
@@ -68,7 +70,7 @@ describe('<ResponsiveImage />', () => {
 
   describe('if `props.label` is passed', () => {
     it('should have the right structure', () => {
-      const actual = getResponsiveImage({ label: '🔷' });
+      const actual = getWrappedResponsiveImage({ label: '🔷' });
 
       expect(actual).toMatchSnapshot();
     });
@@ -76,7 +78,7 @@ describe('<ResponsiveImage />', () => {
 
   describe('if `props.isLazyLoaded` is false', () => {
     it('should have the right structure', () => {
-      const actual = getResponsiveImage({ isLazyLoaded: false });
+      const actual = getWrappedResponsiveImage({ isLazyLoaded: false });
 
       expect(actual).toMatchSnapshot();
     });

--- a/src/components/media/Thumbnail/__snapshots__/component.spec.js.snap
+++ b/src/components/media/Thumbnail/__snapshots__/component.spec.js.snap
@@ -48,7 +48,7 @@ exports[`<Thumbnail /> by default should render the right structure 1`] = `
           imageHeight={null}
           imageNotFoundLabelText="Image not found!"
           imageTitle="Image Title"
-          imageUrl="www.⚡️.net"
+          imageUrl=""
           imageWidth={null}
           isAvatar={false}
           isCircular={false}
@@ -69,20 +69,31 @@ exports[`<Thumbnail /> by default should render the right structure 1`] = `
               fluid={true}
               onLoad={[Function]}
               sizes={null}
-              src="www.⚡️.net"
+              src=""
               srcSet={null}
               title="Image Title"
               ui={true}
             >
-              <img
+              <div
                 alt="Image Widget"
                 className="ui fluid image"
                 onLoad={[Function]}
                 sizes={null}
-                src="www.⚡️.net"
+                src=""
                 srcSet={null}
                 title="Image Title"
-              />
+              >
+                <Label
+                  content="Image not found!"
+                >
+                  <div
+                    className="ui label"
+                    onClick={[Function]}
+                  >
+                    Image not found!
+                  </div>
+                </Label>
+              </div>
             </Image>
           </figure>
         </ResponsiveImage>
@@ -141,7 +152,7 @@ exports[`<Thumbnail /> if \`props.isCircular\` is true should render the right s
           imageHeight={null}
           imageNotFoundLabelText="Image not found!"
           imageTitle="Image Title"
-          imageUrl="www.⚡️.net"
+          imageUrl=""
           imageWidth={null}
           isAvatar={false}
           isCircular={true}
@@ -162,20 +173,31 @@ exports[`<Thumbnail /> if \`props.isCircular\` is true should render the right s
               fluid={true}
               onLoad={[Function]}
               sizes={null}
-              src="www.⚡️.net"
+              src=""
               srcSet={null}
               title="Image Title"
               ui={true}
             >
-              <img
+              <div
                 alt="Image Widget"
                 className="ui fluid image"
                 onLoad={[Function]}
                 sizes={null}
-                src="www.⚡️.net"
+                src=""
                 srcSet={null}
                 title="Image Title"
-              />
+              >
+                <Label
+                  content="Image not found!"
+                >
+                  <div
+                    className="ui label"
+                    onClick={[Function]}
+                  >
+                    Image not found!
+                  </div>
+                </Label>
+              </div>
             </Image>
           </figure>
         </ResponsiveImage>
@@ -234,7 +256,7 @@ exports[`<Thumbnail /> if \`props.isSquare\` is true should render the right str
           imageHeight={null}
           imageNotFoundLabelText="Image not found!"
           imageTitle="Image Title"
-          imageUrl="www.⚡️.net"
+          imageUrl=""
           imageWidth={null}
           isAvatar={false}
           isCircular={false}
@@ -255,20 +277,31 @@ exports[`<Thumbnail /> if \`props.isSquare\` is true should render the right str
               fluid={true}
               onLoad={[Function]}
               sizes={null}
-              src="www.⚡️.net"
+              src=""
               srcSet={null}
               title="Image Title"
               ui={true}
             >
-              <img
+              <div
                 alt="Image Widget"
                 className="ui fluid image"
                 onLoad={[Function]}
                 sizes={null}
-                src="www.⚡️.net"
+                src=""
                 srcSet={null}
                 title="Image Title"
-              />
+              >
+                <Label
+                  content="Image not found!"
+                >
+                  <div
+                    className="ui label"
+                    onClick={[Function]}
+                  >
+                    Image not found!
+                  </div>
+                </Label>
+              </div>
             </Image>
           </figure>
         </ResponsiveImage>
@@ -327,7 +360,7 @@ exports[`<Thumbnail /> if \`props.size\` is supplied should render the right str
           imageHeight={null}
           imageNotFoundLabelText="Image not found!"
           imageTitle="Image Title"
-          imageUrl="www.⚡️.net"
+          imageUrl=""
           imageWidth={null}
           isAvatar={false}
           isCircular={false}
@@ -348,20 +381,31 @@ exports[`<Thumbnail /> if \`props.size\` is supplied should render the right str
               fluid={true}
               onLoad={[Function]}
               sizes={null}
-              src="www.⚡️.net"
+              src=""
               srcSet={null}
               title="Image Title"
               ui={true}
             >
-              <img
+              <div
                 alt="Image Widget"
                 className="ui fluid image"
                 onLoad={[Function]}
                 sizes={null}
-                src="www.⚡️.net"
+                src=""
                 srcSet={null}
                 title="Image Title"
-              />
+              >
+                <Label
+                  content="Image not found!"
+                >
+                  <div
+                    className="ui label"
+                    onClick={[Function]}
+                  >
+                    Image not found!
+                  </div>
+                </Label>
+              </div>
             </Image>
           </figure>
         </ResponsiveImage>

--- a/src/components/property-page-widgets/HostProfile/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/HostProfile/__snapshots__/component.spec.js.snap
@@ -162,7 +162,7 @@ exports[`<HostProfile /> if \`props.email\` is defined should render the right s
                                   imageHeight={null}
                                   imageNotFoundLabelText="Image not found!"
                                   imageTitle="Image Title"
-                                  imageUrl="https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max"
+                                  imageUrl=""
                                   imageWidth={null}
                                   isAvatar={false}
                                   isCircular={true}
@@ -183,20 +183,31 @@ exports[`<HostProfile /> if \`props.email\` is defined should render the right s
                                       fluid={true}
                                       onLoad={[Function]}
                                       sizes={null}
-                                      src="https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max"
+                                      src=""
                                       srcSet={null}
                                       title="Image Title"
                                       ui={true}
                                     >
-                                      <img
+                                      <div
                                         alt="Image Widget"
                                         className="ui fluid image"
                                         onLoad={[Function]}
                                         sizes={null}
-                                        src="https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max"
+                                        src=""
                                         srcSet={null}
                                         title="Image Title"
-                                      />
+                                      >
+                                        <Label
+                                          content="Image not found!"
+                                        >
+                                          <div
+                                            className="ui label"
+                                            onClick={[Function]}
+                                          >
+                                            Image not found!
+                                          </div>
+                                        </Label>
+                                      </div>
                                     </Image>
                                   </figure>
                                 </ResponsiveImage>
@@ -516,7 +527,7 @@ exports[`<HostProfile /> if \`props.languages\` is defined should render the rig
                                   imageHeight={null}
                                   imageNotFoundLabelText="Image not found!"
                                   imageTitle="Image Title"
-                                  imageUrl="https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max"
+                                  imageUrl=""
                                   imageWidth={null}
                                   isAvatar={false}
                                   isCircular={true}
@@ -537,20 +548,31 @@ exports[`<HostProfile /> if \`props.languages\` is defined should render the rig
                                       fluid={true}
                                       onLoad={[Function]}
                                       sizes={null}
-                                      src="https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max"
+                                      src=""
                                       srcSet={null}
                                       title="Image Title"
                                       ui={true}
                                     >
-                                      <img
+                                      <div
                                         alt="Image Widget"
                                         className="ui fluid image"
                                         onLoad={[Function]}
                                         sizes={null}
-                                        src="https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max"
+                                        src=""
                                         srcSet={null}
                                         title="Image Title"
-                                      />
+                                      >
+                                        <Label
+                                          content="Image not found!"
+                                        >
+                                          <div
+                                            className="ui label"
+                                            onClick={[Function]}
+                                          >
+                                            Image not found!
+                                          </div>
+                                        </Label>
+                                      </div>
                                     </Image>
                                   </figure>
                                 </ResponsiveImage>
@@ -863,7 +885,7 @@ exports[`<HostProfile /> if \`props.phone\` is defined should render the right s
                                   imageHeight={null}
                                   imageNotFoundLabelText="Image not found!"
                                   imageTitle="Image Title"
-                                  imageUrl="https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max"
+                                  imageUrl=""
                                   imageWidth={null}
                                   isAvatar={false}
                                   isCircular={true}
@@ -884,20 +906,31 @@ exports[`<HostProfile /> if \`props.phone\` is defined should render the right s
                                       fluid={true}
                                       onLoad={[Function]}
                                       sizes={null}
-                                      src="https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max"
+                                      src=""
                                       srcSet={null}
                                       title="Image Title"
                                       ui={true}
                                     >
-                                      <img
+                                      <div
                                         alt="Image Widget"
                                         className="ui fluid image"
                                         onLoad={[Function]}
                                         sizes={null}
-                                        src="https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max"
+                                        src=""
                                         srcSet={null}
                                         title="Image Title"
-                                      />
+                                      >
+                                        <Label
+                                          content="Image not found!"
+                                        >
+                                          <div
+                                            className="ui label"
+                                            onClick={[Function]}
+                                          >
+                                            Image not found!
+                                          </div>
+                                        </Label>
+                                      </div>
                                     </Image>
                                   </figure>
                                 </ResponsiveImage>
@@ -1214,7 +1247,7 @@ exports[`<HostProfile /> should render the right structure 1`] = `
                                   imageHeight={null}
                                   imageNotFoundLabelText="Image not found!"
                                   imageTitle="Image Title"
-                                  imageUrl="https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max"
+                                  imageUrl=""
                                   imageWidth={null}
                                   isAvatar={false}
                                   isCircular={true}
@@ -1235,20 +1268,31 @@ exports[`<HostProfile /> should render the right structure 1`] = `
                                       fluid={true}
                                       onLoad={[Function]}
                                       sizes={null}
-                                      src="https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max"
+                                      src=""
                                       srcSet={null}
                                       title="Image Title"
                                       ui={true}
                                     >
-                                      <img
+                                      <div
                                         alt="Image Widget"
                                         className="ui fluid image"
                                         onLoad={[Function]}
                                         sizes={null}
-                                        src="https://si4.cdbcdn.com/oh/4efbc79e-34db-4447-b31a-24e77f33f4e9.jpg?w=1024&mode=max"
+                                        src=""
                                         srcSet={null}
                                         title="Image Title"
-                                      />
+                                      >
+                                        <Label
+                                          content="Image not found!"
+                                        >
+                                          <div
+                                            className="ui label"
+                                            onClick={[Function]}
+                                          >
+                                            Image not found!
+                                          </div>
+                                        </Label>
+                                      </div>
                                     </Image>
                                   </figure>
                                 </ResponsiveImage>

--- a/src/components/property-page-widgets/Pictures/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Pictures/__snapshots__/component.spec.js.snap
@@ -192,7 +192,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                                   imageHeight={null}
                                   imageNotFoundLabelText="Image not found!"
                                   imageTitle="Image Title"
-                                  imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                  imageUrl=""
                                   imageWidth={null}
                                   isAvatar={false}
                                   isCircular={false}
@@ -213,20 +213,31 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                                       fluid={true}
                                       onLoad={[Function]}
                                       sizes={null}
-                                      src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                      src=""
                                       srcSet={null}
                                       title="Image Title"
                                       ui={true}
                                     >
-                                      <img
+                                      <div
                                         alt="Image Widget"
                                         className="ui fluid image"
                                         onLoad={[Function]}
                                         sizes={null}
-                                        src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                        src=""
                                         srcSet={null}
                                         title="Image Title"
-                                      />
+                                      >
+                                        <Label
+                                          content="Image not found!"
+                                        >
+                                          <div
+                                            className="ui label"
+                                            onClick={[Function]}
+                                          >
+                                            Image not found!
+                                          </div>
+                                        </Label>
+                                      </div>
                                     </Image>
                                   </figure>
                                 </ResponsiveImage>
@@ -305,7 +316,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                                   imageHeight={null}
                                   imageNotFoundLabelText="Image not found!"
                                   imageTitle="Image Title"
-                                  imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                  imageUrl=""
                                   imageWidth={null}
                                   isAvatar={false}
                                   isCircular={false}
@@ -326,20 +337,31 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                                       fluid={true}
                                       onLoad={[Function]}
                                       sizes={null}
-                                      src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                      src=""
                                       srcSet={null}
                                       title="Image Title"
                                       ui={true}
                                     >
-                                      <img
+                                      <div
                                         alt="Image Widget"
                                         className="ui fluid image"
                                         onLoad={[Function]}
                                         sizes={null}
-                                        src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                        src=""
                                         srcSet={null}
                                         title="Image Title"
-                                      />
+                                      >
+                                        <Label
+                                          content="Image not found!"
+                                        >
+                                          <div
+                                            className="ui label"
+                                            onClick={[Function]}
+                                          >
+                                            Image not found!
+                                          </div>
+                                        </Label>
+                                      </div>
                                     </Image>
                                   </figure>
                                 </ResponsiveImage>
@@ -448,7 +470,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                                   imageHeight={null}
                                   imageNotFoundLabelText="Image not found!"
                                   imageTitle="Image Title"
-                                  imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                  imageUrl=""
                                   imageWidth={null}
                                   isAvatar={false}
                                   isCircular={false}
@@ -469,20 +491,31 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                                       fluid={true}
                                       onLoad={[Function]}
                                       sizes={null}
-                                      src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                      src=""
                                       srcSet={null}
                                       title="Image Title"
                                       ui={true}
                                     >
-                                      <img
+                                      <div
                                         alt="Image Widget"
                                         className="ui fluid image"
                                         onLoad={[Function]}
                                         sizes={null}
-                                        src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                        src=""
                                         srcSet={null}
                                         title="Image Title"
-                                      />
+                                      >
+                                        <Label
+                                          content="Image not found!"
+                                        >
+                                          <div
+                                            className="ui label"
+                                            onClick={[Function]}
+                                          >
+                                            Image not found!
+                                          </div>
+                                        </Label>
+                                      </div>
                                     </Image>
                                   </figure>
                                 </ResponsiveImage>
@@ -561,7 +594,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                                   imageHeight={null}
                                   imageNotFoundLabelText="Image not found!"
                                   imageTitle="Image Title"
-                                  imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                  imageUrl=""
                                   imageWidth={null}
                                   isAvatar={false}
                                   isCircular={false}
@@ -582,20 +615,31 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                                       fluid={true}
                                       onLoad={[Function]}
                                       sizes={null}
-                                      src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                      src=""
                                       srcSet={null}
                                       title="Image Title"
                                       ui={true}
                                     >
-                                      <img
+                                      <div
                                         alt="Image Widget"
                                         className="ui fluid image"
                                         onLoad={[Function]}
                                         sizes={null}
-                                        src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                        src=""
                                         srcSet={null}
                                         title="Image Title"
-                                      />
+                                      >
+                                        <Label
+                                          content="Image not found!"
+                                        >
+                                          <div
+                                            className="ui label"
+                                            onClick={[Function]}
+                                          >
+                                            Image not found!
+                                          </div>
+                                        </Label>
+                                      </div>
                                     </Image>
                                   </figure>
                                 </ResponsiveImage>
@@ -704,7 +748,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                                   imageHeight={null}
                                   imageNotFoundLabelText="Image not found!"
                                   imageTitle="Image Title"
-                                  imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                  imageUrl=""
                                   imageWidth={null}
                                   isAvatar={false}
                                   isCircular={false}
@@ -725,20 +769,31 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                                       fluid={true}
                                       onLoad={[Function]}
                                       sizes={null}
-                                      src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                      src=""
                                       srcSet={null}
                                       title="Image Title"
                                       ui={true}
                                     >
-                                      <img
+                                      <div
                                         alt="Image Widget"
                                         className="ui fluid image"
                                         onLoad={[Function]}
                                         sizes={null}
-                                        src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                        src=""
                                         srcSet={null}
                                         title="Image Title"
-                                      />
+                                      >
+                                        <Label
+                                          content="Image not found!"
+                                        >
+                                          <div
+                                            className="ui label"
+                                            onClick={[Function]}
+                                          >
+                                            Image not found!
+                                          </div>
+                                        </Label>
+                                      </div>
                                     </Image>
                                   </figure>
                                 </ResponsiveImage>
@@ -817,7 +872,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                                   imageHeight={null}
                                   imageNotFoundLabelText="Image not found!"
                                   imageTitle="Image Title"
-                                  imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                  imageUrl=""
                                   imageWidth={null}
                                   isAvatar={false}
                                   isCircular={false}
@@ -838,20 +893,31 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                                       fluid={true}
                                       onLoad={[Function]}
                                       sizes={null}
-                                      src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                      src=""
                                       srcSet={null}
                                       title="Image Title"
                                       ui={true}
                                     >
-                                      <img
+                                      <div
                                         alt="Image Widget"
                                         className="ui fluid image"
                                         onLoad={[Function]}
                                         sizes={null}
-                                        src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                        src=""
                                         srcSet={null}
                                         title="Image Title"
-                                      />
+                                      >
+                                        <Label
+                                          content="Image not found!"
+                                        >
+                                          <div
+                                            className="ui label"
+                                            onClick={[Function]}
+                                          >
+                                            Image not found!
+                                          </div>
+                                        </Label>
+                                      </div>
                                     </Image>
                                   </figure>
                                 </ResponsiveImage>
@@ -960,7 +1026,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                                   imageHeight={null}
                                   imageNotFoundLabelText="Image not found!"
                                   imageTitle="Image Title"
-                                  imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                  imageUrl=""
                                   imageWidth={null}
                                   isAvatar={false}
                                   isCircular={false}
@@ -981,20 +1047,31 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                                       fluid={true}
                                       onLoad={[Function]}
                                       sizes={null}
-                                      src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                      src=""
                                       srcSet={null}
                                       title="Image Title"
                                       ui={true}
                                     >
-                                      <img
+                                      <div
                                         alt="Image Widget"
                                         className="ui fluid image"
                                         onLoad={[Function]}
                                         sizes={null}
-                                        src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                        src=""
                                         srcSet={null}
                                         title="Image Title"
-                                      />
+                                      >
+                                        <Label
+                                          content="Image not found!"
+                                        >
+                                          <div
+                                            className="ui label"
+                                            onClick={[Function]}
+                                          >
+                                            Image not found!
+                                          </div>
+                                        </Label>
+                                      </div>
                                     </Image>
                                   </figure>
                                 </ResponsiveImage>
@@ -1073,7 +1150,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                                   imageHeight={null}
                                   imageNotFoundLabelText="Image not found!"
                                   imageTitle="Image Title"
-                                  imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                  imageUrl=""
                                   imageWidth={null}
                                   isAvatar={false}
                                   isCircular={false}
@@ -1094,20 +1171,31 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                                       fluid={true}
                                       onLoad={[Function]}
                                       sizes={null}
-                                      src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                      src=""
                                       srcSet={null}
                                       title="Image Title"
                                       ui={true}
                                     >
-                                      <img
+                                      <div
                                         alt="Image Widget"
                                         className="ui fluid image"
                                         onLoad={[Function]}
                                         sizes={null}
-                                        src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                        src=""
                                         srcSet={null}
                                         title="Image Title"
-                                      />
+                                      >
+                                        <Label
+                                          content="Image not found!"
+                                        >
+                                          <div
+                                            className="ui label"
+                                            onClick={[Function]}
+                                          >
+                                            Image not found!
+                                          </div>
+                                        </Label>
+                                      </div>
                                     </Image>
                                   </figure>
                                 </ResponsiveImage>
@@ -1216,7 +1304,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                                   imageHeight={null}
                                   imageNotFoundLabelText="Image not found!"
                                   imageTitle="Image Title"
-                                  imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                  imageUrl=""
                                   imageWidth={null}
                                   isAvatar={false}
                                   isCircular={false}
@@ -1237,20 +1325,31 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                                       fluid={true}
                                       onLoad={[Function]}
                                       sizes={null}
-                                      src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                      src=""
                                       srcSet={null}
                                       title="Image Title"
                                       ui={true}
                                     >
-                                      <img
+                                      <div
                                         alt="Image Widget"
                                         className="ui fluid image"
                                         onLoad={[Function]}
                                         sizes={null}
-                                        src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                        src=""
                                         srcSet={null}
                                         title="Image Title"
-                                      />
+                                      >
+                                        <Label
+                                          content="Image not found!"
+                                        >
+                                          <div
+                                            className="ui label"
+                                            onClick={[Function]}
+                                          >
+                                            Image not found!
+                                          </div>
+                                        </Label>
+                                      </div>
                                     </Image>
                                   </figure>
                                 </ResponsiveImage>
@@ -1329,7 +1428,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                                   imageHeight={null}
                                   imageNotFoundLabelText="Image not found!"
                                   imageTitle="Image Title"
-                                  imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                  imageUrl=""
                                   imageWidth={null}
                                   isAvatar={false}
                                   isCircular={false}
@@ -1350,20 +1449,31 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                                       fluid={true}
                                       onLoad={[Function]}
                                       sizes={null}
-                                      src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                      src=""
                                       srcSet={null}
                                       title="Image Title"
                                       ui={true}
                                     >
-                                      <img
+                                      <div
                                         alt="Image Widget"
                                         className="ui fluid image"
                                         onLoad={[Function]}
                                         sizes={null}
-                                        src="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&mode=max"
+                                        src=""
                                         srcSet={null}
                                         title="Image Title"
-                                      />
+                                      >
+                                        <Label
+                                          content="Image not found!"
+                                        >
+                                          <div
+                                            className="ui label"
+                                            onClick={[Function]}
+                                          >
+                                            Image not found!
+                                          </div>
+                                        </Label>
+                                      </div>
                                     </Image>
                                   </figure>
                                 </ResponsiveImage>

--- a/src/components/property-page-widgets/PropertyPageHero/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/PropertyPageHero/__snapshots__/component.spec.js.snap
@@ -120,14 +120,13 @@ exports[`PropertyPageHero if there are fewer than two items in \`galleryImages\`
                 imageHeight={null}
                 imageNotFoundLabelText="Image not found!"
                 imageTitle="Image Title"
-                imageUrl="some url"
+                imageUrl=""
                 imageWidth={null}
                 isAvatar={false}
                 isCircular={false}
                 isFluid={true}
                 isLazyLoaded={true}
                 label={null}
-                placeholderImageUrl={null}
                 sizes={null}
                 srcSet={null}
               >
@@ -141,20 +140,31 @@ exports[`PropertyPageHero if there are fewer than two items in \`galleryImages\`
                     fluid={true}
                     onLoad={[Function]}
                     sizes={null}
-                    src="some url"
+                    src=""
                     srcSet={null}
                     title="Image Title"
                     ui={true}
                   >
-                    <img
+                    <div
                       alt="Image Widget"
                       className="ui fluid image"
                       onLoad={[Function]}
                       sizes={null}
-                      src="some url"
+                      src=""
                       srcSet={null}
                       title="Image Title"
-                    />
+                    >
+                      <Label
+                        content="Image not found!"
+                      >
+                        <div
+                          className="ui label"
+                          onClick={[Function]}
+                        >
+                          Image not found!
+                        </div>
+                      </Label>
+                    </div>
                   </Image>
                 </figure>
               </ResponsiveImage>
@@ -466,14 +476,13 @@ exports[`PropertyPageHero should render the right structure 1`] = `
                 imageHeight={null}
                 imageNotFoundLabelText="Image not found!"
                 imageTitle="Image Title"
-                imageUrl="some url"
+                imageUrl=""
                 imageWidth={null}
                 isAvatar={false}
                 isCircular={false}
                 isFluid={true}
                 isLazyLoaded={true}
                 label={null}
-                placeholderImageUrl={null}
                 sizes={null}
                 srcSet={null}
               >
@@ -487,20 +496,31 @@ exports[`PropertyPageHero should render the right structure 1`] = `
                     fluid={true}
                     onLoad={[Function]}
                     sizes={null}
-                    src="some url"
+                    src=""
                     srcSet={null}
                     title="Image Title"
                     ui={true}
                   >
-                    <img
+                    <div
                       alt="Image Widget"
                       className="ui fluid image"
                       onLoad={[Function]}
                       sizes={null}
-                      src="some url"
+                      src=""
                       srcSet={null}
                       title="Image Title"
-                    />
+                    >
+                      <Label
+                        content="Image not found!"
+                      >
+                        <div
+                          className="ui label"
+                          onClick={[Function]}
+                        >
+                          Image not found!
+                        </div>
+                      </Label>
+                    </div>
                   </Image>
                 </figure>
               </ResponsiveImage>

--- a/src/utils/with-lazy-load/__snapshots__/withLazyLoad.spec.js.snap
+++ b/src/utils/with-lazy-load/__snapshots__/withLazyLoad.spec.js.snap
@@ -1,5 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`withLazyLoad WrapperComponent if isLazyLoaded is false should return the right structure 1`] = `
+<🚜
+  isLazyLoaded={false}
+  lazyProp="😴"
+  other="otherProps"
+/>
+`;
+
 exports[`withLazyLoad WrapperComponent should pass the right props to \`Component\` 1`] = `
 <LazyLoader
   componentProps={

--- a/src/utils/with-lazy-load/withLazyLoad.spec.js
+++ b/src/utils/with-lazy-load/withLazyLoad.spec.js
@@ -14,7 +14,7 @@ const DISPLAY_NAME = '🚜';
 Component.displayName = DISPLAY_NAME;
 
 const props = { lazyProp: '😴', other: 'otherProps' };
-const getHOC = () =>
+const getHOC = props =>
   shallow(React.createElement(withLazyLoad('lazyProp')(Component), props));
 
 LazyLoader.mockImplementation(() => <div />);
@@ -42,9 +42,21 @@ describe('withLazyLoad', () => {
 
   describe('WrapperComponent', () => {
     it('should pass the right props to `Component`', () => {
-      const actual = getHOC();
+      const actual = getHOC(props);
 
       expect(actual).toMatchSnapshot();
+    });
+
+    describe('if isLazyLoaded is false', () => {
+      it('should return the right structure', () => {
+        const actual = getHOC({
+          lazyProp: '😴',
+          other: 'otherProps',
+          isLazyLoaded: false,
+        });
+
+        expect(actual).toMatchSnapshot();
+      });
     });
   });
 });


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-2393)

### What **one** thing does this PR do?
Prevents `LazyLoader` to render responsive images if component is on position 0.

### Before
![before](https://user-images.githubusercontent.com/33876435/60647922-1ee58f80-9e3f-11e9-8eab-989493f2da00.gif)

### After
![after](https://user-images.githubusercontent.com/33876435/60647933-24db7080-9e3f-11e9-8a0e-07c8d8262f58.gif)

