### PR TITLE
TE-2511 PropertySearchResultList: expose props.onChange

### DIFF
--- a/src/components/general-widgets/PropertySearchResultList/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/PropertySearchResultList/__snapshots__/component.spec.js.snap
@@ -9,6 +9,7 @@ exports[`<PropertySearchResultList /> by default should render the right structu
   messageButtonOnClick={[Function]}
   messageButtonText={null}
   messageText={null}
+  onChange={[Function]}
   propertySearchResults={
     Array [
       Object {
@@ -232,6 +233,7 @@ exports[`<PropertySearchResultList /> if \`props.dropdownOptions\` is passed sho
   messageButtonOnClick={[Function]}
   messageButtonText={null}
   messageText={null}
+  onChange={[Function]}
   propertySearchResults={
     Array [
       Object {
@@ -622,6 +624,7 @@ exports[`<PropertySearchResultList /> if \`props.isShowingPlaceholder\` is true 
   messageButtonOnClick={[Function]}
   messageButtonText={null}
   messageText={null}
+  onChange={[Function]}
   propertySearchResults={Array []}
   renderShowingResultsText={[Function]}
   resultsCountText="results"
@@ -879,6 +882,7 @@ exports[`<PropertySearchResultList /> if \`props.messageText\` is passed should 
   messageButtonOnClick={[Function]}
   messageButtonText="Some button text"
   messageText="Some message text"
+  onChange={[Function]}
   propertySearchResults={
     Array [
       Object {
@@ -1140,6 +1144,7 @@ exports[`<PropertySearchResultList /> if \`props.propertySearchResults.length\` 
   messageButtonOnClick={[Function]}
   messageButtonText={null}
   messageText={null}
+  onChange={[Function]}
   propertySearchResults={
     Array [
       Object {
@@ -2231,6 +2236,7 @@ exports[`<PropertySearchResultList /> if \`props.resultsCountText\` is passed sh
   messageButtonOnClick={[Function]}
   messageButtonText={null}
   messageText={null}
+  onChange={[Function]}
   propertySearchResults={
     Array [
       Object {

--- a/src/components/general-widgets/PropertySearchResultList/component.js
+++ b/src/components/general-widgets/PropertySearchResultList/component.js
@@ -39,7 +39,7 @@ export class Component extends PureComponent {
     { propertySearchResults: previousPropertySearchResults },
     { activePage: previousActivePage }
   ) => {
-    const { propertySearchResults } = this.props;
+    const { onChange, propertySearchResults } = this.props;
     const { activePage } = this.state;
 
     if (
@@ -48,6 +48,7 @@ export class Component extends PureComponent {
     )
       return;
 
+    onChange(activePage);
     this.setState({
       propertySearchResultsToDisplay: getPropertySearchResultsToDisplay(
         activePage,
@@ -166,6 +167,7 @@ Component.defaultProps = {
   messageButtonOnClick: Function.prototype,
   messageButtonText: null,
   messageText: null,
+  onChange: Function.prototype,
   propertySearchResults: [],
   resultsCountText: RESULTS,
   isShowingPlaceholder: false,
@@ -207,6 +209,11 @@ Component.propTypes = {
   messageButtonText: PropTypes.string,
   /** Text to show as a message above the search results. */
   messageText: PropTypes.string,
+  /**
+   * A function called each time the page is changed.
+   * @param  {number} activePage
+   */
+  onChange: PropTypes.func,
   /** An array of [`PropertySearchResult`](#/PropertySearchResult) props objects. */
   propertySearchResults: PropTypes.arrayOf(PropTypes.object),
   /**

--- a/src/components/general-widgets/PropertySearchResultList/component.spec.js
+++ b/src/components/general-widgets/PropertySearchResultList/component.spec.js
@@ -128,6 +128,21 @@ describe('<PropertySearchResultList />', () => {
     });
 
     describe('if `state.activePage` has changed', () => {
+      it('should call `props.onChange` with the right arguments', () => {
+        const onChange = jest.fn();
+        const propertySearchResults = [];
+        const wrapper = getShallowPropertySearchResultList({
+          onChange,
+          propertySearchResults,
+        });
+
+        wrapper
+          .instance()
+          .componentDidUpdate({ propertySearchResults }, { activePage: 2 });
+
+        expect(onChange).toHaveBeenCalledWith(1);
+      });
+
       it('should call `getPropertySearchResultsToDisplay` with the right arguments', () => {
         const propertySearchResults = [];
         const wrapper = getShallowPropertySearchResultList({
@@ -162,6 +177,20 @@ describe('<PropertySearchResultList />', () => {
     });
 
     describe('if `props.propertySearchResults` has changed', () => {
+      it('should call `props.onChange` with the right arguments', () => {
+        const onChange = jest.fn();
+        const wrapper = getShallowPropertySearchResultList({
+          onChange,
+          propertySearchResults: [],
+        });
+
+        wrapper
+          .instance()
+          .componentDidUpdate({ propertySearchResults: [] }, { activePage: 1 });
+
+        expect(onChange).toHaveBeenCalledWith(1);
+      });
+
       it('should call `getPropertySearchResultsToDisplay` with the right arguments', () => {
         const propertySearchResults = [];
         const wrapper = getShallowPropertySearchResultList({


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-2511)

### What **one** thing does this PR do?
PropertySearchResultList: expose props.onChange

