### PR TITLE
TE-2554 DateRangePicker: fix loony focus change behaviour

### DIFF
--- a/src/components/general-widgets/HomepageHero/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/HomepageHero/__snapshots__/component.spec.js.snap
@@ -880,6 +880,7 @@ exports[`HomepageHero should render the right structure 1`] = `
                                                         </div>
                                                       </Input>
                                                     </InputController>
+                                                    <div />
                                                   </DateRangePicker>
                                                 </Responsive>
                                               </WithResponsive(DateRangePicker)>

--- a/src/components/general-widgets/SearchBar/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/SearchBar/__snapshots__/component.spec.js.snap
@@ -560,6 +560,7 @@ exports[`<SearchBar /> by default should render the right structure 1`] = `
                       </div>
                     </Input>
                   </InputController>
+                  <div />
                 </DateRangePicker>
               </Responsive>
             </WithResponsive(DateRangePicker)>
@@ -1337,6 +1338,7 @@ exports[`<SearchBar /> if \`props.isFixed\` is true should render the right stru
                                 </div>
                               </Input>
                             </InputController>
+                            <div />
                           </DateRangePicker>
                         </Responsive>
                       </WithResponsive(DateRangePicker)>
@@ -2307,6 +2309,7 @@ exports[`<SearchBar /> if \`props.isShowingSummary\` is true should render the r
                       </div>
                     </Input>
                   </InputController>
+                  <div />
                 </DateRangePicker>
               </Responsive>
             </WithResponsive(DateRangePicker)>
@@ -3066,6 +3069,7 @@ exports[`<SearchBar /> if \`props.isStackable\` is true should render the right 
                       </div>
                     </Input>
                   </InputController>
+                  <div />
                 </DateRangePicker>
               </Responsive>
             </WithResponsive(DateRangePicker)>
@@ -3472,6 +3476,7 @@ exports[`<SearchBar /> if \`props.locationOptions\` is not passed should render 
                       </div>
                     </Input>
                   </InputController>
+                  <div />
                 </DateRangePicker>
               </Responsive>
             </WithResponsive(DateRangePicker)>
@@ -4213,6 +4218,7 @@ exports[`<SearchBar /> if \`props.searchButton\` is passed should render the rig
                       </div>
                     </Input>
                   </InputController>
+                  <div />
                 </DateRangePicker>
               </Responsive>
             </WithResponsive(DateRangePicker)>

--- a/src/components/inputs/DateRangePicker/__snapshots__/component.spec.js.snap
+++ b/src/components/inputs/DateRangePicker/__snapshots__/component.spec.js.snap
@@ -128,13 +128,13 @@ exports[`<DateRangePicker /> \`render\` if \`getIsFocusControlled\` returns \`fa
               startDate={null}
               startDateId="start_date_id_"
               startDatePlaceholderText=""
-              withPortal={false}
             >
               <div />
             </DateRangePicker>
           </div>
         </Input>
       </InputController>
+      <div />
     </DateRangePicker>
   </Responsive>
 </WithResponsive(DateRangePicker)>
@@ -268,13 +268,13 @@ exports[`<DateRangePicker /> \`render\` if \`getIsFocusControlled\` returns \`tr
               startDate={null}
               startDateId="start_date_id_"
               startDatePlaceholderText=""
-              withPortal={false}
             >
               <div />
             </DateRangePicker>
           </div>
         </Input>
       </InputController>
+      <div />
     </DateRangePicker>
   </Responsive>
 </WithResponsive(DateRangePicker)>

--- a/src/components/inputs/DateRangePicker/component.js
+++ b/src/components/inputs/DateRangePicker/component.js
@@ -1,5 +1,5 @@
 import moment from 'moment';
-import React, { PureComponent } from 'react';
+import React, { Fragment, PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import uniqid from 'uniqid';
 import { debounce } from 'debounce';
@@ -19,6 +19,7 @@ import { isDisplayedAsModal } from 'utils/is-displayed-as-modal';
 import { getIsFocusControlled } from './utils/getIsFocusControlled';
 import { mapValueToProps } from './utils/mapValueToProps';
 import { getNumberOfMonths } from './utils/getNumberOfMonths';
+import { getIsVisible } from './utils/getIsVisible';
 import { MAXIMUM_SCREEN_WIDTH_FOR_TWO_MONTH_CALENDAR } from './constants';
 
 /**
@@ -27,6 +28,8 @@ import { MAXIMUM_SCREEN_WIDTH_FOR_TWO_MONTH_CALENDAR } from './constants';
 // eslint-disable-next-line jsdoc/require-jsdoc
 class Component extends PureComponent {
   state = {
+    endDateId: uniqid('end_date_id_'),
+    startDateId: uniqid('start_date_id_'),
     focusedInput: null,
     windowHeight: null,
   };
@@ -52,7 +55,17 @@ class Component extends PureComponent {
     previousFocusedInput !== focusedInput && onFocusChange(focusedInput);
   };
 
+  createRef = ref => {
+    this.visibilityCheck = ref;
+  };
+
   handleFocusChange = focusedInput => {
+    if (
+      !isDisplayedAsModal(this.state.windowHeight) &&
+      !getIsVisible(this.visibilityCheck)
+    )
+      return;
+
     getIsFocusControlled(this.props.focusedInput)
       ? this.props.onFocusChange(focusedInput)
       : this.setState({ focusedInput });
@@ -83,51 +96,55 @@ class Component extends PureComponent {
       willOpenAbove,
       windowInnerWidth,
     } = this.props;
+    const { endDateId, startDateId } = this.state;
     const { focusedInput } = getIsFocusControlled(this.props.focusedInput)
       ? this.props
       : this.state;
 
     return (
-      <InputController
-        adaptOnChangeEvent={returnFirstArgument}
-        error={error}
-        initialValue={initialValue}
-        inputOnChangeFunctionName="onDatesChange"
-        isFocused={!!focusedInput}
-        isValid={isValid}
-        mapValueToProps={mapValueToProps}
-        name={name}
-        onChange={onChange}
-        value={value}
-      >
-        <DateRangePicker
-          /* eslint-disable react/jsx-sort-props */
-          // Consumer defined props.
-          displayFormat={displayFormat}
-          endDatePlaceholderText={endDatePlaceholderText}
-          isDayBlocked={getIsDayBlocked}
-          openDirection={getUpOrDownFromBoolean(willOpenAbove)}
-          startDatePlaceholderText={startDatePlaceholderText}
-          // Controlled props
-          focusedInput={focusedInput}
-          // NOTE onDatesChange is required by DateRangePicker but is set in `InputController`
-          onDatesChange={Function.prototype}
-          onFocusChange={this.handleFocusChange}
-          // Static required props.
-          endDateId={uniqid('end_date_id_')}
-          startDateId={uniqid('start_date_id_')}
-          // Static custom appearance props.
-          customArrowIcon={<Icon name={ICON_NAMES.ARROW_RIGHT} />}
-          customInputIcon={<Icon name={ICON_NAMES.CALENDAR} />}
-          daySize={52}
-          hideKeyboardShortcutsPanel
-          navNext={<Icon name={ICON_NAMES.ARROW_RIGHT} />}
-          navPrev={<Icon name={ICON_NAMES.ARROW_LEFT} />}
-          numberOfMonths={getNumberOfMonths(windowInnerWidth)}
-          withPortal={isDisplayedAsModal(this.state.windowHeight)}
-          /* eslint-enable react/jsx-sort-props */
-        />
-      </InputController>
+      <Fragment>
+        <InputController
+          adaptOnChangeEvent={returnFirstArgument}
+          error={error}
+          initialValue={initialValue}
+          inputOnChangeFunctionName="onDatesChange"
+          isFocused={!!focusedInput}
+          isValid={isValid}
+          mapValueToProps={mapValueToProps}
+          name={name}
+          onChange={onChange}
+          value={value}
+        >
+          <DateRangePicker
+            /* eslint-disable react/jsx-sort-props */
+            // Consumer defined props.
+            displayFormat={displayFormat}
+            endDatePlaceholderText={endDatePlaceholderText}
+            isDayBlocked={getIsDayBlocked}
+            openDirection={getUpOrDownFromBoolean(willOpenAbove)}
+            startDatePlaceholderText={startDatePlaceholderText}
+            // Controlled props
+            focusedInput={focusedInput}
+            // NOTE onDatesChange is required by DateRangePicker but is set in `InputController`
+            onDatesChange={Function.prototype}
+            onFocusChange={this.handleFocusChange}
+            // Static required props.
+            endDateId={endDateId}
+            startDateId={startDateId}
+            // Static custom appearance props.
+            customArrowIcon={<Icon name={ICON_NAMES.ARROW_RIGHT} />}
+            customInputIcon={<Icon name={ICON_NAMES.CALENDAR} />}
+            daySize={52}
+            hideKeyboardShortcutsPanel
+            navNext={<Icon name={ICON_NAMES.ARROW_RIGHT} />}
+            navPrev={<Icon name={ICON_NAMES.ARROW_LEFT} />}
+            numberOfMonths={getNumberOfMonths(windowInnerWidth)}
+            withPortal={isDisplayedAsModal(this.state.windowHeight)}
+            /* eslint-enable react/jsx-sort-props */
+          />
+        </InputController>
+        <div ref={this.createRef} />
+      </Fragment>
     );
   }
 }

--- a/src/components/inputs/DateRangePicker/utils/getIsVisible.js
+++ b/src/components/inputs/DateRangePicker/utils/getIsVisible.js
@@ -1,0 +1,5 @@
+/**
+ * @param  {Object} element
+ * @return {boolean}
+ */
+export const getIsVisible = element => !!element && !!element.offSetParent;

--- a/src/components/inputs/DateRangePicker/utils/getIsVisible.spec.js
+++ b/src/components/inputs/DateRangePicker/utils/getIsVisible.spec.js
@@ -1,0 +1,35 @@
+import { getIsVisible } from './getIsVisible';
+
+describe('getIsVisible', () => {
+  describe('if `element` is `null` or `undefined`', () => {
+    it('should return `false`', () => {
+      const testCases = [null, undefined];
+
+      testCases.forEach(testCase => {
+        const actual = getIsVisible(testCase);
+
+        expect(actual).toBe(false);
+      });
+    });
+  });
+
+  describe('if `element.offSetParent` is `null` or `undefined`', () => {
+    it('should return `false`', () => {
+      const testCases = [{ offSetParent: null }, { offSetParent: undefined }];
+
+      testCases.forEach(testCase => {
+        const actual = getIsVisible(testCase);
+
+        expect(actual).toBe(false);
+      });
+    });
+  });
+
+  describe('if `element.offSetParent` is defined', () => {
+    it('should return `true`', () => {
+      const actual = getIsVisible({ offSetParent: '👨' });
+
+      expect(actual).toBe(true);
+    });
+  });
+});

--- a/src/components/property-page-widgets/PropertyPageSearchBar/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/PropertyPageSearchBar/__snapshots__/component.spec.js.snap
@@ -407,6 +407,7 @@ exports[`<PropertyPageSearchBar /> if \`isShowingPlaceholder\` === true should h
                                         </div>
                                       </Input>
                                     </InputController>
+                                    <div />
                                   </DateRangePicker>
                                 </Responsive>
                               </WithResponsive(DateRangePicker)>
@@ -1060,6 +1061,7 @@ exports[`<PropertyPageSearchBar /> if \`isShowingPlaceholder\` === true should h
                                         </div>
                                       </Input>
                                     </InputController>
+                                    <div />
                                   </DateRangePicker>
                                 </Responsive>
                               </WithResponsive(DateRangePicker)>
@@ -1985,6 +1987,7 @@ exports[`<PropertyPageSearchBar /> should have the right structure 1`] = `
                                         </div>
                                       </Input>
                                     </InputController>
+                                    <div />
                                   </DateRangePicker>
                                 </Responsive>
                               </WithResponsive(DateRangePicker)>
@@ -2797,6 +2800,7 @@ exports[`<PropertyPageSearchBar /> should have the right structure 1`] = `
                                         </div>
                                       </Input>
                                     </InputController>
+                                    <div />
                                   </DateRangePicker>
                                 </Responsive>
                               </WithResponsive(DateRangePicker)>


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-2554)

### What **one** thing does this PR do?
Ignores calls to onFocusChange for date range pickers which are not visible on the page.