### PR TITLE
TE-2514 Line height adjusments

### DIFF
--- a/src/components/collections/CounterInputSegment/__snapshots__/component.spec.js.snap
+++ b/src/components/collections/CounterInputSegment/__snapshots__/component.spec.js.snap
@@ -103,6 +103,7 @@ exports[`<CounterInputSegment /> should return the right structure 1`] = `
               }
             >
               <Paragraph
+                isCompact={false}
                 size="medium"
                 weight={null}
               >
@@ -209,6 +210,7 @@ exports[`<CounterInputSegment /> should return the right structure 1`] = `
                         </Button>
                       </Button>
                       <Paragraph
+                        isCompact={false}
                         size="medium"
                         weight={null}
                       >
@@ -328,6 +330,7 @@ exports[`<CounterInputSegment /> should return the right structure 1`] = `
               }
             >
               <Paragraph
+                isCompact={false}
                 size="medium"
                 weight={null}
               >
@@ -434,6 +437,7 @@ exports[`<CounterInputSegment /> should return the right structure 1`] = `
                         </Button>
                       </Button>
                       <Paragraph
+                        isCompact={false}
                         size="medium"
                         weight={null}
                       >

--- a/src/components/collections/Footer/__snapshots__/component.spec.js.snap
+++ b/src/components/collections/Footer/__snapshots__/component.spec.js.snap
@@ -559,6 +559,7 @@ exports[`<Footer /> if \`props.copyrightText\` is passed should render the right
                               />
                             </svg>
                             <Paragraph
+                              isCompact={false}
                               size="medium"
                               weight={null}
                             >
@@ -917,6 +918,7 @@ exports[`<Footer /> if \`props.currencyOptions\` is an empty array or undefined 
                               />
                             </svg>
                             <Paragraph
+                              isCompact={false}
                               size="medium"
                               weight={null}
                             >
@@ -1522,6 +1524,7 @@ exports[`<Footer /> if \`props.emailAddress\` is passed should render the right 
                               />
                             </svg>
                             <Paragraph
+                              isCompact={false}
                               size="medium"
                               weight={null}
                             >
@@ -2145,6 +2148,7 @@ exports[`<Footer /> if \`props.faxNumber\` is passed should render the right str
                               />
                             </svg>
                             <Paragraph
+                              isCompact={false}
                               size="medium"
                               weight={null}
                             >
@@ -3101,6 +3105,7 @@ exports[`<Footer /> if \`props.hasEmailCapture\` is \`true\` should render the r
                               />
                             </svg>
                             <Paragraph
+                              isCompact={false}
                               size="medium"
                               weight={null}
                             >
@@ -3487,6 +3492,7 @@ exports[`<Footer /> if \`props.languageOptions\` is an empty array or undefined 
                               />
                             </svg>
                             <Paragraph
+                              isCompact={false}
                               size="medium"
                               weight={null}
                             >
@@ -4218,6 +4224,7 @@ exports[`<Footer /> if \`props.navigationItems\` are grouped should render the r
                               />
                             </svg>
                             <Paragraph
+                              isCompact={false}
                               size="medium"
                               weight={null}
                             >
@@ -4871,6 +4878,7 @@ exports[`<Footer /> if \`props.navigationItems\` are passed should render the ri
                               />
                             </svg>
                             <Paragraph
+                              isCompact={false}
                               size="medium"
                               weight={null}
                             >
@@ -5476,6 +5484,7 @@ exports[`<Footer /> if \`props.propertyAddress\` is passed should render the rig
                               />
                             </svg>
                             <Paragraph
+                              isCompact={false}
                               size="medium"
                               weight={null}
                             >
@@ -6102,6 +6111,7 @@ exports[`<Footer /> if \`socialMediaLinks\` has length > 0 should render the rig
                               />
                             </svg>
                             <Paragraph
+                              isCompact={false}
                               size="medium"
                               weight={null}
                             >
@@ -6792,6 +6802,7 @@ exports[`<Footer /> should render the right structure 1`] = `
                               />
                             </svg>
                             <Paragraph
+                              isCompact={false}
                               size="medium"
                               weight={null}
                             >

--- a/src/components/collections/Header/utils/__snapshots__/getLogoMarkup.spec.js.snap
+++ b/src/components/collections/Header/utils/__snapshots__/getLogoMarkup.spec.js.snap
@@ -54,6 +54,7 @@ exports[`getLogoMarkup by default should render the right structure 1`] = `
           </Header>
         </Heading>
         <Paragraph
+          isCompact={false}
           size="tiny"
           weight={null}
         >
@@ -69,9 +70,7 @@ exports[`getLogoMarkup by default should render the right structure 1`] = `
 </MenuItem>
 `;
 
-exports[
-  `getLogoMarkup if \`logoSrc\`, \`logoSizes\` and \`logoSrcSet\` are passed should render the right structure 1`
-] = `
+exports[`getLogoMarkup if \`logoSrc\`, \`logoSizes\` and \`logoSrcSet\` are passed should render the right structure 1`] = `
 <MenuItem
   className="has-sub-text"
   href="someLogoHref"
@@ -121,6 +120,7 @@ exports[
           />
         </Image>
         <Paragraph
+          isCompact={false}
           size="tiny"
           weight={null}
         >

--- a/src/components/collections/RangeInputSegment/__snapshots__/component.spec.js.snap
+++ b/src/components/collections/RangeInputSegment/__snapshots__/component.spec.js.snap
@@ -68,6 +68,7 @@ exports[`<RangeInputSegment /> should return the right structure 1`] = `
             </Header>
           </Heading>
           <Paragraph
+            isCompact={false}
             size="medium"
             weight={null}
           >

--- a/src/components/collections/ToggleInputSegment/__snapshots__/component.spec.js.snap
+++ b/src/components/collections/ToggleInputSegment/__snapshots__/component.spec.js.snap
@@ -206,6 +206,7 @@ exports[`Component if \`props.description\` is passed should render the right st
               </Header>
             </Heading>
             <Paragraph
+              isCompact={false}
               size="medium"
               weight={null}
             >

--- a/src/components/elements/FilterTrigger/__snapshots__/component.spec.js.snap
+++ b/src/components/elements/FilterTrigger/__snapshots__/component.spec.js.snap
@@ -39,6 +39,7 @@ exports[`<FilterTrigger /> by default should render the right structure 1`] = `
             />
           </svg>
           <Paragraph
+            isCompact={false}
             size="medium"
             weight={null}
           >
@@ -94,6 +95,7 @@ exports[`<FilterTrigger /> if \`hasFiltersSelected\` === true should render the 
             />
           </svg>
           <Paragraph
+            isCompact={false}
             size="medium"
             weight={null}
           >

--- a/src/components/elements/Icon/__snapshots__/component.spec.js.snap
+++ b/src/components/elements/Icon/__snapshots__/component.spec.js.snap
@@ -40,6 +40,7 @@ exports[`<Icon /> if \`isReversed\` is true should render the right structure 1`
   some="otherProps"
 >
   <Paragraph
+    isCompact={false}
     size="medium"
     weight={null}
   >
@@ -70,6 +71,7 @@ exports[`<Icon /> if \`labelText\` is passed should render the right structure 1
     />
   </svg>
   <Paragraph
+    isCompact={false}
     size="medium"
     weight={null}
   >
@@ -92,6 +94,7 @@ exports[`<Icon /> if \`labelWeight\` and \`labelText\` is passed should render t
     />
   </svg>
   <Paragraph
+    isCompact={false}
     size="medium"
     weight="heavy"
   >

--- a/src/components/elements/IconCard/__snapshots__/component.spec.js.snap
+++ b/src/components/elements/IconCard/__snapshots__/component.spec.js.snap
@@ -241,6 +241,7 @@ exports[`<IconCard /> if \`props.label\` is defined should render the right stru
         </i>
       </Icon>
       <Paragraph
+        isCompact={false}
         key="🔺0"
         size="medium"
         weight={null}
@@ -301,6 +302,7 @@ exports[`<IconCard /> if \`props.size\` is \`large\` should render the right str
         </i>
       </Icon>
       <Paragraph
+        isCompact={false}
         key="large0"
         size="medium"
         weight={null}

--- a/src/components/elements/PriceLabel/__snapshots__/component.spec.js.snap
+++ b/src/components/elements/PriceLabel/__snapshots__/component.spec.js.snap
@@ -16,6 +16,7 @@ exports[`the \`PriceLabel\` component if there is \`periodText\` if \`isPointing
       justifyContent={null}
     >
       <Paragraph
+        isCompact={false}
         size="medium"
         weight={null}
       />
@@ -55,6 +56,7 @@ exports[`the \`PriceLabel\` component if there is \`periodText\` should return t
       justifyContent={null}
     >
       <Paragraph
+        isCompact={false}
         size="medium"
         weight={null}
       />

--- a/src/components/elements/SummaryCard/__snapshots__/component.spec.js.snap
+++ b/src/components/elements/SummaryCard/__snapshots__/component.spec.js.snap
@@ -29,6 +29,7 @@ exports[`SummaryCard should have the right shape 1`] = `
       ratingNumber={4.5}
     />
     <Paragraph
+      isCompact={false}
       size="medium"
       weight={null}
     >

--- a/src/components/general-widgets/CallMeBack/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/CallMeBack/__snapshots__/component.spec.js.snap
@@ -2604,6 +2604,7 @@ exports[`<CallMeBack /> if \`isPrivacyConsentRequired\` is \`truthy\` should ren
                           className="privacy-consent-label"
                         >
                           <Paragraph
+                            isCompact={false}
                             size="medium"
                             weight={null}
                           >
@@ -2650,6 +2651,7 @@ exports[`<CallMeBack /> if \`isPrivacyConsentRequired\` is \`truthy\` should ren
                                   className="privacy-consent-label"
                                 >
                                   <Paragraph
+                                    isCompact={false}
                                     size="medium"
                                     weight={null}
                                   >
@@ -2681,6 +2683,7 @@ exports[`<CallMeBack /> if \`isPrivacyConsentRequired\` is \`truthy\` should ren
                                   className="privacy-consent-label"
                                 >
                                   <Paragraph
+                                    isCompact={false}
                                     size="medium"
                                     weight={null}
                                   >

--- a/src/components/general-widgets/Contact/Readme.md
+++ b/src/components/general-widgets/Contact/Readme.md
@@ -1,47 +1,4 @@
-```jsx
-const {
-  propertyOptions,
-} = require('./mock-data/options');
-
-<Contact
-  propertyOptions={propertyOptions}
-/>
-```
-
-### Content
-
-
-#### Dropdowns
-
-No dropdown will be rendered if there is no options prop.
-
-```jsx
-<Contact />
-```
-
-A disabled dropdown will be rendered if the options array is empty.
-
-```jsx
-<Contact
-  propertyOptions={[]}
-/>
-```
-
-A dropdown will be rendered if the options array is populated.
-
-```jsx
-const {
-  propertyOptions,
-} = require('./mock-data/options');
-
-<Contact
-  propertyOptions={propertyOptions}
-/>
-```
-
-#### Strings
-
-```jsx
+```jsx 
 const {
   propertyOptions,
 } = require('./mock-data/options');
@@ -63,54 +20,6 @@ const {
   propertyOptions={propertyOptions}
   submitButtonText="Submit"
   isBotProtected
-  botProtectionMessage="The form is protected from hackers"
-/>
-```
-
-### Usage
-
-#### Validation
-
-```jsx
-const {
-  propertyOptions,
-} = require('./mock-data/options');
-
-const validation = {
-  comments: { isRequired: true },
-  dates: {
-    getIsEmpty: value => !value || [value.startDate, value.endDate].includes(null),
-    isRequired: true,
-  },
-  email: { isRequired: true },
-  guests: { isRequired: true },
-  name: { isRequired: true },
-  phone: { isRequired: true },
-  privacyConsent: { isRequired: true },
-  property: { isRequired: true },
-};
-
-<Contact
-  isPrivacyConsentRequired
-  propertyOptions={propertyOptions}
-  validation={validation}
-/>
-```
-
-### States
-
-#### Success
-
-```jsx
-<Contact
-  successMessage="The contact form has been submitted."
-/>
-```
-
-#### Error
-
-```jsx
-<Contact
-  errorMessage="Request Failed. Please try again."
+  botProtectionMessage={<Paragraph weight="light" size="tiny">This site is protected by reCAPTCHA and the Google <a href="https://policies.google.com/privacy" target="_blank">privacy policy</a> and <a href="https://policies.google.com/terms" target="_blank">terms of service</a> apply.</Paragraph>}
 />
 ```

--- a/src/components/general-widgets/Contact/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/Contact/__snapshots__/component.spec.js.snap
@@ -1310,6 +1310,7 @@ exports[`<Contact /> if \`isPrivacyConsentRequired\` is \`truthy\` should render
                           className="privacy-consent-label"
                         >
                           <Paragraph
+                            isCompact={false}
                             size="medium"
                             weight={null}
                           >
@@ -1356,6 +1357,7 @@ exports[`<Contact /> if \`isPrivacyConsentRequired\` is \`truthy\` should render
                                   className="privacy-consent-label"
                                 >
                                   <Paragraph
+                                    isCompact={false}
                                     size="medium"
                                     weight={null}
                                   >
@@ -1387,6 +1389,7 @@ exports[`<Contact /> if \`isPrivacyConsentRequired\` is \`truthy\` should render
                                   className="privacy-consent-label"
                                 >
                                   <Paragraph
+                                    isCompact={false}
                                     size="medium"
                                     weight={null}
                                   >

--- a/src/components/general-widgets/CookieAlert/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/CookieAlert/__snapshots__/component.spec.js.snap
@@ -176,6 +176,7 @@ exports[`The \`CookieAlert\` component if \`isUserOnMobile\` is false should ret
                       className="field"
                     >
                       <Paragraph
+                        isCompact={false}
                         onBlur={[Function]}
                         onChange={[Function]}
                         size="medium"

--- a/src/components/general-widgets/CookieAlert/utils/__snapshots__/getFormMarkup.spec.js.snap
+++ b/src/components/general-widgets/CookieAlert/utils/__snapshots__/getFormMarkup.spec.js.snap
@@ -12,6 +12,7 @@ exports[`\`getFormMarkup\` should render the right structure 1`] = `
   validation={Object {}}
 >
   <Paragraph
+    isCompact={false}
     size="medium"
     weight={null}
   >

--- a/src/components/general-widgets/EmailCapture/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/EmailCapture/__snapshots__/component.spec.js.snap
@@ -1116,6 +1116,7 @@ exports[`<EmailCapture /> the wrapped component if \`props.isUserOnMobile === fa
                                 className="privacy-consent-label"
                               >
                                 <Paragraph
+                                  isCompact={false}
                                   size="medium"
                                   weight={null}
                                 >
@@ -1162,6 +1163,7 @@ exports[`<EmailCapture /> the wrapped component if \`props.isUserOnMobile === fa
                                         className="privacy-consent-label"
                                       >
                                         <Paragraph
+                                          isCompact={false}
                                           size="medium"
                                           weight={null}
                                         >
@@ -1193,6 +1195,7 @@ exports[`<EmailCapture /> the wrapped component if \`props.isUserOnMobile === fa
                                         className="privacy-consent-label"
                                       >
                                         <Paragraph
+                                          isCompact={false}
                                           size="medium"
                                           weight={null}
                                         >
@@ -1886,6 +1889,7 @@ exports[`<EmailCapture /> the wrapped component if \`props.isUserOnMobile === tr
                                 className="privacy-consent-label"
                               >
                                 <Paragraph
+                                  isCompact={false}
                                   size="medium"
                                   weight={null}
                                 >
@@ -1932,6 +1936,7 @@ exports[`<EmailCapture /> the wrapped component if \`props.isUserOnMobile === tr
                                         className="privacy-consent-label"
                                       >
                                         <Paragraph
+                                          isCompact={false}
                                           size="medium"
                                           weight={null}
                                         >
@@ -1963,6 +1968,7 @@ exports[`<EmailCapture /> the wrapped component if \`props.isUserOnMobile === tr
                                         className="privacy-consent-label"
                                       >
                                         <Paragraph
+                                          isCompact={false}
                                           size="medium"
                                           weight={null}
                                         >

--- a/src/components/general-widgets/EmailCapture/utils/__snapshots__/getPrivacyCheckboxMarkup.spec.js.snap
+++ b/src/components/general-widgets/EmailCapture/utils/__snapshots__/getPrivacyCheckboxMarkup.spec.js.snap
@@ -15,6 +15,7 @@ exports[`getPrivacyCheckboxMarkup should return the correct structure 1`] = `
       className="privacy-consent-label"
     >
       <Paragraph
+        isCompact={false}
         size="medium"
         weight={null}
       >

--- a/src/components/general-widgets/OwnerSignUp/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/OwnerSignUp/__snapshots__/component.spec.js.snap
@@ -614,6 +614,7 @@ exports[`<OwnerSignUp /> if \`isPrivacyConsentRequired\` is \`truthy\` should re
                           className="privacy-consent-label"
                         >
                           <Paragraph
+                            isCompact={false}
                             size="medium"
                             weight={null}
                           >
@@ -660,6 +661,7 @@ exports[`<OwnerSignUp /> if \`isPrivacyConsentRequired\` is \`truthy\` should re
                                   className="privacy-consent-label"
                                 >
                                   <Paragraph
+                                    isCompact={false}
                                     size="medium"
                                     weight={null}
                                   >
@@ -691,6 +693,7 @@ exports[`<OwnerSignUp /> if \`isPrivacyConsentRequired\` is \`truthy\` should re
                                   className="privacy-consent-label"
                                 >
                                   <Paragraph
+                                    isCompact={false}
                                     size="medium"
                                     weight={null}
                                   >

--- a/src/components/general-widgets/Promotion/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/Promotion/__snapshots__/component.spec.js.snap
@@ -540,6 +540,7 @@ exports[`The \`Promotion\` component if \`discountCode\` prop is passed should h
                                           >
                                             <div>
                                               <Paragraph
+                                                isCompact={false}
                                                 size="tiny"
                                                 weight={null}
                                               >
@@ -640,6 +641,7 @@ exports[`The \`Promotion\` component if \`discountCode\` prop is passed should h
                                           >
                                             <div>
                                               <Paragraph
+                                                isCompact={false}
                                                 size="tiny"
                                                 weight={null}
                                               >

--- a/src/components/general-widgets/PropertySearchResult/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/PropertySearchResult/__snapshots__/component.spec.js.snap
@@ -63,6 +63,7 @@ exports[`<PropertySearchResult /> if \`periodText\` is a truthy value should ren
             ratingNumber={4.7}
           />
           <Paragraph
+            isCompact={false}
             size="medium"
             weight={null}
           >
@@ -130,6 +131,7 @@ exports[`<PropertySearchResult /> if \`props.isCompact\` is passed should return
             ratingNumber={4.7}
           />
           <Paragraph
+            isCompact={false}
             size="medium"
             weight={null}
           >
@@ -264,6 +266,7 @@ exports[`<PropertySearchResult /> if \`ratingNumber\` is a truthy value should r
           justifyContent={null}
         >
           <Paragraph
+            isCompact={false}
             size="medium"
             weight={null}
           >
@@ -345,6 +348,7 @@ exports[`<PropertySearchResult /> should render the right structure 1`] = `
             ratingNumber={4.7}
           />
           <Paragraph
+            isCompact={false}
             size="medium"
             weight={null}
           >

--- a/src/components/general-widgets/PropertySearchResultList/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/PropertySearchResultList/__snapshots__/component.spec.js.snap
@@ -2201,6 +2201,7 @@ exports[`<PropertySearchResultList /> if \`props.propertySearchResults.length\` 
             </Pagination>
           </Pagination>
           <Paragraph
+            isCompact={false}
             size="medium"
             weight={null}
           >

--- a/src/components/general-widgets/Review/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/Review/__snapshots__/component.spec.js.snap
@@ -497,6 +497,7 @@ exports[`<Review /> if \`props.reviewResponse\` is passed should render the righ
               className="description"
             >
               <Paragraph
+                isCompact={false}
                 size="medium"
                 weight={null}
               >
@@ -564,6 +565,7 @@ exports[`<Review /> if \`props.reviewResponse\` is passed should render the righ
                                   className="top aligned twelve wide column"
                                 >
                                   <Paragraph
+                                    isCompact={false}
                                     size="medium"
                                     weight={null}
                                   >
@@ -600,6 +602,7 @@ exports[`<Review /> if \`props.reviewResponse\` is passed should render the righ
                                   className="top aligned twelve wide column"
                                 >
                                   <Paragraph
+                                    isCompact={false}
                                     size="tiny"
                                     weight={null}
                                   >
@@ -945,6 +948,7 @@ exports[`<Review /> should render the right structure 1`] = `
               className="description"
             >
               <Paragraph
+                isCompact={false}
                 size="medium"
                 weight={null}
               >

--- a/src/components/inputs/Counter/__snapshots__/component.spec.js.snap
+++ b/src/components/inputs/Counter/__snapshots__/component.spec.js.snap
@@ -98,6 +98,7 @@ exports[`Counter render should render the right structure 1`] = `
           </Button>
         </Button>
         <Paragraph
+          isCompact={false}
           size="medium"
           weight={null}
         >

--- a/src/components/inputs/RatingInput/__snapshots__/component.spec.js.snap
+++ b/src/components/inputs/RatingInput/__snapshots__/component.spec.js.snap
@@ -183,6 +183,7 @@ exports[`the \`RatingInput\` component should render a \`Paragraph\` component i
   onChange={[Function]}
 >
   <Paragraph
+    isCompact={false}
     size="medium"
     weight={null}
   >

--- a/src/components/media/ResponsiveImage/__snapshots__/component.spec.js.snap
+++ b/src/components/media/ResponsiveImage/__snapshots__/component.spec.js.snap
@@ -58,6 +58,7 @@ exports[`<ResponsiveImage /> \`render\` if \`props.label\` is passed should have
     id="image"
   />
   <Paragraph
+    isCompact={false}
     size="medium"
     weight={null}
   >

--- a/src/components/media/Slideshow/__snapshots__/component.spec.js.snap
+++ b/src/components/media/Slideshow/__snapshots__/component.spec.js.snap
@@ -405,6 +405,7 @@ exports[`<Slideshow /> if \`images\` have \`descriptionText\` should return the 
   isStretched={false}
 >
   <Paragraph
+    isCompact={false}
     size="medium"
     weight={null}
   >

--- a/src/components/property-page-widgets/Availability/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Availability/__snapshots__/component.spec.js.snap
@@ -352,6 +352,7 @@ exports[`<Availability /> the wrapped component if \`size(props.roomOptionsWithI
             width={null}
           >
             <Paragraph
+              isCompact={false}
               size="tiny"
               weight="heavy"
             >

--- a/src/components/property-page-widgets/Description/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Description/__snapshots__/component.spec.js.snap
@@ -184,6 +184,7 @@ exports[`<Description /> if \`props.descriptionText\` is HTML should have the co
                               />
                             </svg>
                             <Paragraph
+                              isCompact={false}
                               size="medium"
                               weight={null}
                             >
@@ -231,6 +232,7 @@ exports[`<Description /> if \`props.descriptionText\` is HTML should have the co
                               />
                             </svg>
                             <Paragraph
+                              isCompact={false}
                               size="medium"
                               weight={null}
                             >
@@ -278,6 +280,7 @@ exports[`<Description /> if \`props.descriptionText\` is HTML should have the co
                               />
                             </svg>
                             <Paragraph
+                              isCompact={false}
                               size="medium"
                               weight={null}
                             >
@@ -325,6 +328,7 @@ exports[`<Description /> if \`props.descriptionText\` is HTML should have the co
                               />
                             </svg>
                             <Paragraph
+                              isCompact={false}
                               size="medium"
                               weight={null}
                             >
@@ -410,6 +414,7 @@ exports[`<Description /> if \`props.descriptionText\` is HTML should have the co
                                   />
                                 </svg>
                                 <Paragraph
+                                  isCompact={false}
                                   size="medium"
                                   weight={null}
                                 >
@@ -466,6 +471,7 @@ exports[`<Description /> if \`props.descriptionText\` is HTML should have the co
                                   />
                                 </svg>
                                 <Paragraph
+                                  isCompact={false}
                                   size="medium"
                                   weight={null}
                                 >
@@ -522,6 +528,7 @@ exports[`<Description /> if \`props.descriptionText\` is HTML should have the co
                                   />
                                 </svg>
                                 <Paragraph
+                                  isCompact={false}
                                   size="medium"
                                   weight={null}
                                 >
@@ -578,6 +585,7 @@ exports[`<Description /> if \`props.descriptionText\` is HTML should have the co
                                   />
                                 </svg>
                                 <Paragraph
+                                  isCompact={false}
                                   size="medium"
                                   weight={null}
                                 >
@@ -704,6 +712,7 @@ exports[`<Description /> if \`props.descriptionText\` is HTML should have the co
                     />
                   </svg>
                   <Paragraph
+                    isCompact={false}
                     size="medium"
                     weight={null}
                   >
@@ -742,6 +751,7 @@ exports[`<Description /> if \`props.descriptionText\` is HTML should have the co
                     />
                   </svg>
                   <Paragraph
+                    isCompact={false}
                     size="medium"
                     weight={null}
                   >
@@ -940,6 +950,7 @@ exports[`<Description /> if \`props.descriptionText\` is a plain string with few
                               />
                             </svg>
                             <Paragraph
+                              isCompact={false}
                               size="medium"
                               weight={null}
                             >
@@ -987,6 +998,7 @@ exports[`<Description /> if \`props.descriptionText\` is a plain string with few
                               />
                             </svg>
                             <Paragraph
+                              isCompact={false}
                               size="medium"
                               weight={null}
                             >
@@ -1034,6 +1046,7 @@ exports[`<Description /> if \`props.descriptionText\` is a plain string with few
                               />
                             </svg>
                             <Paragraph
+                              isCompact={false}
                               size="medium"
                               weight={null}
                             >
@@ -1081,6 +1094,7 @@ exports[`<Description /> if \`props.descriptionText\` is a plain string with few
                               />
                             </svg>
                             <Paragraph
+                              isCompact={false}
                               size="medium"
                               weight={null}
                             >
@@ -1166,6 +1180,7 @@ exports[`<Description /> if \`props.descriptionText\` is a plain string with few
                                   />
                                 </svg>
                                 <Paragraph
+                                  isCompact={false}
                                   size="medium"
                                   weight={null}
                                 >
@@ -1222,6 +1237,7 @@ exports[`<Description /> if \`props.descriptionText\` is a plain string with few
                                   />
                                 </svg>
                                 <Paragraph
+                                  isCompact={false}
                                   size="medium"
                                   weight={null}
                                 >
@@ -1278,6 +1294,7 @@ exports[`<Description /> if \`props.descriptionText\` is a plain string with few
                                   />
                                 </svg>
                                 <Paragraph
+                                  isCompact={false}
                                   size="medium"
                                   weight={null}
                                 >
@@ -1334,6 +1351,7 @@ exports[`<Description /> if \`props.descriptionText\` is a plain string with few
                                   />
                                 </svg>
                                 <Paragraph
+                                  isCompact={false}
                                   size="medium"
                                   weight={null}
                                 >
@@ -1367,6 +1385,7 @@ exports[`<Description /> if \`props.descriptionText\` is a plain string with few
               className="top aligned twelve wide column"
             >
               <Paragraph
+                isCompact={false}
                 key="Livingstone is a modern website template with clean and straight lines. Its special feature is a wide horizontal header photo slideshow in which logo and header navigation nicely blend in.0"
                 size="medium"
                 weight={null}
@@ -1378,6 +1397,7 @@ exports[`<Description /> if \`props.descriptionText\` is a plain string with few
                 </p>
               </Paragraph>
               <Paragraph
+                isCompact={false}
                 key="Maecenas et efficitur diam. Etiam non ante urna. Donec imperdiet cursus lectus, luctus vestibulum urna aliquet vel. Donec non vehicula est. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos.1"
                 size="medium"
                 weight={null}
@@ -1450,6 +1470,7 @@ exports[`<Description /> if \`props.descriptionText\` is a plain string with few
                     />
                   </svg>
                   <Paragraph
+                    isCompact={false}
                     size="medium"
                     weight={null}
                   >
@@ -1488,6 +1509,7 @@ exports[`<Description /> if \`props.descriptionText\` is a plain string with few
                     />
                   </svg>
                   <Paragraph
+                    isCompact={false}
                     size="medium"
                     weight={null}
                   >
@@ -1690,6 +1712,7 @@ exports[`<Description /> if \`props.descriptionText\` is a plain string with mor
                               />
                             </svg>
                             <Paragraph
+                              isCompact={false}
                               size="medium"
                               weight={null}
                             >
@@ -1737,6 +1760,7 @@ exports[`<Description /> if \`props.descriptionText\` is a plain string with mor
                               />
                             </svg>
                             <Paragraph
+                              isCompact={false}
                               size="medium"
                               weight={null}
                             >
@@ -1784,6 +1808,7 @@ exports[`<Description /> if \`props.descriptionText\` is a plain string with mor
                               />
                             </svg>
                             <Paragraph
+                              isCompact={false}
                               size="medium"
                               weight={null}
                             >
@@ -1831,6 +1856,7 @@ exports[`<Description /> if \`props.descriptionText\` is a plain string with mor
                               />
                             </svg>
                             <Paragraph
+                              isCompact={false}
                               size="medium"
                               weight={null}
                             >
@@ -1916,6 +1942,7 @@ exports[`<Description /> if \`props.descriptionText\` is a plain string with mor
                                   />
                                 </svg>
                                 <Paragraph
+                                  isCompact={false}
                                   size="medium"
                                   weight={null}
                                 >
@@ -1972,6 +1999,7 @@ exports[`<Description /> if \`props.descriptionText\` is a plain string with mor
                                   />
                                 </svg>
                                 <Paragraph
+                                  isCompact={false}
                                   size="medium"
                                   weight={null}
                                 >
@@ -2028,6 +2056,7 @@ exports[`<Description /> if \`props.descriptionText\` is a plain string with mor
                                   />
                                 </svg>
                                 <Paragraph
+                                  isCompact={false}
                                   size="medium"
                                   weight={null}
                                 >
@@ -2084,6 +2113,7 @@ exports[`<Description /> if \`props.descriptionText\` is a plain string with mor
                                   />
                                 </svg>
                                 <Paragraph
+                                  isCompact={false}
                                   size="medium"
                                   weight={null}
                                 >
@@ -2117,6 +2147,7 @@ exports[`<Description /> if \`props.descriptionText\` is a plain string with mor
               className="top aligned twelve wide column"
             >
               <Paragraph
+                isCompact={false}
                 key="Livingstone is a modern website template with clean and straight lines. Its special feature is a wide horizontal header photo slideshow in which logo and header navigation nicely blend in.0"
                 size="medium"
                 weight={null}
@@ -2128,6 +2159,7 @@ exports[`<Description /> if \`props.descriptionText\` is a plain string with mor
                 </p>
               </Paragraph>
               <Paragraph
+                isCompact={false}
                 key="Maecenas et efficitur diam. Etiam non ante urna. Donec imperdiet cursus lectus, luctus vestibulum urna aliquet vel. Donec non vehicula est. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos.1"
                 size="medium"
                 weight={null}
@@ -2139,6 +2171,7 @@ exports[`<Description /> if \`props.descriptionText\` is a plain string with mor
                 </p>
               </Paragraph>
               <Paragraph
+                isCompact={false}
                 key="Maecenas et efficitur diam. Etiam non ante urna. Donec imperdiet cursus lectus, luctus vestibulum urna aliquet vel. Donec non vehicula est. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per...2"
                 size="medium"
                 weight={null}
@@ -2310,6 +2343,7 @@ exports[`<Description /> if \`props.descriptionText\` is a plain string with mor
                     />
                   </svg>
                   <Paragraph
+                    isCompact={false}
                     size="medium"
                     weight={null}
                   >
@@ -2348,6 +2382,7 @@ exports[`<Description /> if \`props.descriptionText\` is a plain string with mor
                     />
                   </svg>
                   <Paragraph
+                    isCompact={false}
                     size="medium"
                     weight={null}
                   >
@@ -2531,6 +2566,7 @@ exports[`<Description /> if \`props.homeHighlights\` is empty should not render 
                               />
                             </svg>
                             <Paragraph
+                              isCompact={false}
                               size="medium"
                               weight={null}
                             >
@@ -2578,6 +2614,7 @@ exports[`<Description /> if \`props.homeHighlights\` is empty should not render 
                               />
                             </svg>
                             <Paragraph
+                              isCompact={false}
                               size="medium"
                               weight={null}
                             >
@@ -2625,6 +2662,7 @@ exports[`<Description /> if \`props.homeHighlights\` is empty should not render 
                               />
                             </svg>
                             <Paragraph
+                              isCompact={false}
                               size="medium"
                               weight={null}
                             >
@@ -2672,6 +2710,7 @@ exports[`<Description /> if \`props.homeHighlights\` is empty should not render 
                               />
                             </svg>
                             <Paragraph
+                              isCompact={false}
                               size="medium"
                               weight={null}
                             >
@@ -2757,6 +2796,7 @@ exports[`<Description /> if \`props.homeHighlights\` is empty should not render 
                                   />
                                 </svg>
                                 <Paragraph
+                                  isCompact={false}
                                   size="medium"
                                   weight={null}
                                 >
@@ -2813,6 +2853,7 @@ exports[`<Description /> if \`props.homeHighlights\` is empty should not render 
                                   />
                                 </svg>
                                 <Paragraph
+                                  isCompact={false}
                                   size="medium"
                                   weight={null}
                                 >
@@ -2869,6 +2910,7 @@ exports[`<Description /> if \`props.homeHighlights\` is empty should not render 
                                   />
                                 </svg>
                                 <Paragraph
+                                  isCompact={false}
                                   size="medium"
                                   weight={null}
                                 >
@@ -2925,6 +2967,7 @@ exports[`<Description /> if \`props.homeHighlights\` is empty should not render 
                                   />
                                 </svg>
                                 <Paragraph
+                                  isCompact={false}
                                   size="medium"
                                   weight={null}
                                 >
@@ -3126,6 +3169,7 @@ exports[`<Description /> should have the correct structure 1`] = `
                               />
                             </svg>
                             <Paragraph
+                              isCompact={false}
                               size="medium"
                               weight={null}
                             >
@@ -3173,6 +3217,7 @@ exports[`<Description /> should have the correct structure 1`] = `
                               />
                             </svg>
                             <Paragraph
+                              isCompact={false}
                               size="medium"
                               weight={null}
                             >
@@ -3220,6 +3265,7 @@ exports[`<Description /> should have the correct structure 1`] = `
                               />
                             </svg>
                             <Paragraph
+                              isCompact={false}
                               size="medium"
                               weight={null}
                             >
@@ -3267,6 +3313,7 @@ exports[`<Description /> should have the correct structure 1`] = `
                               />
                             </svg>
                             <Paragraph
+                              isCompact={false}
                               size="medium"
                               weight={null}
                             >
@@ -3352,6 +3399,7 @@ exports[`<Description /> should have the correct structure 1`] = `
                                   />
                                 </svg>
                                 <Paragraph
+                                  isCompact={false}
                                   size="medium"
                                   weight={null}
                                 >
@@ -3408,6 +3456,7 @@ exports[`<Description /> should have the correct structure 1`] = `
                                   />
                                 </svg>
                                 <Paragraph
+                                  isCompact={false}
                                   size="medium"
                                   weight={null}
                                 >
@@ -3464,6 +3513,7 @@ exports[`<Description /> should have the correct structure 1`] = `
                                   />
                                 </svg>
                                 <Paragraph
+                                  isCompact={false}
                                   size="medium"
                                   weight={null}
                                 >
@@ -3520,6 +3570,7 @@ exports[`<Description /> should have the correct structure 1`] = `
                                   />
                                 </svg>
                                 <Paragraph
+                                  isCompact={false}
                                   size="medium"
                                   weight={null}
                                 >
@@ -3600,6 +3651,7 @@ exports[`<Description /> should have the correct structure 1`] = `
                     />
                   </svg>
                   <Paragraph
+                    isCompact={false}
                     size="medium"
                     weight={null}
                   >
@@ -3638,6 +3690,7 @@ exports[`<Description /> should have the correct structure 1`] = `
                     />
                   </svg>
                   <Paragraph
+                    isCompact={false}
                     size="medium"
                     weight={null}
                   >

--- a/src/components/property-page-widgets/Description/utils/__snapshots__/getDescriptionTextMarkup.spec.js.snap
+++ b/src/components/property-page-widgets/Description/utils/__snapshots__/getDescriptionTextMarkup.spec.js.snap
@@ -3,6 +3,7 @@
 exports[`getDescriptionTextMarkup if \`descriptionText\` has fewer than 100 words should return the right shape 1`] = `
 Array [
   <Paragraph
+    isCompact={false}
     size="medium"
     weight={null}
   >
@@ -14,6 +15,7 @@ Array [
 exports[`getDescriptionTextMarkup if \`descriptionText\` has more than 100 words should return the right shape 1`] = `
 <React.Fragment>
   <Paragraph
+    isCompact={false}
     size="medium"
     weight={null}
   >
@@ -37,6 +39,7 @@ exports[`getDescriptionTextMarkup if \`descriptionText\` has more than 100 words
     }
   >
     <Paragraph
+      isCompact={false}
       size="medium"
       weight={null}
     >

--- a/src/components/property-page-widgets/Description/utils/__snapshots__/getParagraphMarkup.spec.js.snap
+++ b/src/components/property-page-widgets/Description/utils/__snapshots__/getParagraphMarkup.spec.js.snap
@@ -3,6 +3,7 @@
 exports[`getDescriptionTextMarkup should return the right shape 1`] = `
 Array [
   <Paragraph
+    isCompact={false}
     size="medium"
     weight={null}
   >

--- a/src/components/property-page-widgets/HostProfile/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/HostProfile/__snapshots__/component.spec.js.snap
@@ -239,6 +239,7 @@ exports[`<HostProfile /> if \`props.email\` is defined should render the right s
                     className="top aligned seven wide computer twelve wide mobile twelve wide tablet column"
                   >
                     <Paragraph
+                      isCompact={false}
                       size="medium"
                       weight={null}
                     >
@@ -570,6 +571,7 @@ exports[`<HostProfile /> if \`props.languages\` is defined should render the rig
                     className="top aligned seven wide computer twelve wide mobile twelve wide tablet column"
                   >
                     <Paragraph
+                      isCompact={false}
                       size="medium"
                       weight={null}
                     >
@@ -894,6 +896,7 @@ exports[`<HostProfile /> if \`props.phone\` is defined should render the right s
                     className="top aligned seven wide computer twelve wide mobile twelve wide tablet column"
                   >
                     <Paragraph
+                      isCompact={false}
                       size="medium"
                       weight={null}
                     >
@@ -1222,6 +1225,7 @@ exports[`<HostProfile /> should render the right structure 1`] = `
                     className="top aligned seven wide computer twelve wide mobile twelve wide tablet column"
                   >
                     <Paragraph
+                      isCompact={false}
                       size="medium"
                       weight={null}
                     >

--- a/src/components/property-page-widgets/HostProfile/utils/__snapshots__/getDescription.spec.js.snap
+++ b/src/components/property-page-widgets/HostProfile/utils/__snapshots__/getDescription.spec.js.snap
@@ -9,6 +9,7 @@ exports[`\`getDescription\` if \`description\` is valid html should render the r
   width={null}
 >
   <Paragraph
+    isCompact={false}
     size="medium"
     weight={null}
   >
@@ -28,6 +29,7 @@ exports[`\`getDescription\` should have the right structure 1`] = `
   width={null}
 >
   <Paragraph
+    isCompact={false}
     size="medium"
     weight={null}
   >

--- a/src/components/property-page-widgets/Location/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Location/__snapshots__/component.spec.js.snap
@@ -171,6 +171,7 @@ exports[`<Location /> the \`Child\` of the \`Location\` component should have th
                             </i>
                           </Icon>
                           <Paragraph
+                            isCompact={false}
                             key="20km0"
                             size="medium"
                             weight={null}
@@ -182,6 +183,7 @@ exports[`<Location /> the \`Child\` of the \`Location\` component should have th
                             </p>
                           </Paragraph>
                           <Paragraph
+                            isCompact={false}
                             key="Airport1"
                             size="medium"
                             weight={null}
@@ -243,6 +245,7 @@ exports[`<Location /> the \`Child\` of the \`Location\` component should have th
                             </i>
                           </Icon>
                           <Paragraph
+                            isCompact={false}
                             key="2km0"
                             size="medium"
                             weight={null}
@@ -254,6 +257,7 @@ exports[`<Location /> the \`Child\` of the \`Location\` component should have th
                             </p>
                           </Paragraph>
                           <Paragraph
+                            isCompact={false}
                             key="Bus1"
                             size="medium"
                             weight={null}
@@ -315,6 +319,7 @@ exports[`<Location /> the \`Child\` of the \`Location\` component should have th
                             </i>
                           </Icon>
                           <Paragraph
+                            isCompact={false}
                             key="12km0"
                             size="medium"
                             weight={null}
@@ -326,6 +331,7 @@ exports[`<Location /> the \`Child\` of the \`Location\` component should have th
                             </p>
                           </Paragraph>
                           <Paragraph
+                            isCompact={false}
                             key="Motorway1"
                             size="medium"
                             weight={null}
@@ -387,6 +393,7 @@ exports[`<Location /> the \`Child\` of the \`Location\` component should have th
                             </i>
                           </Icon>
                           <Paragraph
+                            isCompact={false}
                             key="2km0"
                             size="medium"
                             weight={null}
@@ -398,6 +405,7 @@ exports[`<Location /> the \`Child\` of the \`Location\` component should have th
                             </p>
                           </Paragraph>
                           <Paragraph
+                            isCompact={false}
                             key="Underground1"
                             size="medium"
                             weight={null}
@@ -557,6 +565,7 @@ exports[`<Location /> the \`Child\` of the \`Location\` component should have th
                             </i>
                           </Icon>
                           <Paragraph
+                            isCompact={false}
                             key="20km0"
                             size="medium"
                             weight={null}
@@ -568,6 +577,7 @@ exports[`<Location /> the \`Child\` of the \`Location\` component should have th
                             </p>
                           </Paragraph>
                           <Paragraph
+                            isCompact={false}
                             key="Airport1"
                             size="medium"
                             weight={null}
@@ -629,6 +639,7 @@ exports[`<Location /> the \`Child\` of the \`Location\` component should have th
                             </i>
                           </Icon>
                           <Paragraph
+                            isCompact={false}
                             key="2km0"
                             size="medium"
                             weight={null}
@@ -640,6 +651,7 @@ exports[`<Location /> the \`Child\` of the \`Location\` component should have th
                             </p>
                           </Paragraph>
                           <Paragraph
+                            isCompact={false}
                             key="Bus1"
                             size="medium"
                             weight={null}
@@ -701,6 +713,7 @@ exports[`<Location /> the \`Child\` of the \`Location\` component should have th
                             </i>
                           </Icon>
                           <Paragraph
+                            isCompact={false}
                             key="12km0"
                             size="medium"
                             weight={null}
@@ -712,6 +725,7 @@ exports[`<Location /> the \`Child\` of the \`Location\` component should have th
                             </p>
                           </Paragraph>
                           <Paragraph
+                            isCompact={false}
                             key="Motorway1"
                             size="medium"
                             weight={null}
@@ -773,6 +787,7 @@ exports[`<Location /> the \`Child\` of the \`Location\` component should have th
                             </i>
                           </Icon>
                           <Paragraph
+                            isCompact={false}
                             key="2km0"
                             size="medium"
                             weight={null}
@@ -784,6 +799,7 @@ exports[`<Location /> the \`Child\` of the \`Location\` component should have th
                             </p>
                           </Paragraph>
                           <Paragraph
+                            isCompact={false}
                             key="Underground1"
                             size="medium"
                             weight={null}
@@ -861,6 +877,7 @@ Array [
           </i>
         </Icon>
         <Paragraph
+          isCompact={false}
           key="20km0"
           size="medium"
           weight={null}
@@ -872,6 +889,7 @@ Array [
           </p>
         </Paragraph>
         <Paragraph
+          isCompact={false}
           key="Airport1"
           size="medium"
           weight={null}
@@ -933,6 +951,7 @@ Array [
           </i>
         </Icon>
         <Paragraph
+          isCompact={false}
           key="2km0"
           size="medium"
           weight={null}
@@ -944,6 +963,7 @@ Array [
           </p>
         </Paragraph>
         <Paragraph
+          isCompact={false}
           key="Bus1"
           size="medium"
           weight={null}
@@ -1005,6 +1025,7 @@ Array [
           </i>
         </Icon>
         <Paragraph
+          isCompact={false}
           key="12km0"
           size="medium"
           weight={null}
@@ -1016,6 +1037,7 @@ Array [
           </p>
         </Paragraph>
         <Paragraph
+          isCompact={false}
           key="Motorway1"
           size="medium"
           weight={null}
@@ -1077,6 +1099,7 @@ Array [
           </i>
         </Icon>
         <Paragraph
+          isCompact={false}
           key="2km0"
           size="medium"
           weight={null}
@@ -1088,6 +1111,7 @@ Array [
           </p>
         </Paragraph>
         <Paragraph
+          isCompact={false}
           key="Underground1"
           size="medium"
           weight={null}
@@ -1149,6 +1173,7 @@ Array [
           </i>
         </Icon>
         <Paragraph
+          isCompact={false}
           key="20km0"
           size="medium"
           weight={null}
@@ -1160,6 +1185,7 @@ Array [
           </p>
         </Paragraph>
         <Paragraph
+          isCompact={false}
           key="Airport1"
           size="medium"
           weight={null}
@@ -1221,6 +1247,7 @@ Array [
           </i>
         </Icon>
         <Paragraph
+          isCompact={false}
           key="2km0"
           size="medium"
           weight={null}
@@ -1232,6 +1259,7 @@ Array [
           </p>
         </Paragraph>
         <Paragraph
+          isCompact={false}
           key="Bus1"
           size="medium"
           weight={null}
@@ -1293,6 +1321,7 @@ Array [
           </i>
         </Icon>
         <Paragraph
+          isCompact={false}
           key="12km0"
           size="medium"
           weight={null}
@@ -1304,6 +1333,7 @@ Array [
           </p>
         </Paragraph>
         <Paragraph
+          isCompact={false}
           key="Motorway1"
           size="medium"
           weight={null}
@@ -1365,6 +1395,7 @@ Array [
           </i>
         </Icon>
         <Paragraph
+          isCompact={false}
           key="2km0"
           size="medium"
           weight={null}
@@ -1376,6 +1407,7 @@ Array [
           </p>
         </Paragraph>
         <Paragraph
+          isCompact={false}
           key="Underground1"
           size="medium"
           weight={null}

--- a/src/components/property-page-widgets/Location/utils/__snapshots__/getLocationDescription.spec.js.snap
+++ b/src/components/property-page-widgets/Location/utils/__snapshots__/getLocationDescription.spec.js.snap
@@ -21,6 +21,7 @@ exports[`getLocationDescription if passed a string that doesnt contain any HTML 
   width={null}
 >
   <Paragraph
+    isCompact={false}
     size="medium"
     weight={null}
   >

--- a/src/components/property-page-widgets/Pictures/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Pictures/__snapshots__/component.spec.js.snap
@@ -216,6 +216,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                               </LazyLoader>
                             </withLazyLoad(ResponsiveImage)>
                             <Paragraph
+                              isCompact={false}
                               size="medium"
                               weight={null}
                             >
@@ -307,6 +308,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                               </LazyLoader>
                             </withLazyLoad(ResponsiveImage)>
                             <Paragraph
+                              isCompact={false}
                               size="medium"
                               weight={null}
                             >
@@ -434,6 +436,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                               </LazyLoader>
                             </withLazyLoad(ResponsiveImage)>
                             <Paragraph
+                              isCompact={false}
                               size="medium"
                               weight={null}
                             >
@@ -525,6 +528,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                               </LazyLoader>
                             </withLazyLoad(ResponsiveImage)>
                             <Paragraph
+                              isCompact={false}
                               size="medium"
                               weight={null}
                             >
@@ -652,6 +656,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                               </LazyLoader>
                             </withLazyLoad(ResponsiveImage)>
                             <Paragraph
+                              isCompact={false}
                               size="medium"
                               weight={null}
                             >
@@ -743,6 +748,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                               </LazyLoader>
                             </withLazyLoad(ResponsiveImage)>
                             <Paragraph
+                              isCompact={false}
                               size="medium"
                               weight={null}
                             >
@@ -870,6 +876,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                               </LazyLoader>
                             </withLazyLoad(ResponsiveImage)>
                             <Paragraph
+                              isCompact={false}
                               size="medium"
                               weight={null}
                             >
@@ -961,6 +968,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                               </LazyLoader>
                             </withLazyLoad(ResponsiveImage)>
                             <Paragraph
+                              isCompact={false}
                               size="medium"
                               weight={null}
                             >
@@ -1088,6 +1096,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                               </LazyLoader>
                             </withLazyLoad(ResponsiveImage)>
                             <Paragraph
+                              isCompact={false}
                               size="medium"
                               weight={null}
                             >
@@ -1179,6 +1188,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                               </LazyLoader>
                             </withLazyLoad(ResponsiveImage)>
                             <Paragraph
+                              isCompact={false}
                               size="medium"
                               weight={null}
                             >

--- a/src/components/property-page-widgets/PolicyAndNotes/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/PolicyAndNotes/__snapshots__/component.spec.js.snap
@@ -116,6 +116,7 @@ exports[`<PolicyAndNotes /> if \`props.cancellationPolicyRules\` is passed shoul
                       </Header>
                     </Heading>
                     <Paragraph
+                      isCompact={false}
                       key="All paid prepayments are non-refundable.0"
                       size="medium"
                       weight={null}
@@ -254,6 +255,7 @@ exports[`<PolicyAndNotes /> if \`props.damageDepositRules\` is passed should hav
                       </Header>
                     </Heading>
                     <Paragraph
+                      isCompact={false}
                       key="A refundable damage deposit of 200.00 € (EUR) is due.0"
                       size="medium"
                       weight={null}
@@ -618,6 +620,7 @@ exports[`<PolicyAndNotes /> if \`props.notesText\` is passed should have the rig
                       </Header>
                     </Heading>
                     <Paragraph
+                      isCompact={false}
                       size="medium"
                       weight={null}
                     >
@@ -760,6 +763,7 @@ exports[`<PolicyAndNotes /> if \`props.paymentScheduleRules\` is passed should h
                       </Header>
                     </Heading>
                     <Paragraph
+                      isCompact={false}
                       key="50% due at time of booking.0"
                       size="medium"
                       weight={null}
@@ -771,6 +775,7 @@ exports[`<PolicyAndNotes /> if \`props.paymentScheduleRules\` is passed should h
                       </p>
                     </Paragraph>
                     <Paragraph
+                      isCompact={false}
                       key="Remaining balance: Due later.1"
                       size="medium"
                       weight={null}

--- a/src/components/property-page-widgets/PolicyAndNotes/utils/__snapshots__/getRuleMarkup.spec.js.snap
+++ b/src/components/property-page-widgets/PolicyAndNotes/utils/__snapshots__/getRuleMarkup.spec.js.snap
@@ -2,6 +2,7 @@
 
 exports[`\`getRuleMarkup\` should return the right structure 1`] = `
 <Paragraph
+  isCompact={false}
   size="medium"
   weight={null}
 >

--- a/src/components/property-page-widgets/Rates/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Rates/__snapshots__/component.spec.js.snap
@@ -407,6 +407,7 @@ exports[`<Rates /> by default should have the right structure 1`] = `
                               >
                                 <div>
                                   <Paragraph
+                                    isCompact={false}
                                     size="medium"
                                     weight="heavy"
                                   >
@@ -417,6 +418,7 @@ exports[`<Rates /> by default should have the right structure 1`] = `
                                     </p>
                                   </Paragraph>
                                   <Paragraph
+                                    isCompact={false}
                                     size="medium"
                                     weight="light"
                                   >
@@ -490,6 +492,7 @@ exports[`<Rates /> by default should have the right structure 1`] = `
                                 className="left floated top aligned column"
                               >
                                 <Paragraph
+                                  isCompact={false}
                                   size="medium"
                                   weight="heavy"
                                 >
@@ -550,6 +553,7 @@ exports[`<Rates /> by default should have the right structure 1`] = `
                                 className="left floated top aligned column"
                               >
                                 <Paragraph
+                                  isCompact={false}
                                   size="medium"
                                   weight="heavy"
                                 >
@@ -610,6 +614,7 @@ exports[`<Rates /> by default should have the right structure 1`] = `
                                 className="left floated top aligned column"
                               >
                                 <Paragraph
+                                  isCompact={false}
                                   size="medium"
                                   weight="heavy"
                                 >
@@ -670,6 +675,7 @@ exports[`<Rates /> by default should have the right structure 1`] = `
                                 className="left floated top aligned column"
                               >
                                 <Paragraph
+                                  isCompact={false}
                                   size="medium"
                                   weight="heavy"
                                 >
@@ -758,6 +764,7 @@ exports[`<Rates /> by default should have the right structure 1`] = `
                               >
                                 <div>
                                   <Paragraph
+                                    isCompact={false}
                                     size="medium"
                                     weight="heavy"
                                   >
@@ -768,6 +775,7 @@ exports[`<Rates /> by default should have the right structure 1`] = `
                                     </p>
                                   </Paragraph>
                                   <Paragraph
+                                    isCompact={false}
                                     size="medium"
                                     weight="light"
                                   >
@@ -841,6 +849,7 @@ exports[`<Rates /> by default should have the right structure 1`] = `
                                 className="left floated top aligned column"
                               >
                                 <Paragraph
+                                  isCompact={false}
                                   size="medium"
                                   weight="heavy"
                                 >
@@ -901,6 +910,7 @@ exports[`<Rates /> by default should have the right structure 1`] = `
                                 className="left floated top aligned column"
                               >
                                 <Paragraph
+                                  isCompact={false}
                                   size="medium"
                                   weight="heavy"
                                 >
@@ -961,6 +971,7 @@ exports[`<Rates /> by default should have the right structure 1`] = `
                                 className="left floated top aligned column"
                               >
                                 <Paragraph
+                                  isCompact={false}
                                   size="medium"
                                   weight="heavy"
                                 >
@@ -1021,6 +1032,7 @@ exports[`<Rates /> by default should have the right structure 1`] = `
                                 className="left floated top aligned column"
                               >
                                 <Paragraph
+                                  isCompact={false}
                                   size="medium"
                                   weight="heavy"
                                 >
@@ -1109,6 +1121,7 @@ exports[`<Rates /> by default should have the right structure 1`] = `
                               >
                                 <div>
                                   <Paragraph
+                                    isCompact={false}
                                     size="medium"
                                     weight="heavy"
                                   >
@@ -1119,6 +1132,7 @@ exports[`<Rates /> by default should have the right structure 1`] = `
                                     </p>
                                   </Paragraph>
                                   <Paragraph
+                                    isCompact={false}
                                     size="medium"
                                     weight="light"
                                   >
@@ -1192,6 +1206,7 @@ exports[`<Rates /> by default should have the right structure 1`] = `
                                 className="left floated top aligned column"
                               >
                                 <Paragraph
+                                  isCompact={false}
                                   size="medium"
                                   weight="heavy"
                                 >
@@ -1252,6 +1267,7 @@ exports[`<Rates /> by default should have the right structure 1`] = `
                                 className="left floated top aligned column"
                               >
                                 <Paragraph
+                                  isCompact={false}
                                   size="medium"
                                   weight="heavy"
                                 >
@@ -1312,6 +1328,7 @@ exports[`<Rates /> by default should have the right structure 1`] = `
                                 className="left floated top aligned column"
                               >
                                 <Paragraph
+                                  isCompact={false}
                                   size="medium"
                                   weight="heavy"
                                 >
@@ -1372,6 +1389,7 @@ exports[`<Rates /> by default should have the right structure 1`] = `
                                 className="left floated top aligned column"
                               >
                                 <Paragraph
+                                  isCompact={false}
                                   size="medium"
                                   weight="heavy"
                                 >
@@ -1432,12 +1450,14 @@ exports[`<Rates /> by default should have the right structure 1`] = `
             Array [
               <div>
                 <Paragraph
+                  isCompact={false}
                   size="medium"
                   weight="heavy"
                 >
                   Season 1
                 </Paragraph>
                 <Paragraph
+                  isCompact={false}
                   size="medium"
                   weight="light"
                 >
@@ -1472,12 +1492,14 @@ exports[`<Rates /> by default should have the right structure 1`] = `
             Array [
               <div>
                 <Paragraph
+                  isCompact={false}
                   size="medium"
                   weight="heavy"
                 >
                   Season 2
                 </Paragraph>
                 <Paragraph
+                  isCompact={false}
                   size="medium"
                   weight="light"
                 >
@@ -1512,12 +1534,14 @@ exports[`<Rates /> by default should have the right structure 1`] = `
             Array [
               <div>
                 <Paragraph
+                  isCompact={false}
                   size="medium"
                   weight="heavy"
                 >
                   Season 3
                 </Paragraph>
                 <Paragraph
+                  isCompact={false}
                   size="medium"
                   weight="light"
                 >
@@ -2002,6 +2026,7 @@ exports[`<Rates /> by default should have the right structure 1`] = `
                       >
                         <div>
                           <Paragraph
+                            isCompact={false}
                             size="medium"
                             weight="heavy"
                           >
@@ -2012,6 +2037,7 @@ exports[`<Rates /> by default should have the right structure 1`] = `
                             </p>
                           </Paragraph>
                           <Paragraph
+                            isCompact={false}
                             size="medium"
                             weight="light"
                           >
@@ -2119,6 +2145,7 @@ exports[`<Rates /> by default should have the right structure 1`] = `
                       >
                         <div>
                           <Paragraph
+                            isCompact={false}
                             size="medium"
                             weight="heavy"
                           >
@@ -2129,6 +2156,7 @@ exports[`<Rates /> by default should have the right structure 1`] = `
                             </p>
                           </Paragraph>
                           <Paragraph
+                            isCompact={false}
                             size="medium"
                             weight="light"
                           >
@@ -2236,6 +2264,7 @@ exports[`<Rates /> by default should have the right structure 1`] = `
                       >
                         <div>
                           <Paragraph
+                            isCompact={false}
                             size="medium"
                             weight="heavy"
                           >
@@ -2246,6 +2275,7 @@ exports[`<Rates /> by default should have the right structure 1`] = `
                             </p>
                           </Paragraph>
                           <Paragraph
+                            isCompact={false}
                             size="medium"
                             weight="light"
                           >
@@ -3186,6 +3216,7 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
       }
     >
       <Paragraph
+        isCompact={false}
         size="medium"
         weight="heavy"
       >
@@ -3974,6 +4005,7 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
                               >
                                 <div>
                                   <Paragraph
+                                    isCompact={false}
                                     size="medium"
                                     weight="heavy"
                                   >
@@ -3984,6 +4016,7 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
                                     </p>
                                   </Paragraph>
                                   <Paragraph
+                                    isCompact={false}
                                     size="medium"
                                     weight="light"
                                   >
@@ -4057,6 +4090,7 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
                                 className="left floated top aligned column"
                               >
                                 <Paragraph
+                                  isCompact={false}
                                   size="medium"
                                   weight="heavy"
                                 >
@@ -4117,6 +4151,7 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
                                 className="left floated top aligned column"
                               >
                                 <Paragraph
+                                  isCompact={false}
                                   size="medium"
                                   weight="heavy"
                                 >
@@ -4177,6 +4212,7 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
                                 className="left floated top aligned column"
                               >
                                 <Paragraph
+                                  isCompact={false}
                                   size="medium"
                                   weight="heavy"
                                 >
@@ -4237,6 +4273,7 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
                                 className="left floated top aligned column"
                               >
                                 <Paragraph
+                                  isCompact={false}
                                   size="medium"
                                   weight="heavy"
                                 >
@@ -4325,6 +4362,7 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
                               >
                                 <div>
                                   <Paragraph
+                                    isCompact={false}
                                     size="medium"
                                     weight="heavy"
                                   >
@@ -4335,6 +4373,7 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
                                     </p>
                                   </Paragraph>
                                   <Paragraph
+                                    isCompact={false}
                                     size="medium"
                                     weight="light"
                                   >
@@ -4408,6 +4447,7 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
                                 className="left floated top aligned column"
                               >
                                 <Paragraph
+                                  isCompact={false}
                                   size="medium"
                                   weight="heavy"
                                 >
@@ -4468,6 +4508,7 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
                                 className="left floated top aligned column"
                               >
                                 <Paragraph
+                                  isCompact={false}
                                   size="medium"
                                   weight="heavy"
                                 >
@@ -4528,6 +4569,7 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
                                 className="left floated top aligned column"
                               >
                                 <Paragraph
+                                  isCompact={false}
                                   size="medium"
                                   weight="heavy"
                                 >
@@ -4588,6 +4630,7 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
                                 className="left floated top aligned column"
                               >
                                 <Paragraph
+                                  isCompact={false}
                                   size="medium"
                                   weight="heavy"
                                 >
@@ -4676,6 +4719,7 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
                               >
                                 <div>
                                   <Paragraph
+                                    isCompact={false}
                                     size="medium"
                                     weight="heavy"
                                   >
@@ -4686,6 +4730,7 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
                                     </p>
                                   </Paragraph>
                                   <Paragraph
+                                    isCompact={false}
                                     size="medium"
                                     weight="light"
                                   >
@@ -4759,6 +4804,7 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
                                 className="left floated top aligned column"
                               >
                                 <Paragraph
+                                  isCompact={false}
                                   size="medium"
                                   weight="heavy"
                                 >
@@ -4819,6 +4865,7 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
                                 className="left floated top aligned column"
                               >
                                 <Paragraph
+                                  isCompact={false}
                                   size="medium"
                                   weight="heavy"
                                 >
@@ -4879,6 +4926,7 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
                                 className="left floated top aligned column"
                               >
                                 <Paragraph
+                                  isCompact={false}
                                   size="medium"
                                   weight="heavy"
                                 >
@@ -4939,6 +4987,7 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
                                 className="left floated top aligned column"
                               >
                                 <Paragraph
+                                  isCompact={false}
                                   size="medium"
                                   weight="heavy"
                                 >
@@ -4999,12 +5048,14 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
             Array [
               <div>
                 <Paragraph
+                  isCompact={false}
                   size="medium"
                   weight="heavy"
                 >
                   Season 1
                 </Paragraph>
                 <Paragraph
+                  isCompact={false}
                   size="medium"
                   weight="light"
                 >
@@ -5039,12 +5090,14 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
             Array [
               <div>
                 <Paragraph
+                  isCompact={false}
                   size="medium"
                   weight="heavy"
                 >
                   Season 2
                 </Paragraph>
                 <Paragraph
+                  isCompact={false}
                   size="medium"
                   weight="light"
                 >
@@ -5079,12 +5132,14 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
             Array [
               <div>
                 <Paragraph
+                  isCompact={false}
                   size="medium"
                   weight="heavy"
                 >
                   Season 3
                 </Paragraph>
                 <Paragraph
+                  isCompact={false}
                   size="medium"
                   weight="light"
                 >
@@ -5569,6 +5624,7 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
                       >
                         <div>
                           <Paragraph
+                            isCompact={false}
                             size="medium"
                             weight="heavy"
                           >
@@ -5579,6 +5635,7 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
                             </p>
                           </Paragraph>
                           <Paragraph
+                            isCompact={false}
                             size="medium"
                             weight="light"
                           >
@@ -5686,6 +5743,7 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
                       >
                         <div>
                           <Paragraph
+                            isCompact={false}
                             size="medium"
                             weight="heavy"
                           >
@@ -5696,6 +5754,7 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
                             </p>
                           </Paragraph>
                           <Paragraph
+                            isCompact={false}
                             size="medium"
                             weight="light"
                           >
@@ -5803,6 +5862,7 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
                       >
                         <div>
                           <Paragraph
+                            isCompact={false}
                             size="medium"
                             weight="heavy"
                           >
@@ -5813,6 +5873,7 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
                             </p>
                           </Paragraph>
                           <Paragraph
+                            isCompact={false}
                             size="medium"
                             weight="light"
                           >

--- a/src/components/property-page-widgets/Rates/utils/__snapshots__/getRateCategoryHeadingMarkup.spec.js.snap
+++ b/src/components/property-page-widgets/Rates/utils/__snapshots__/getRateCategoryHeadingMarkup.spec.js.snap
@@ -3,12 +3,14 @@
 exports[`getRateCategoryHeadingMarkup if \`rateCategory.costPerExtraGuest\` is \`null\` or \`undefined\` should return the right markup 1`] = `
 <div>
   <Paragraph
+    isCompact={false}
     size="medium"
     weight="heavy"
   >
     Mid Season
   </Paragraph>
   <Paragraph
+    isCompact={false}
     size="medium"
     weight="light"
   >
@@ -37,12 +39,14 @@ exports[`getRateCategoryHeadingMarkup if \`rateCategory.costPerExtraGuest\` is \
 exports[`getRateCategoryHeadingMarkup if \`rateCategory.costPerExtraGuest\` is \`null\` or \`undefined\` should return the right markup 2`] = `
 <div>
   <Paragraph
+    isCompact={false}
     size="medium"
     weight="heavy"
   >
     High Season
   </Paragraph>
   <Paragraph
+    isCompact={false}
     size="medium"
     weight="light"
   >
@@ -71,12 +75,14 @@ exports[`getRateCategoryHeadingMarkup if \`rateCategory.costPerExtraGuest\` is \
 exports[`getRateCategoryHeadingMarkup if \`rateCategory.numberOfGuests\` is \`null\` or \`undefined\` should return the right markup 1`] = `
 <div>
   <Paragraph
+    isCompact={false}
     size="medium"
     weight="heavy"
   >
     Mid Season
   </Paragraph>
   <Paragraph
+    isCompact={false}
     size="medium"
     weight="light"
   >
@@ -90,12 +96,14 @@ exports[`getRateCategoryHeadingMarkup if \`rateCategory.numberOfGuests\` is \`nu
 exports[`getRateCategoryHeadingMarkup if \`rateCategory.numberOfGuests\` is \`null\` or \`undefined\` should return the right markup 2`] = `
 <div>
   <Paragraph
+    isCompact={false}
     size="medium"
     weight="heavy"
   >
     High Season
   </Paragraph>
   <Paragraph
+    isCompact={false}
     size="medium"
     weight="light"
   >
@@ -109,12 +117,14 @@ exports[`getRateCategoryHeadingMarkup if \`rateCategory.numberOfGuests\` is \`nu
 exports[`getRateCategoryHeadingMarkup if all values are defined should return the right markup 1`] = `
 <div>
   <Paragraph
+    isCompact={false}
     size="medium"
     weight="heavy"
   >
     Mid Season
   </Paragraph>
   <Paragraph
+    isCompact={false}
     size="medium"
     weight="light"
   >

--- a/src/components/property-page-widgets/Rates/utils/__snapshots__/getRoomTypeDropdownMarkup.spec.js.snap
+++ b/src/components/property-page-widgets/Rates/utils/__snapshots__/getRoomTypeDropdownMarkup.spec.js.snap
@@ -25,6 +25,7 @@ Array [
       }
     >
       <Paragraph
+        isCompact={false}
         size="medium"
         weight="heavy"
       >

--- a/src/components/property-page-widgets/Reviews/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Reviews/__snapshots__/component.spec.js.snap
@@ -1625,6 +1625,7 @@ exports[`<Reviews /> if \`props.isShowingPlaceholder\` is \`true\` should render
                                                       className="top aligned twelve wide column"
                                                     >
                                                       <Paragraph
+                                                        isCompact={false}
                                                         size="medium"
                                                         weight={null}
                                                       >
@@ -1661,6 +1662,7 @@ exports[`<Reviews /> if \`props.isShowingPlaceholder\` is \`true\` should render
                                                       className="top aligned twelve wide column"
                                                     >
                                                       <Paragraph
+                                                        isCompact={false}
                                                         size="tiny"
                                                         weight={null}
                                                       >
@@ -2765,6 +2767,7 @@ exports[`<Reviews /> should render the right structure 1`] = `
                                   className="description"
                                 >
                                   <Paragraph
+                                    isCompact={false}
                                     size="medium"
                                     weight={null}
                                   >
@@ -2832,6 +2835,7 @@ exports[`<Reviews /> should render the right structure 1`] = `
                                                       className="top aligned twelve wide column"
                                                     >
                                                       <Paragraph
+                                                        isCompact={false}
                                                         size="medium"
                                                         weight={null}
                                                       >
@@ -2868,6 +2872,7 @@ exports[`<Reviews /> should render the right structure 1`] = `
                                                       className="top aligned twelve wide column"
                                                     >
                                                       <Paragraph
+                                                        isCompact={false}
                                                         size="tiny"
                                                         weight={null}
                                                       >
@@ -3252,6 +3257,7 @@ exports[`<Reviews /> should render the right structure 1`] = `
                                   className="description"
                                 >
                                   <Paragraph
+                                    isCompact={false}
                                     size="medium"
                                     weight={null}
                                   >

--- a/src/components/property-page-widgets/RoomType/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/RoomType/__snapshots__/component.spec.js.snap
@@ -469,6 +469,7 @@ exports[`<RoomType /> by default should render the correct structure 1`] = `
                                                 />
                                               </svg>
                                               <Paragraph
+                                                isCompact={false}
                                                 size="medium"
                                                 weight={null}
                                               >
@@ -1413,6 +1414,7 @@ exports[`<RoomType /> if \`isUserOnMobile === true\` should render the correct s
                                           role="listitem"
                                         >
                                           <Paragraph
+                                            isCompact={false}
                                             size="medium"
                                             weight={null}
                                           >

--- a/src/components/property-page-widgets/RoomType/utils/__snapshots__/getModalContentMarkup.spec.js.snap
+++ b/src/components/property-page-widgets/RoomType/utils/__snapshots__/getModalContentMarkup.spec.js.snap
@@ -226,6 +226,7 @@ exports[`getModalContentMarkup if \`props.amenities\` size is zero should not re
       </ImageGallery>
     </Slideshow>
     <Paragraph
+      isCompact={false}
       size="medium"
       weight={null}
     >
@@ -251,6 +252,7 @@ exports[`getModalContentMarkup if \`props.amenities\` size is zero should not re
             role="listitem"
           >
             <Paragraph
+              isCompact={false}
               size="medium"
               weight="heavy"
             >
@@ -271,6 +273,7 @@ exports[`getModalContentMarkup if \`props.amenities\` size is zero should not re
             role="listitem"
           >
             <Paragraph
+              isCompact={false}
               size="medium"
               weight="heavy"
             >
@@ -322,6 +325,7 @@ exports[`getModalContentMarkup if \`props.amenities\` size is zero should not re
                 className="bottom aligned twelve wide column"
               >
                 <Paragraph
+                  isCompact={false}
                   size="medium"
                   weight={null}
                 >
@@ -601,6 +605,7 @@ exports[`getModalContentMarkup if \`props.description\` === null should not rend
             role="listitem"
           >
             <Paragraph
+              isCompact={false}
               size="medium"
               weight="heavy"
             >
@@ -621,6 +626,7 @@ exports[`getModalContentMarkup if \`props.description\` === null should not rend
             role="listitem"
           >
             <Paragraph
+              isCompact={false}
               size="medium"
               weight="heavy"
             >
@@ -765,6 +771,7 @@ exports[`getModalContentMarkup if \`props.description\` === null should not rend
                             className="icon has-label"
                           >
                             <Paragraph
+                              isCompact={false}
                               size="medium"
                               weight="heavy"
                             >
@@ -785,6 +792,7 @@ exports[`getModalContentMarkup if \`props.description\` === null should not rend
                           </i>
                         </Icon>
                         <Paragraph
+                          isCompact={false}
                           size="medium"
                           weight={null}
                         >
@@ -829,6 +837,7 @@ exports[`getModalContentMarkup if \`props.description\` === null should not rend
                             className="icon has-label"
                           >
                             <Paragraph
+                              isCompact={false}
                               size="medium"
                               weight="heavy"
                             >
@@ -849,6 +858,7 @@ exports[`getModalContentMarkup if \`props.description\` === null should not rend
                           </i>
                         </Icon>
                         <Paragraph
+                          isCompact={false}
                           size="medium"
                           weight={null}
                         >
@@ -893,6 +903,7 @@ exports[`getModalContentMarkup if \`props.description\` === null should not rend
                 className="bottom aligned twelve wide column"
               >
                 <Paragraph
+                  isCompact={false}
                   size="medium"
                   weight={null}
                 >
@@ -1001,6 +1012,7 @@ exports[`getModalContentMarkup if \`props.ratingNumber\` === null should not ren
       </ImageGallery>
     </Slideshow>
     <Paragraph
+      isCompact={false}
       size="medium"
       weight={null}
     >
@@ -1026,6 +1038,7 @@ exports[`getModalContentMarkup if \`props.ratingNumber\` === null should not ren
             role="listitem"
           >
             <Paragraph
+              isCompact={false}
               size="medium"
               weight="heavy"
             >
@@ -1046,6 +1059,7 @@ exports[`getModalContentMarkup if \`props.ratingNumber\` === null should not ren
             role="listitem"
           >
             <Paragraph
+              isCompact={false}
               size="medium"
               weight="heavy"
             >
@@ -1190,6 +1204,7 @@ exports[`getModalContentMarkup if \`props.ratingNumber\` === null should not ren
                             className="icon has-label"
                           >
                             <Paragraph
+                              isCompact={false}
                               size="medium"
                               weight="heavy"
                             >
@@ -1210,6 +1225,7 @@ exports[`getModalContentMarkup if \`props.ratingNumber\` === null should not ren
                           </i>
                         </Icon>
                         <Paragraph
+                          isCompact={false}
                           size="medium"
                           weight={null}
                         >
@@ -1254,6 +1270,7 @@ exports[`getModalContentMarkup if \`props.ratingNumber\` === null should not ren
                             className="icon has-label"
                           >
                             <Paragraph
+                              isCompact={false}
                               size="medium"
                               weight="heavy"
                             >
@@ -1274,6 +1291,7 @@ exports[`getModalContentMarkup if \`props.ratingNumber\` === null should not ren
                           </i>
                         </Icon>
                         <Paragraph
+                          isCompact={false}
                           size="medium"
                           weight={null}
                         >
@@ -1318,6 +1336,7 @@ exports[`getModalContentMarkup if \`props.ratingNumber\` === null should not ren
                 className="bottom aligned twelve wide column"
               >
                 <Paragraph
+                  isCompact={false}
                   size="medium"
                   weight={null}
                 >
@@ -1579,6 +1598,7 @@ exports[`getModalContentMarkup if \`props.slideShowImages.length\` > 1 should re
       </ImageGallery>
     </Slideshow>
     <Paragraph
+      isCompact={false}
       size="medium"
       weight={null}
     >
@@ -1604,6 +1624,7 @@ exports[`getModalContentMarkup if \`props.slideShowImages.length\` > 1 should re
             role="listitem"
           >
             <Paragraph
+              isCompact={false}
               size="medium"
               weight="heavy"
             >
@@ -1624,6 +1645,7 @@ exports[`getModalContentMarkup if \`props.slideShowImages.length\` > 1 should re
             role="listitem"
           >
             <Paragraph
+              isCompact={false}
               size="medium"
               weight="heavy"
             >
@@ -1768,6 +1790,7 @@ exports[`getModalContentMarkup if \`props.slideShowImages.length\` > 1 should re
                             className="icon has-label"
                           >
                             <Paragraph
+                              isCompact={false}
                               size="medium"
                               weight="heavy"
                             >
@@ -1788,6 +1811,7 @@ exports[`getModalContentMarkup if \`props.slideShowImages.length\` > 1 should re
                           </i>
                         </Icon>
                         <Paragraph
+                          isCompact={false}
                           size="medium"
                           weight={null}
                         >
@@ -1832,6 +1856,7 @@ exports[`getModalContentMarkup if \`props.slideShowImages.length\` > 1 should re
                             className="icon has-label"
                           >
                             <Paragraph
+                              isCompact={false}
                               size="medium"
                               weight="heavy"
                             >
@@ -1852,6 +1877,7 @@ exports[`getModalContentMarkup if \`props.slideShowImages.length\` > 1 should re
                           </i>
                         </Icon>
                         <Paragraph
+                          isCompact={false}
                           size="medium"
                           weight={null}
                         >
@@ -1896,6 +1922,7 @@ exports[`getModalContentMarkup if \`props.slideShowImages.length\` > 1 should re
                 className="bottom aligned twelve wide column"
               >
                 <Paragraph
+                  isCompact={false}
                   size="medium"
                   weight={null}
                 >
@@ -2145,6 +2172,7 @@ exports[`getModalContentMarkup should return the correct structure 1`] = `
       </ImageGallery>
     </Slideshow>
     <Paragraph
+      isCompact={false}
       size="medium"
       weight={null}
     >
@@ -2170,6 +2198,7 @@ exports[`getModalContentMarkup should return the correct structure 1`] = `
             role="listitem"
           >
             <Paragraph
+              isCompact={false}
               size="medium"
               weight="heavy"
             >
@@ -2190,6 +2219,7 @@ exports[`getModalContentMarkup should return the correct structure 1`] = `
             role="listitem"
           >
             <Paragraph
+              isCompact={false}
               size="medium"
               weight="heavy"
             >
@@ -2334,6 +2364,7 @@ exports[`getModalContentMarkup should return the correct structure 1`] = `
                             className="icon has-label"
                           >
                             <Paragraph
+                              isCompact={false}
                               size="medium"
                               weight="heavy"
                             >
@@ -2354,6 +2385,7 @@ exports[`getModalContentMarkup should return the correct structure 1`] = `
                           </i>
                         </Icon>
                         <Paragraph
+                          isCompact={false}
                           size="medium"
                           weight={null}
                         >
@@ -2398,6 +2430,7 @@ exports[`getModalContentMarkup should return the correct structure 1`] = `
                             className="icon has-label"
                           >
                             <Paragraph
+                              isCompact={false}
                               size="medium"
                               weight="heavy"
                             >
@@ -2418,6 +2451,7 @@ exports[`getModalContentMarkup should return the correct structure 1`] = `
                           </i>
                         </Icon>
                         <Paragraph
+                          isCompact={false}
                           size="medium"
                           weight={null}
                         >
@@ -2462,6 +2496,7 @@ exports[`getModalContentMarkup should return the correct structure 1`] = `
                 className="bottom aligned twelve wide column"
               >
                 <Paragraph
+                  isCompact={false}
                   size="medium"
                   weight={null}
                 >

--- a/src/components/property-page-widgets/RoomTypes/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/RoomTypes/__snapshots__/component.spec.js.snap
@@ -2017,6 +2017,7 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                                       />
                                                     </svg>
                                                     <Paragraph
+                                                      isCompact={false}
                                                       size="medium"
                                                       weight={null}
                                                     >
@@ -2064,6 +2065,7 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                                       />
                                                     </svg>
                                                     <Paragraph
+                                                      isCompact={false}
                                                       size="medium"
                                                       weight={null}
                                                     >
@@ -2111,6 +2113,7 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                                       />
                                                     </svg>
                                                     <Paragraph
+                                                      isCompact={false}
                                                       size="medium"
                                                       weight={null}
                                                     >
@@ -2922,6 +2925,7 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                                       />
                                                     </svg>
                                                     <Paragraph
+                                                      isCompact={false}
                                                       size="medium"
                                                       weight={null}
                                                     >
@@ -2969,6 +2973,7 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                                       />
                                                     </svg>
                                                     <Paragraph
+                                                      isCompact={false}
                                                       size="medium"
                                                       weight={null}
                                                     >
@@ -3016,6 +3021,7 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                                       />
                                                     </svg>
                                                     <Paragraph
+                                                      isCompact={false}
                                                       size="medium"
                                                       weight={null}
                                                     >

--- a/src/components/property-page-widgets/Rules/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Rules/__snapshots__/component.spec.js.snap
@@ -95,6 +95,7 @@ exports[`<Rules /> by default should render the right structure 1`] = `
                     />
                   </svg>
                   <Paragraph
+                    isCompact={false}
                     size="medium"
                     weight={null}
                   >
@@ -147,6 +148,7 @@ exports[`<Rules /> by default should render the right structure 1`] = `
                     />
                   </svg>
                   <Paragraph
+                    isCompact={false}
                     size="medium"
                     weight={null}
                   >
@@ -246,18 +248,21 @@ exports[`<Rules /> if \`props.rules\` length > 0 should render the right structu
                 items={
                   Array [
                     <Paragraph
+                      isCompact={false}
                       size="medium"
                       weight={null}
                     >
                       Smoking not allowed
                     </Paragraph>,
                     <Paragraph
+                      isCompact={false}
                       size="medium"
                       weight={null}
                     >
                       No parties or events
                     </Paragraph>,
                     <Paragraph
+                      isCompact={false}
                       size="medium"
                       weight={null}
                     >
@@ -271,6 +276,7 @@ exports[`<Rules /> if \`props.rules\` length > 0 should render the right structu
                   role="list"
                 >
                   <Paragraph
+                    isCompact={false}
                     key="Smoking not allowed0"
                     onClick={[Function]}
                     size="medium"
@@ -283,6 +289,7 @@ exports[`<Rules /> if \`props.rules\` length > 0 should render the right structu
                     </p>
                   </Paragraph>
                   <Paragraph
+                    isCompact={false}
                     key="No parties or events1"
                     onClick={[Function]}
                     size="medium"
@@ -295,6 +302,7 @@ exports[`<Rules /> if \`props.rules\` length > 0 should render the right structu
                     </p>
                   </Paragraph>
                   <Paragraph
+                    isCompact={false}
                     key="Pets are allowed2"
                     onClick={[Function]}
                     size="medium"
@@ -352,6 +360,7 @@ exports[`<Rules /> if \`props.rules\` length > 0 should render the right structu
                     />
                   </svg>
                   <Paragraph
+                    isCompact={false}
                     size="medium"
                     weight={null}
                   >
@@ -404,6 +413,7 @@ exports[`<Rules /> if \`props.rules\` length > 0 should render the right structu
                     />
                   </svg>
                   <Paragraph
+                    isCompact={false}
                     size="medium"
                     weight={null}
                   >

--- a/src/components/property-page-widgets/SleepingArrangements/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/SleepingArrangements/__snapshots__/component.spec.js.snap
@@ -85,6 +85,7 @@ exports[`<SleepingArrangements /> by default should render the right structure 1
           </i>
         </Icon>
         <Paragraph
+          isCompact={false}
           key="1 king bed0"
           size="medium"
           weight={null}
@@ -143,6 +144,7 @@ exports[`<SleepingArrangements /> by default should render the right structure 1
           </i>
         </Icon>
         <Paragraph
+          isCompact={false}
           key="2 single beds0"
           size="medium"
           weight={null}
@@ -201,6 +203,7 @@ exports[`<SleepingArrangements /> by default should render the right structure 1
           </i>
         </Icon>
         <Paragraph
+          isCompact={false}
           key="1 kennel0"
           size="medium"
           weight={null}
@@ -302,6 +305,7 @@ exports[`<SleepingArrangements /> if \`props.headingText\` is defined should ren
           </i>
         </Icon>
         <Paragraph
+          isCompact={false}
           key="1 king bed0"
           size="medium"
           weight={null}
@@ -360,6 +364,7 @@ exports[`<SleepingArrangements /> if \`props.headingText\` is defined should ren
           </i>
         </Icon>
         <Paragraph
+          isCompact={false}
           key="2 single beds0"
           size="medium"
           weight={null}
@@ -418,6 +423,7 @@ exports[`<SleepingArrangements /> if \`props.headingText\` is defined should ren
           </i>
         </Icon>
         <Paragraph
+          isCompact={false}
           key="1 kennel0"
           size="medium"
           weight={null}

--- a/src/components/typography/Paragraph/__snapshots__/component.spec.js.snap
+++ b/src/components/typography/Paragraph/__snapshots__/component.spec.js.snap
@@ -1,0 +1,46 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Paragraph /> by default should render the right structure 1`] = `
+<Paragraph
+  isCompact={false}
+  size="medium"
+  weight={null}
+>
+  <p
+    className=""
+  >
+    🚸
+    2
+  </p>
+</Paragraph>
+`;
+
+exports[`<Paragraph /> if \`props.isCompact\` is passed should render the right structure 1`] = `
+<Paragraph
+  isCompact={true}
+  size="medium"
+  weight={null}
+>
+  <p
+    className="is-compact"
+  >
+    🚸
+    2
+  </p>
+</Paragraph>
+`;
+
+exports[`<Paragraph /> if \`props.size\` === tiny should render the right structure 1`] = `
+<Paragraph
+  isCompact={false}
+  size="tiny"
+  weight={null}
+>
+  <p
+    className="tiny"
+  >
+    🚸
+    2
+  </p>
+</Paragraph>
+`;

--- a/src/components/typography/Paragraph/component.js
+++ b/src/components/typography/Paragraph/component.js
@@ -9,13 +9,21 @@ const TINY = 'tiny';
  * A paragraph provides text content
  */
 // eslint-disable-next-line jsdoc/require-jsdoc
-export const Component = ({ children, size, weight }) => (
-  <p className={getClassNames(weight, { tiny: size === TINY })}>{children}</p>
+export const Component = ({ children, isCompact, size, weight }) => (
+  <p
+    className={getClassNames(weight, {
+      tiny: size === TINY,
+      'is-compact': isCompact,
+    })}
+  >
+    {children}
+  </p>
 );
 
 Component.displayName = 'Paragraph';
 
 Component.defaultProps = {
+  isCompact: false,
   size: MEDIUM,
   weight: null,
 };
@@ -26,6 +34,8 @@ Component.propTypes = {
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node,
   ]).isRequired,
+  /** The paragraph has reduced line height. */
+  isCompact: PropTypes.bool,
   /** The size of the paragraph. */
   size: PropTypes.oneOf([MEDIUM, TINY]),
   /** The weight of the paragraph. */

--- a/src/components/typography/Paragraph/component.spec.js
+++ b/src/components/typography/Paragraph/component.spec.js
@@ -1,49 +1,37 @@
 import React from 'react';
-import { shallow } from 'enzyme';
-import {
-  expectComponentToBe,
-  expectComponentToHaveDisplayName,
-} from '@lodgify/enzyme-jest-expect-helpers';
+import { mount } from 'enzyme';
+import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
 
 import { Component as Paragraph } from './component';
 
-const getParagraph = props => shallow(<Paragraph {...props} />);
-
 const children = ['🚸', 2];
 
+const getParagraph = props =>
+  mount(<Paragraph children={children} {...props} />);
+
 describe('<Paragraph />', () => {
-  it('should default render a single `p` element', () => {
-    const wrapper = getParagraph({ children });
+  describe('by default', () => {
+    it('should render the right structure', () => {
+      const actual = getParagraph();
 
-    expectComponentToBe(wrapper, 'p');
+      expect(actual).toMatchSnapshot();
+    });
   });
 
-  it('should default to adding no className', () => {
-    const header = getParagraph({ children });
-    const actual = header.find('p.tiny');
+  describe('if `props.isCompact` is passed', () => {
+    it('should render the right structure', () => {
+      const actual = getParagraph({ isCompact: true });
 
-    expect(actual).toHaveLength(0);
+      expect(actual).toMatchSnapshot();
+    });
   });
 
-  it('should add no className if `props.size` is `medium`', () => {
-    const header = getParagraph({ children, size: 'medium' });
-    const actual = header.find('p.medium');
+  describe('if `props.size` === tiny', () => {
+    it('should render the right structure', () => {
+      const actual = getParagraph({ size: 'tiny' });
 
-    expect(actual).toHaveLength(0);
-  });
-
-  it('should add className `tiny` if `props.size` is `tiny`', () => {
-    const header = getParagraph({ children, size: 'tiny' });
-    const actual = header.find(`p.tiny`);
-
-    expect(actual).toHaveLength(1);
-  });
-
-  it('should render children', () => {
-    const header = getParagraph({ children });
-    const actual = header.contains(children);
-
-    expect(actual).toBe(true);
+      expect(actual).toMatchSnapshot();
+    });
   });
 
   it('should have displayName `Paragraph`', () => {

--- a/src/styles/semantic/themes/livingstone/collections/form.overrides
+++ b/src/styles/semantic/themes/livingstone/collections/form.overrides
@@ -55,7 +55,6 @@
 
   /* Action link */
   a {
-    line-height: @actionLinkLineHeight;
     color: @themeActionColorDefault;
     color: var(@themeActionColorIdentifier, @themeActionColorDefault);
   }
@@ -133,6 +132,10 @@
 
     .field {
       margin-bottom: @cookieAlertFormFieldMarginBottom;
+    }
+
+    a {
+      line-height: @actionLinkLineHeight;
     }
 
     .ui.button {

--- a/src/styles/semantic/themes/livingstone/globals/site.overrides
+++ b/src/styles/semantic/themes/livingstone/globals/site.overrides
@@ -126,6 +126,10 @@ p.light {
   color: @lightParagraphColor;
 }
 
+p.is-compact {
+  line-height: normal;
+}
+
 /*-------------------
        Links
 --------------------*/

--- a/src/styles/semantic/themes/livingstone/globals/site.overrides
+++ b/src/styles/semantic/themes/livingstone/globals/site.overrides
@@ -57,18 +57,22 @@ h5,
   word-wrap: break-word;
 }
 
+h1,
 h1.ui.header {
   line-height: @h1LineHeight;
 }
 
+h2,
 h2.ui.header {
   line-height: @h2LineHeight;
 }
 
+h3,
 h3.ui.header {
   line-height: @h3LineHeight;
 }
 
+h4,
 h4.ui.header {
   line-height: @h4LineHeight;
 }

--- a/src/styles/semantic/themes/livingstone/globals/site.overrides
+++ b/src/styles/semantic/themes/livingstone/globals/site.overrides
@@ -132,6 +132,10 @@ p.light {
 
 p.is-compact {
   line-height: normal;
+
+  a {
+    line-height: inherit;
+  }
 }
 
 /*-------------------

--- a/src/utils/get-privacy-consent-label/__snapshots__/getPrivacyConsentLabel.spec.js.snap
+++ b/src/utils/get-privacy-consent-label/__snapshots__/getPrivacyConsentLabel.spec.js.snap
@@ -5,6 +5,7 @@ exports[`getPrivacyConsentLabel if \`privacyConsentLabelLinkUrl\` is passed shou
   className="privacy-consent-label"
 >
   <Paragraph
+    isCompact={false}
     size="medium"
     weight={null}
   >
@@ -49,6 +50,7 @@ exports[`getPrivacyConsentLabel if both \`privacyConsentLabelLinkUrl\` and \`pri
   className="privacy-consent-label"
 >
   <Paragraph
+    isCompact={false}
     size="medium"
     weight={null}
   >
@@ -93,6 +95,7 @@ exports[`getPrivacyConsentLabel should return the right structure 1`] = `
   className="privacy-consent-label"
 >
   <Paragraph
+    isCompact={false}
     size="medium"
     weight={null}
   >


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-2514)

### What **one** thing does this PR do?
- h2's all have the same line height
- isCompact paragraphs have reduced line height along with their `<a>`s

### Any other notes
<img width="1213" alt="Screenshot 2019-07-18 at 17 45 17" src="https://user-images.githubusercontent.com/10498995/61475360-ebe8e300-a98a-11e9-97dc-c96b883c341b.png">

#### Line height before
<img width="817" alt="Screenshot 2019-07-18 at 18 36 03" src="https://user-images.githubusercontent.com/10498995/61475374-f1462d80-a98a-11e9-872e-12661b080d40.png">

#### Line height after
<img width="501" alt="Screenshot 2019-07-18 at 18 36 07" src="https://user-images.githubusercontent.com/10498995/61475375-f1462d80-a98a-11e9-97ce-cdb89959edd3.png">
