### PR TITLE
TE-2476 fix(Footer): pass email not faxNumber to href

### DIFF
--- a/src/components/collections/Footer/__snapshots__/component.spec.js.snap
+++ b/src/components/collections/Footer/__snapshots__/component.spec.js.snap
@@ -1568,7 +1568,7 @@ exports[`<Footer /> if \`props.emailAddress\` is passed should render the right 
                         Email
                       </label>
                       <a
-                        href="mailto:undefined"
+                        href="mailto:adsf@asdf.com"
                       >
                         adsf@asdf.com
                       </a>

--- a/src/components/collections/Footer/component.js
+++ b/src/components/collections/Footer/component.js
@@ -170,7 +170,7 @@ export const Component = ({
           {emailAddress && (
             <Menu.Item className="is-selectable">
               <label>{emailAddressLabel}</label>
-              <a href={getHrefMailToString(faxNumber)}>{emailAddress}</a>
+              <a href={getHrefMailToString(emailAddress)}>{emailAddress}</a>
             </Menu.Item>
           )}
           {copyrightText && (


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-2476)

### What **one** thing does this PR do?
fix(Footer): pass email not faxNumber to href

