### PR TITLE
TE-2472 search bar inputs

### DIFF
--- a/src/components/general-widgets/SearchBar/component.js
+++ b/src/components/general-widgets/SearchBar/component.js
@@ -36,6 +36,22 @@ export class Component extends PureComponent {
   };
 
   componentDidUpdate(previousProps, previousState) {
+    const previousInputValueProps = {
+      dates: previousProps.datesInputValue,
+      guests: previousProps.guestsInputValue,
+      location: previousProps.locationInputValue,
+    };
+
+    const currentInputValueProps = {
+      dates: this.props.datesInputValue,
+      guests: this.props.guestsInputValue,
+      location: this.props.locationInputValue,
+    };
+
+    if (!isEqual(previousInputValueProps, currentInputValueProps)) {
+      this.setState(currentInputValueProps);
+    }
+
     !isEqual(previousState, this.state) && this.props.onChangeInput(this.state);
   }
 

--- a/src/components/general-widgets/SearchBar/component.spec.js
+++ b/src/components/general-widgets/SearchBar/component.spec.js
@@ -123,6 +123,56 @@ describe('<SearchBar />', () => {
     });
   });
 
+  describe('componentDidUpdate', () => {
+    describe('if `previousInputValueProps` and `currentInputValueProps` do not equal', () => {
+      it('should call setState with the correct arguments', () => {
+        const onChangeInput = jest.fn();
+        const currentInputValueProps = {
+          datesInputValue: {
+            startDate: {},
+            endDate: {},
+          },
+          guestsInputValue: 1,
+          locationInputValue: 'bro',
+        };
+        const wrapper = getSearchBarShallow({
+          onChangeInput,
+          ...currentInputValueProps,
+        });
+
+        wrapper.instance().setState = jest.fn();
+        wrapper.instance().componentDidUpdate(
+          {
+            datesInputValue: {
+              startDate: {},
+              endDate: {},
+            },
+            guestsInputValue: 2,
+            locationInputValue: 'lol',
+          },
+          {}
+        );
+
+        expect(wrapper.instance().setState).toHaveBeenCalledWith({
+          dates: currentInputValueProps.datesInputValue,
+          guests: currentInputValueProps.guestsInputValue,
+          location: currentInputValueProps.locationInputValue,
+        });
+      });
+    });
+
+    describe('if `previousState` and `this.state` do not equal', () => {
+      it('should call `this.prop.onChangeInput` with the correct arguments', () => {
+        const onChangeInput = jest.fn();
+        const wrapper = getSearchBarShallow({ onChangeInput });
+
+        wrapper.instance().componentDidUpdate({}, {});
+
+        expect(onChangeInput).toHaveBeenCalledWith(wrapper.instance().state);
+      });
+    });
+  });
+
   describe('componentWillUnmount', () => {
     describe('if `this.props.isDisplayedAsModal` is `true`', () => {
       it('should not call `global.document.removeEventListener`', () => {


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-2472)

### What **one** thing does this PR do?
Inputs values are no longer cleared when values are changed by a controlled component.

### Any other notes
#### Before
![Kapture 2019-07-24 at 10 28 24](https://user-images.githubusercontent.com/10498995/61782421-4f996300-ae06-11e9-8cf4-04e82d04df8b.gif)

#### After
![Kapture 2019-07-24 at 10 27 43](https://user-images.githubusercontent.com/10498995/61782427-51fbbd00-ae06-11e9-9d3d-7206c4f5ce4c.gif)


