### PR TITLE
TE-2428 PropertySearchResult exposes an `isCompact` prop

### DIFF
--- a/src/components/general-widgets/PropertySearchResult/Readme.md
+++ b/src/components/general-widgets/PropertySearchResult/Readme.md
@@ -12,7 +12,7 @@ const amenities = ['Pool', 'Wifi', 'Washer', 'Kitchen'];
   guestsText="guests"
   imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
   priceLabelPeriodText="per month"
-  priceLabelPricePerPeriod="$280"
+  priceLabelpricePerPeriod="$280"
   priceLabelPricePerPeriodPrefix="from"
   propertyAmenities={amenities}
   propertyName="The Cat House"
@@ -38,7 +38,31 @@ const amenities = ['Pool', 'Wifi', 'Washer', 'Kitchen'];
   guestsNumber={2}
   guestsText="guests"
   imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
-  priceLabelPricePerPeriod="$280"
+  priceLabelpricePerPeriod="$280"
+  propertyAmenities={amenities}
+  propertyName="The Cat House"
+  propertyType="Bed and breakfast"
+  propertyUrl="/"
+  ratingNumber={4.8}
+/>
+```
+
+#### Compact
+```jsx
+const amenities = ['Pool', 'Wifi', 'Washer', 'Kitchen']; 
+
+<PropertySearchResult
+  isCompact
+  bathsNumber={2}
+  bathsText="baths"
+  bedroomsNumber={2}
+  bedroomsText="bedrooms"
+  bedsNumber={2}
+  bedsText="beds"
+  guestsNumber={2}
+  guestsText="guests"
+  imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
+  priceLabelpricePerPeriod="$280"
   propertyAmenities={amenities}
   propertyName="The Cat House"
   propertyType="Bed and breakfast"
@@ -64,7 +88,7 @@ const amenities = ['Pool', 'Wifi', 'Washer', 'Kitchen'];
   guestsNumber={2}
   guestsText="guests"
   imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
-  priceLabelPricePerPeriod="$280"
+  priceLabelpricePerPeriod="$280"
   propertyAmenities={amenities}
   propertyName="The Cat House"
   propertyType="Bed and breakfast"
@@ -81,7 +105,7 @@ const amenities = ['Pool', 'Wifi', 'Washer', 'Kitchen'];
   guestsNumber={0}
   imageUrl=""
   isShowingPlaceholder
-  priceLabelPricePerPeriod=""
+  priceLabelpricePerPeriod=""
   propertyName=""
   propertyType=""
   propertyUrl=""

--- a/src/components/general-widgets/PropertySearchResult/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/PropertySearchResult/__snapshots__/component.spec.js.snap
@@ -32,7 +32,7 @@ exports[`<PropertySearchResult /> if \`periodText\` is a truthy value should ren
           onChange={[Function]}
           onClick={[Function]}
           periodText="some priceLabelPeriodText"
-          pricePerPeriod="some priceLabelPricePerPeriod"
+          pricePerPeriod=""
           pricePerPeriodPrefix="some priceLabelPricePerPeriodPrefix"
         />
       </Segment>
@@ -76,6 +76,91 @@ exports[`<PropertySearchResult /> if \`periodText\` is a truthy value should ren
       <CardDescription>
         Pool · Wifi · Washer · Kitchen
       </CardDescription>
+    </CardContent>
+  </Card>
+</div>
+`;
+
+exports[`<PropertySearchResult /> if \`props.isCompact\` is passed should return the right structure 1`] = `
+<div
+  className="ui card has-search-result is-compact"
+  onMouseOut={[Function]}
+  onMouseOver={[Function]}
+>
+  <Card
+    href="/"
+    target="_self"
+  >
+    <FlexContainer
+      alignContent={null}
+      alignItems={null}
+      flexDirection={null}
+      flexWrap={null}
+      justifyContent={null}
+    >
+      <withLazyLoad(ResponsiveImage)
+        imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
+        isFluid={true}
+        isLazyLoaded={true}
+      />
+    </FlexContainer>
+    <CardContent>
+      <CardHeader>
+        <Heading
+          className={null}
+          hasMargin={true}
+          isColorInverted={false}
+          size="medium"
+          textAlign={null}
+        >
+          The Cat House
+        </Heading>
+      </CardHeader>
+      <CardDescription>
+        <FlexContainer
+          alignContent={null}
+          alignItems="center"
+          flexDirection="row"
+          flexWrap={null}
+          justifyContent={null}
+        >
+          <Rating
+            iconSize="tiny"
+            isShowingNumeral={true}
+            ratingNumber={4.7}
+          />
+          <Paragraph
+            size="medium"
+            weight={null}
+          >
+            · Bed and breakfast
+          </Paragraph>
+        </FlexContainer>
+      </CardDescription>
+      <CardDescription>
+        2 guests · 2 bedrooms · 2 beds · 2 baths
+      </CardDescription>
+      <CardDescription>
+        Pool · Wifi · Washer · Kitchen
+      </CardDescription>
+      <FlexContainer
+        alignContent={null}
+        alignItems={null}
+        flexDirection={null}
+        flexWrap={null}
+        justifyContent="flex-end"
+      >
+        <PriceLabel
+          hasShadow={false}
+          isActive={false}
+          isPointing={false}
+          onChange={[Function]}
+          onClick={[Function]}
+          periodText="some priceLabelPeriodText"
+          pricePerPeriod=""
+          pricePerPeriodPrefix="some priceLabelPricePerPeriodPrefix"
+        />
+      </FlexContainer>
     </CardContent>
   </Card>
 </div>
@@ -153,7 +238,7 @@ exports[`<PropertySearchResult /> should render the right structure 1`] = `
           onChange={[Function]}
           onClick={[Function]}
           periodText="some priceLabelPeriodText"
-          pricePerPeriod="some priceLabelPricePerPeriod"
+          pricePerPeriod=""
           pricePerPeriodPrefix="some priceLabelPricePerPeriodPrefix"
         />
       </Segment>

--- a/src/components/general-widgets/PropertySearchResult/component.js
+++ b/src/components/general-widgets/PropertySearchResult/component.js
@@ -12,7 +12,6 @@ import { Heading } from 'typography/Heading';
 import { FlexContainer } from 'layout/FlexContainer';
 import { PriceLabel } from 'elements/PriceLabel';
 
-// import { getPriceLabelMarkup } from './utils/getPriceLabelMarkup';
 import { getSearchResultDescription } from './utils/getSearchResultDescription';
 import { getPropertyAmenities } from './utils/getPropertyAmenities';
 
@@ -52,10 +51,11 @@ export class Component extends PureComponent {
       imageSrcSet,
       imageUrl,
       isActive,
+      isCompact,
       isShowingPlaceholder,
       placeholderImageUrl,
       priceLabelPeriodText,
-      priceLabelPricePerPeriod,
+      priceLabelpricePerPeriod,
       priceLabelPricePerPeriodPrefix,
       propertyAmenities,
       propertyName,
@@ -69,6 +69,7 @@ export class Component extends PureComponent {
       <div
         className={getClassNames('ui', 'card', 'has-search-result', {
           active: isActive || this.state.isActive,
+          'is-compact': isCompact,
         })}
         onMouseOut={this.toggleActive}
         onMouseOver={this.toggleActive}
@@ -87,13 +88,15 @@ export class Component extends PureComponent {
                   sizes={imageSizes}
                   srcSet={imageSrcSet}
                 />
-                <Segment raised>
-                  <PriceLabel
-                    periodText={priceLabelPeriodText}
-                    pricePerPeriod={priceLabelPricePerPeriod}
-                    pricePerPeriodPrefix={priceLabelPricePerPeriodPrefix}
-                  />
-                </Segment>
+                {!isCompact && (
+                  <Segment raised>
+                    <PriceLabel
+                      periodText={priceLabelPeriodText}
+                      pricePerPeriod={priceLabelpricePerPeriod}
+                      pricePerPeriodPrefix={priceLabelPricePerPeriodPrefix}
+                    />
+                  </Segment>
+                )}
               </FlexContainer>
               <Card.Content>
                 <Card.Header>
@@ -120,6 +123,15 @@ export class Component extends PureComponent {
                 <Card.Description>
                   {getPropertyAmenities(propertyAmenities)}
                 </Card.Description>
+                {isCompact && (
+                  <FlexContainer justifyContent="flex-end">
+                    <PriceLabel
+                      periodText={priceLabelPeriodText}
+                      pricePerPeriod={priceLabelpricePerPeriod}
+                      pricePerPeriodPrefix={priceLabelPricePerPeriodPrefix}
+                    />
+                  </FlexContainer>
+                )}
               </Card.Content>
             </Fragment>
           )}
@@ -142,12 +154,13 @@ Component.defaultProps = {
   imageSizes: undefined,
   imageSrcSet: undefined,
   isActive: false,
+  isCompact: false,
   isShowingPlaceholder: false,
   name: undefined,
   onChange: Function.prototype,
   placeholderImageUrl: undefined,
   priceLabelPeriodText: '',
-  priceLabelPricePerPeriod: '',
+  priceLabelpricePerPeriod: '',
   priceLabelPricePerPeriodPrefix: '',
   propertyAmenities: [],
   propertyUrlTarget: '_self',
@@ -180,6 +193,8 @@ Component.propTypes = {
   imageUrl: PropTypes.string.isRequired,
   /** Is the property search result in an active state. */
   isActive: PropTypes.bool,
+  /** Is the property search result displayed with a compact layout. */
+  isCompact: PropTypes.bool,
   /** Is the component showing placeholders to reserve space for content which will appear. */
   isShowingPlaceholder: PropTypes.bool,
   /** The name for the property search result. */
@@ -195,10 +210,10 @@ Component.propTypes = {
   placeholderImageUrl: PropTypes.string,
   /** The text describing the pricing period. */
   priceLabelPeriodText: PropTypes.string,
-  /** The price per period of the property, with currency symbol. */
-  priceLabelPricePerPeriod: PropTypes.string,
   /** The text prefix to display along with the price per period. */
   priceLabelPricePerPeriodPrefix: PropTypes.string,
+  /** The price per period of the property, with currency symbol. */
+  priceLabelpricePerPeriod: PropTypes.string,
   /** The amenities to display as a text*/
   propertyAmenities: PropTypes.arrayOf(PropTypes.string),
   /** The name of the property. */

--- a/src/components/general-widgets/PropertySearchResult/component.spec.js
+++ b/src/components/general-widgets/PropertySearchResult/component.spec.js
@@ -86,6 +86,14 @@ describe('<PropertySearchResult />', () => {
     });
   });
 
+  describe('if `props.isCompact` is passed', () => {
+    it('should return the right structure', () => {
+      const actual = getPropertySearchResult({ isCompact: true });
+
+      expect(actual).toMatchSnapshot();
+    });
+  });
+
   describe('if `props.isShowingPlaceholder` is passed', () => {
     it('should return the right structure', () => {
       const actual = getPropertySearchResult({ isShowingPlaceholder: true });

--- a/src/components/general-widgets/PropertySearchResultList/Readme.md
+++ b/src/components/general-widgets/PropertySearchResultList/Readme.md
@@ -12,9 +12,9 @@ const { propertySearchResults } = require('./mock-data/mock-data');
   //   guestsText: 'guests',
   //   imageUrl:
   //     'https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg',
-  //   pricePerPeriod: '$280',
-  //   periodText: 'per month',
-  //   pricePerPeriodPrefix: 'from'
+  //   priceLabelpricePerPeriod: '$280',
+  //   priceLabelPeriodText: 'per month',
+  //   priceLabelPricePerPeriodPrefix: 'from'
   //   propertyAmenities: ['Pool', 'Wifi', 'Washer', 'Kitchen'],
   //   propertyName: 'The Cat House',
   //   propertyType: 'Bed and breakfast',

--- a/src/components/general-widgets/PropertySearchResultList/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/PropertySearchResultList/__snapshots__/component.spec.js.snap
@@ -22,8 +22,8 @@ exports[`<PropertySearchResultList /> by default should render the right structu
         "guestsText": "guests",
         "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
         "priceLabelPeriodText": "per month",
-        "priceLabelPricePerPeriod": "$28000",
         "priceLabelPricePerPeriodPrefix": "from",
+        "priceLabelpricePerPeriod": "$28000",
         "propertyAmenities": Array [
           "Pool",
           "Wifi",
@@ -45,7 +45,7 @@ exports[`<PropertySearchResultList /> by default should render the right structu
         "guestsNumber": 4,
         "guestsText": "guests",
         "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
-        "priceLabelPricePerPeriod": "$1280",
+        "priceLabelpricePerPeriod": "$1280",
         "propertyAmenities": Array [
           "Pool",
           "Wifi",
@@ -162,8 +162,8 @@ exports[`<PropertySearchResultList /> by default should render the right structu
             isShowingPlaceholder={false}
             key="The Cat House0"
             priceLabelPeriodText="per month"
-            priceLabelPricePerPeriod="$28000"
             priceLabelPricePerPeriodPrefix="from"
+            priceLabelpricePerPeriod="$28000"
             propertyAmenities={
               Array [
                 "Pool",
@@ -191,7 +191,7 @@ exports[`<PropertySearchResultList /> by default should render the right structu
             imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
             isShowingPlaceholder={false}
             key="Space Hub A-6751"
-            priceLabelPricePerPeriod="$1280"
+            priceLabelpricePerPeriod="$1280"
             propertyAmenities={
               Array [
                 "Pool",
@@ -245,8 +245,8 @@ exports[`<PropertySearchResultList /> if \`props.dropdownOptions\` is passed sho
         "guestsText": "guests",
         "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
         "priceLabelPeriodText": "per month",
-        "priceLabelPricePerPeriod": "$28000",
         "priceLabelPricePerPeriodPrefix": "from",
+        "priceLabelpricePerPeriod": "$28000",
         "propertyAmenities": Array [
           "Pool",
           "Wifi",
@@ -268,7 +268,7 @@ exports[`<PropertySearchResultList /> if \`props.dropdownOptions\` is passed sho
         "guestsNumber": 4,
         "guestsText": "guests",
         "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
-        "priceLabelPricePerPeriod": "$1280",
+        "priceLabelpricePerPeriod": "$1280",
         "propertyAmenities": Array [
           "Pool",
           "Wifi",
@@ -557,8 +557,8 @@ exports[`<PropertySearchResultList /> if \`props.dropdownOptions\` is passed sho
             isShowingPlaceholder={false}
             key="The Cat House0"
             priceLabelPeriodText="per month"
-            priceLabelPricePerPeriod="$28000"
             priceLabelPricePerPeriodPrefix="from"
+            priceLabelpricePerPeriod="$28000"
             propertyAmenities={
               Array [
                 "Pool",
@@ -586,7 +586,7 @@ exports[`<PropertySearchResultList /> if \`props.dropdownOptions\` is passed sho
             imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
             isShowingPlaceholder={false}
             key="Space Hub A-6751"
-            priceLabelPricePerPeriod="$1280"
+            priceLabelpricePerPeriod="$1280"
             propertyAmenities={
               Array [
                 "Pool",
@@ -888,8 +888,8 @@ exports[`<PropertySearchResultList /> if \`props.messageText\` is passed should 
         "guestsText": "guests",
         "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
         "priceLabelPeriodText": "per month",
-        "priceLabelPricePerPeriod": "$28000",
         "priceLabelPricePerPeriodPrefix": "from",
+        "priceLabelpricePerPeriod": "$28000",
         "propertyAmenities": Array [
           "Pool",
           "Wifi",
@@ -911,7 +911,7 @@ exports[`<PropertySearchResultList /> if \`props.messageText\` is passed should 
         "guestsNumber": 4,
         "guestsText": "guests",
         "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
-        "priceLabelPricePerPeriod": "$1280",
+        "priceLabelpricePerPeriod": "$1280",
         "propertyAmenities": Array [
           "Pool",
           "Wifi",
@@ -1075,8 +1075,8 @@ exports[`<PropertySearchResultList /> if \`props.messageText\` is passed should 
             isShowingPlaceholder={false}
             key="The Cat House0"
             priceLabelPeriodText="per month"
-            priceLabelPricePerPeriod="$28000"
             priceLabelPricePerPeriodPrefix="from"
+            priceLabelpricePerPeriod="$28000"
             propertyAmenities={
               Array [
                 "Pool",
@@ -1104,7 +1104,7 @@ exports[`<PropertySearchResultList /> if \`props.messageText\` is passed should 
             imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
             isShowingPlaceholder={false}
             key="Space Hub A-6751"
-            priceLabelPricePerPeriod="$1280"
+            priceLabelpricePerPeriod="$1280"
             propertyAmenities={
               Array [
                 "Pool",
@@ -1149,8 +1149,8 @@ exports[`<PropertySearchResultList /> if \`props.propertySearchResults.length\` 
         "guestsText": "guests",
         "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
         "priceLabelPeriodText": "per month",
-        "priceLabelPricePerPeriod": "$28000",
         "priceLabelPricePerPeriodPrefix": "from",
+        "priceLabelpricePerPeriod": "$28000",
         "propertyAmenities": Array [
           "Pool",
           "Wifi",
@@ -1173,8 +1173,8 @@ exports[`<PropertySearchResultList /> if \`props.propertySearchResults.length\` 
         "guestsText": "guests",
         "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
         "priceLabelPeriodText": "per month",
-        "priceLabelPricePerPeriod": "$28000",
         "priceLabelPricePerPeriodPrefix": "from",
+        "priceLabelpricePerPeriod": "$28000",
         "propertyAmenities": Array [
           "Pool",
           "Wifi",
@@ -1197,8 +1197,8 @@ exports[`<PropertySearchResultList /> if \`props.propertySearchResults.length\` 
         "guestsText": "guests",
         "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
         "priceLabelPeriodText": "per month",
-        "priceLabelPricePerPeriod": "$28000",
         "priceLabelPricePerPeriodPrefix": "from",
+        "priceLabelpricePerPeriod": "$28000",
         "propertyAmenities": Array [
           "Pool",
           "Wifi",
@@ -1221,8 +1221,8 @@ exports[`<PropertySearchResultList /> if \`props.propertySearchResults.length\` 
         "guestsText": "guests",
         "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
         "priceLabelPeriodText": "per month",
-        "priceLabelPricePerPeriod": "$28000",
         "priceLabelPricePerPeriodPrefix": "from",
+        "priceLabelpricePerPeriod": "$28000",
         "propertyAmenities": Array [
           "Pool",
           "Wifi",
@@ -1245,8 +1245,8 @@ exports[`<PropertySearchResultList /> if \`props.propertySearchResults.length\` 
         "guestsText": "guests",
         "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
         "priceLabelPeriodText": "per month",
-        "priceLabelPricePerPeriod": "$28000",
         "priceLabelPricePerPeriodPrefix": "from",
+        "priceLabelpricePerPeriod": "$28000",
         "propertyAmenities": Array [
           "Pool",
           "Wifi",
@@ -1269,8 +1269,8 @@ exports[`<PropertySearchResultList /> if \`props.propertySearchResults.length\` 
         "guestsText": "guests",
         "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
         "priceLabelPeriodText": "per month",
-        "priceLabelPricePerPeriod": "$28000",
         "priceLabelPricePerPeriodPrefix": "from",
+        "priceLabelpricePerPeriod": "$28000",
         "propertyAmenities": Array [
           "Pool",
           "Wifi",
@@ -1293,8 +1293,8 @@ exports[`<PropertySearchResultList /> if \`props.propertySearchResults.length\` 
         "guestsText": "guests",
         "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
         "priceLabelPeriodText": "per month",
-        "priceLabelPricePerPeriod": "$28000",
         "priceLabelPricePerPeriodPrefix": "from",
+        "priceLabelpricePerPeriod": "$28000",
         "propertyAmenities": Array [
           "Pool",
           "Wifi",
@@ -1317,8 +1317,8 @@ exports[`<PropertySearchResultList /> if \`props.propertySearchResults.length\` 
         "guestsText": "guests",
         "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
         "priceLabelPeriodText": "per month",
-        "priceLabelPricePerPeriod": "$28000",
         "priceLabelPricePerPeriodPrefix": "from",
+        "priceLabelpricePerPeriod": "$28000",
         "propertyAmenities": Array [
           "Pool",
           "Wifi",
@@ -1341,8 +1341,8 @@ exports[`<PropertySearchResultList /> if \`props.propertySearchResults.length\` 
         "guestsText": "guests",
         "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
         "priceLabelPeriodText": "per month",
-        "priceLabelPricePerPeriod": "$28000",
         "priceLabelPricePerPeriodPrefix": "from",
+        "priceLabelpricePerPeriod": "$28000",
         "propertyAmenities": Array [
           "Pool",
           "Wifi",
@@ -1365,8 +1365,8 @@ exports[`<PropertySearchResultList /> if \`props.propertySearchResults.length\` 
         "guestsText": "guests",
         "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
         "priceLabelPeriodText": "per month",
-        "priceLabelPricePerPeriod": "$28000",
         "priceLabelPricePerPeriodPrefix": "from",
+        "priceLabelpricePerPeriod": "$28000",
         "propertyAmenities": Array [
           "Pool",
           "Wifi",
@@ -1389,8 +1389,8 @@ exports[`<PropertySearchResultList /> if \`props.propertySearchResults.length\` 
         "guestsText": "guests",
         "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
         "priceLabelPeriodText": "per month",
-        "priceLabelPricePerPeriod": "$28000",
         "priceLabelPricePerPeriodPrefix": "from",
+        "priceLabelpricePerPeriod": "$28000",
         "propertyAmenities": Array [
           "Pool",
           "Wifi",
@@ -1413,8 +1413,8 @@ exports[`<PropertySearchResultList /> if \`props.propertySearchResults.length\` 
         "guestsText": "guests",
         "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
         "priceLabelPeriodText": "per month",
-        "priceLabelPricePerPeriod": "$28000",
         "priceLabelPricePerPeriodPrefix": "from",
+        "priceLabelpricePerPeriod": "$28000",
         "propertyAmenities": Array [
           "Pool",
           "Wifi",
@@ -1437,8 +1437,8 @@ exports[`<PropertySearchResultList /> if \`props.propertySearchResults.length\` 
         "guestsText": "guests",
         "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
         "priceLabelPeriodText": "per month",
-        "priceLabelPricePerPeriod": "$28000",
         "priceLabelPricePerPeriodPrefix": "from",
+        "priceLabelpricePerPeriod": "$28000",
         "propertyAmenities": Array [
           "Pool",
           "Wifi",
@@ -1555,8 +1555,8 @@ exports[`<PropertySearchResultList /> if \`props.propertySearchResults.length\` 
             isShowingPlaceholder={false}
             key="The Cat House0"
             priceLabelPeriodText="per month"
-            priceLabelPricePerPeriod="$28000"
             priceLabelPricePerPeriodPrefix="from"
+            priceLabelpricePerPeriod="$28000"
             propertyAmenities={
               Array [
                 "Pool",
@@ -1585,8 +1585,8 @@ exports[`<PropertySearchResultList /> if \`props.propertySearchResults.length\` 
             isShowingPlaceholder={false}
             key="The Cat House1"
             priceLabelPeriodText="per month"
-            priceLabelPricePerPeriod="$28000"
             priceLabelPricePerPeriodPrefix="from"
+            priceLabelpricePerPeriod="$28000"
             propertyAmenities={
               Array [
                 "Pool",
@@ -1615,8 +1615,8 @@ exports[`<PropertySearchResultList /> if \`props.propertySearchResults.length\` 
             isShowingPlaceholder={false}
             key="The Cat House2"
             priceLabelPeriodText="per month"
-            priceLabelPricePerPeriod="$28000"
             priceLabelPricePerPeriodPrefix="from"
+            priceLabelpricePerPeriod="$28000"
             propertyAmenities={
               Array [
                 "Pool",
@@ -1645,8 +1645,8 @@ exports[`<PropertySearchResultList /> if \`props.propertySearchResults.length\` 
             isShowingPlaceholder={false}
             key="The Cat House3"
             priceLabelPeriodText="per month"
-            priceLabelPricePerPeriod="$28000"
             priceLabelPricePerPeriodPrefix="from"
+            priceLabelpricePerPeriod="$28000"
             propertyAmenities={
               Array [
                 "Pool",
@@ -1675,8 +1675,8 @@ exports[`<PropertySearchResultList /> if \`props.propertySearchResults.length\` 
             isShowingPlaceholder={false}
             key="The Cat House4"
             priceLabelPeriodText="per month"
-            priceLabelPricePerPeriod="$28000"
             priceLabelPricePerPeriodPrefix="from"
+            priceLabelpricePerPeriod="$28000"
             propertyAmenities={
               Array [
                 "Pool",
@@ -1705,8 +1705,8 @@ exports[`<PropertySearchResultList /> if \`props.propertySearchResults.length\` 
             isShowingPlaceholder={false}
             key="The Cat House5"
             priceLabelPeriodText="per month"
-            priceLabelPricePerPeriod="$28000"
             priceLabelPricePerPeriodPrefix="from"
+            priceLabelpricePerPeriod="$28000"
             propertyAmenities={
               Array [
                 "Pool",
@@ -1735,8 +1735,8 @@ exports[`<PropertySearchResultList /> if \`props.propertySearchResults.length\` 
             isShowingPlaceholder={false}
             key="The Cat House6"
             priceLabelPeriodText="per month"
-            priceLabelPricePerPeriod="$28000"
             priceLabelPricePerPeriodPrefix="from"
+            priceLabelpricePerPeriod="$28000"
             propertyAmenities={
               Array [
                 "Pool",
@@ -1765,8 +1765,8 @@ exports[`<PropertySearchResultList /> if \`props.propertySearchResults.length\` 
             isShowingPlaceholder={false}
             key="The Cat House7"
             priceLabelPeriodText="per month"
-            priceLabelPricePerPeriod="$28000"
             priceLabelPricePerPeriodPrefix="from"
+            priceLabelpricePerPeriod="$28000"
             propertyAmenities={
               Array [
                 "Pool",
@@ -1795,8 +1795,8 @@ exports[`<PropertySearchResultList /> if \`props.propertySearchResults.length\` 
             isShowingPlaceholder={false}
             key="The Cat House8"
             priceLabelPeriodText="per month"
-            priceLabelPricePerPeriod="$28000"
             priceLabelPricePerPeriodPrefix="from"
+            priceLabelpricePerPeriod="$28000"
             propertyAmenities={
               Array [
                 "Pool",
@@ -1825,8 +1825,8 @@ exports[`<PropertySearchResultList /> if \`props.propertySearchResults.length\` 
             isShowingPlaceholder={false}
             key="The Cat House9"
             priceLabelPeriodText="per month"
-            priceLabelPricePerPeriod="$28000"
             priceLabelPricePerPeriodPrefix="from"
+            priceLabelpricePerPeriod="$28000"
             propertyAmenities={
               Array [
                 "Pool",
@@ -1855,8 +1855,8 @@ exports[`<PropertySearchResultList /> if \`props.propertySearchResults.length\` 
             isShowingPlaceholder={false}
             key="The Cat House10"
             priceLabelPeriodText="per month"
-            priceLabelPricePerPeriod="$28000"
             priceLabelPricePerPeriodPrefix="from"
+            priceLabelpricePerPeriod="$28000"
             propertyAmenities={
               Array [
                 "Pool",
@@ -1885,8 +1885,8 @@ exports[`<PropertySearchResultList /> if \`props.propertySearchResults.length\` 
             isShowingPlaceholder={false}
             key="The Cat House11"
             priceLabelPeriodText="per month"
-            priceLabelPricePerPeriod="$28000"
             priceLabelPricePerPeriodPrefix="from"
+            priceLabelpricePerPeriod="$28000"
             propertyAmenities={
               Array [
                 "Pool",
@@ -1915,8 +1915,8 @@ exports[`<PropertySearchResultList /> if \`props.propertySearchResults.length\` 
             isShowingPlaceholder={false}
             key="The Cat House12"
             priceLabelPeriodText="per month"
-            priceLabelPricePerPeriod="$28000"
             priceLabelPricePerPeriodPrefix="from"
+            priceLabelpricePerPeriod="$28000"
             propertyAmenities={
               Array [
                 "Pool",
@@ -2239,8 +2239,8 @@ exports[`<PropertySearchResultList /> if \`props.resultsCountText\` is passed sh
         "guestsText": "guests",
         "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
         "priceLabelPeriodText": "per month",
-        "priceLabelPricePerPeriod": "$28000",
         "priceLabelPricePerPeriodPrefix": "from",
+        "priceLabelpricePerPeriod": "$28000",
         "propertyAmenities": Array [
           "Pool",
           "Wifi",
@@ -2262,7 +2262,7 @@ exports[`<PropertySearchResultList /> if \`props.resultsCountText\` is passed sh
         "guestsNumber": 4,
         "guestsText": "guests",
         "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
-        "priceLabelPricePerPeriod": "$1280",
+        "priceLabelpricePerPeriod": "$1280",
         "propertyAmenities": Array [
           "Pool",
           "Wifi",
@@ -2379,8 +2379,8 @@ exports[`<PropertySearchResultList /> if \`props.resultsCountText\` is passed sh
             isShowingPlaceholder={false}
             key="The Cat House0"
             priceLabelPeriodText="per month"
-            priceLabelPricePerPeriod="$28000"
             priceLabelPricePerPeriodPrefix="from"
+            priceLabelpricePerPeriod="$28000"
             propertyAmenities={
               Array [
                 "Pool",
@@ -2408,7 +2408,7 @@ exports[`<PropertySearchResultList /> if \`props.resultsCountText\` is passed sh
             imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
             isShowingPlaceholder={false}
             key="Space Hub A-6751"
-            priceLabelPricePerPeriod="$1280"
+            priceLabelpricePerPeriod="$1280"
             propertyAmenities={
               Array [
                 "Pool",

--- a/src/components/general-widgets/PropertySearchResultList/mock-data/mock-data.js
+++ b/src/components/general-widgets/PropertySearchResultList/mock-data/mock-data.js
@@ -10,7 +10,7 @@ export const propertySearchResults = [
     guestsText: 'guests',
     imageUrl:
       'https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg',
-    priceLabelPricePerPeriod: '$28000',
+    priceLabelpricePerPeriod: '$28000',
     priceLabelPeriodText: 'per month',
     priceLabelPricePerPeriodPrefix: 'from',
     propertyAmenities: ['Pool', 'Wifi', 'Washer', 'Kitchen'],
@@ -30,7 +30,7 @@ export const propertySearchResults = [
     guestsText: 'guests',
     imageUrl:
       'https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg',
-    priceLabelPricePerPeriod: '$1280',
+    priceLabelpricePerPeriod: '$1280',
     propertyAmenities: ['Pool', 'Wifi', 'Washer', 'Kitchen'],
     propertyName: 'Space Hub A-675',
     propertyType: 'Space Station',

--- a/src/styles/semantic/themes/livingstone/views/card.overrides
+++ b/src/styles/semantic/themes/livingstone/views/card.overrides
@@ -118,20 +118,57 @@
     margin: 0 @searchResultSideMargin @searchResultMargin @searchResultSideMargin;
     width: @searchResultWidth;
 
+    @media @tinyScreen {
+      width: 100% !important;
+      margin-right: 0;
+    }
+
     &.active {
       box-shadow: @searchResultBoxShadow;
       transition: @searchResultBoxShadowTransition;
+    }
+
+    &.is-compact {
+      height: auto;
+      width: @compactSearchResultWidth;
+
+      .ui.card {
+        height: auto !important;
+        flex-direction: row;
+
+        > .flex-container {
+          min-width: @compactSearchResultImageMinWidth;
+          height: auto !important;
+        }
+
+        > .content {
+          padding: @compactSearchResultContentPadding;
+          display: grid;
+
+          > .header .ui.header {
+            font-size: 16px;
+          }
+
+          > .flex-container {
+            height: inherit !important;
+            margin-top: @compactSearchResultPriceLabelMarginTop;
+
+            .ui.header {
+              padding: 0;
+            }
+
+            p {
+              margin-bottom: 0;
+            }
+          }
+        }
+      }
     }
 
     .ui.card {
       display: inline-flex;
       width: 100%;
       height: 100%;
-
-      @media @tinyScreen {
-        width: 100%;
-        margin-right: 0;
-      }
 
       > .flex-container {
         position: relative;

--- a/src/styles/semantic/themes/livingstone/views/card.variables
+++ b/src/styles/semantic/themes/livingstone/views/card.variables
@@ -98,6 +98,12 @@
 @searchResultPlaceholderPadding: 63%;
 @mobileSearchResultPlaceholderPadding: 55%;
 
+@compactSearchResultWidth: 365px;
+@compactSearchResultImageMinWidth: 110px;
+@compactSearchResultContentPadding: 15px;
+@compactSearchResultFontSize: 16px;
+@compactSearchResultPriceLabelMarginTop: 10px;
+
 /*-------------------
       Variations
 --------------------*/


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-2428)

### What **one** thing does this PR do?
Exposes `isCompact` prop for `PropertySearchResult`

### Behaviour

![Kapture 2019-07-11 at 21 35 18](https://user-images.githubusercontent.com/33876435/61080114-9cebfc80-a424-11e9-8901-94081da5c868.gif)

<img width="686" alt="Screenshot 2019-07-12 at 09 18 45" src="https://user-images.githubusercontent.com/33876435/61109803-136d1680-a486-11e9-8fc2-986abc1f687a.png">
