### PR TITLE
TE-2570 Search app optimisations

### DIFF
--- a/src/components/collections/Form/__snapshots__/component.spec.js.snap
+++ b/src/components/collections/Form/__snapshots__/component.spec.js.snap
@@ -144,6 +144,7 @@ exports[`<Form /> if \`props.actionLink\` is passed should render the correct st
               </FormField>
               <Link
                 href={null}
+                isFluid={false}
                 isPositionedRight={false}
                 onClick={[Function]}
                 willOpenInNewTab={false}
@@ -152,6 +153,7 @@ exports[`<Form /> if \`props.actionLink\` is passed should render the correct st
                   as={null}
                   basic={true}
                   floated="left"
+                  fluid={false}
                   href={null}
                   onClick={[Function]}
                   target="_self"

--- a/src/components/elements/Link/component.js
+++ b/src/components/elements/Link/component.js
@@ -8,15 +8,17 @@ import { Button } from 'semantic-ui-react';
 // eslint-disable-next-line jsdoc/require-jsdoc
 export const Component = ({
   children,
-  isPositionedRight,
-  willOpenInNewTab,
   href,
+  isFluid,
+  isPositionedRight,
   onClick,
+  willOpenInNewTab,
 }) => (
   <Button
     as={href && 'a'}
     basic
     floated={isPositionedRight ? 'right' : 'left'}
+    fluid={isFluid}
     href={href}
     onClick={onClick}
     target={willOpenInNewTab ? '_blank' : '_self'}
@@ -30,6 +32,7 @@ Component.displayName = 'Link';
 
 Component.defaultProps = {
   href: null,
+  isFluid: false,
   isPositionedRight: false,
   onClick: Function.prototype,
   willOpenInNewTab: false,
@@ -40,6 +43,8 @@ Component.propTypes = {
   children: PropTypes.node.isRequired,
   /** The URL the link refers to. */
   href: PropTypes.string,
+  /** Does the link take up the width of it's container. */
+  isFluid: PropTypes.bool,
   /** Is the link positioned on the right hand side of its container. */
   isPositionedRight: PropTypes.bool,
   /** The function to call when the link is clicked.

--- a/src/components/elements/Message/__snapshots__/component.spec.js.snap
+++ b/src/components/elements/Message/__snapshots__/component.spec.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Message /> should render the right structure 1`] = `
-<Message>
+<Message
+  isTextAlignedCenter={false}
+>
   <Message
     className="padded"
   >

--- a/src/components/elements/Message/component.js
+++ b/src/components/elements/Message/component.js
@@ -1,22 +1,32 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import { Message } from 'semantic-ui-react';
 
 /**
  * A message displays information that explains nearby content.
  */
 // eslint-disable-next-line jsdoc/require-jsdoc
-export const Component = ({ children }) => (
-  <Message className="padded">{children}</Message>
+export const Component = ({ children, isTextAlignedCenter }) => (
+  <Message
+    className={classNames('padded', {
+      'text-aligned-center': isTextAlignedCenter,
+    })}
+  >
+    {children}
+  </Message>
 );
 
 Component.displayName = 'Message';
 
 Component.defaultProps = {
   children: null,
+  isTextAlignedCenter: false,
 };
 
 Component.propTypes = {
   /** The children to show in the message. */
   children: PropTypes.node,
+  /** Is the message text aligned to the center. */
+  isTextAlignedCenter: PropTypes.bool,
 };

--- a/src/components/elements/SummaryCard/__snapshots__/component.spec.js.snap
+++ b/src/components/elements/SummaryCard/__snapshots__/component.spec.js.snap
@@ -1,5 +1,39 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`SummaryCard if \`ratingNumber\` is falsy should return the right structure 1`] = `
+<Card
+  className="has-summary-card"
+  onClick={[Function]}
+>
+  <CardHeader>
+    <Heading
+      className={null}
+      hasMargin={true}
+      isColorInverted={false}
+      size="medium"
+      textAlign={null}
+    >
+      La casa d'Argent
+    </Heading>
+  </CardHeader>
+  <FlexContainer
+    alignContent={null}
+    alignItems="center"
+    flexDirection="row"
+    flexWrap={null}
+    justifyContent={null}
+  >
+    <Paragraph
+      isCompact={false}
+      size="medium"
+      weight={null}
+    >
+      Soterrani
+    </Paragraph>
+  </FlexContainer>
+</Card>
+`;
+
 exports[`SummaryCard should have the right shape 1`] = `
 <Card
   className="has-summary-card"

--- a/src/components/elements/SummaryCard/component.js
+++ b/src/components/elements/SummaryCard/component.js
@@ -27,7 +27,9 @@ export class Component extends PureComponent {
           <Heading>{propertyName}</Heading>
         </Card.Header>
         <FlexContainer alignItems="center" flexDirection="row">
-          <Rating iconSize="tiny" ratingNumber={ratingNumber} />
+          {!!ratingNumber && (
+            <Rating iconSize="tiny" ratingNumber={ratingNumber} />
+          )}
           <Paragraph size="medium">{propertyType}</Paragraph>
         </FlexContainer>
       </Card>
@@ -40,6 +42,7 @@ Component.displayName = 'SummaryCard';
 Component.defaultProps = {
   name: undefined,
   onClick: Function.prototype,
+  ratingNumber: null,
 };
 
 Component.propTypes = {
@@ -54,5 +57,5 @@ Component.propTypes = {
   /** The name of the type of the property. */
   propertyType: PropTypes.string.isRequired,
   /** The numeral rating for the property, out of 5. */
-  ratingNumber: PropTypes.number.isRequired,
+  ratingNumber: PropTypes.number,
 };

--- a/src/components/elements/SummaryCard/component.spec.js
+++ b/src/components/elements/SummaryCard/component.spec.js
@@ -20,6 +20,14 @@ describe('SummaryCard', () => {
     expect(actual).toMatchSnapshot();
   });
 
+  describe('if `ratingNumber` is falsy', () => {
+    it('should return the right structure', () => {
+      const actual = getSummaryCard({ ratingNumber: 0 });
+
+      expect(actual).toMatchSnapshot();
+    });
+  });
+
   describe('handleClick', () => {
     it('should call `props.onClick` with the right arguments', () => {
       const name = 'Argent';

--- a/src/components/general-widgets/CookieAlert/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/CookieAlert/__snapshots__/component.spec.js.snap
@@ -198,6 +198,7 @@ exports[`The \`CookieAlert\` component if \`isUserOnMobile\` is false should ret
                     >
                       <Link
                         href="/"
+                        isFluid={false}
                         isPositionedRight={false}
                         onBlur={[Function]}
                         onChange={[Function]}
@@ -208,6 +209,7 @@ exports[`The \`CookieAlert\` component if \`isUserOnMobile\` is false should ret
                           as="a"
                           basic={true}
                           floated="left"
+                          fluid={false}
                           href="/"
                           onClick={[Function]}
                           target="_blank"

--- a/src/components/general-widgets/CookieAlert/utils/__snapshots__/getFormMarkup.spec.js.snap
+++ b/src/components/general-widgets/CookieAlert/utils/__snapshots__/getFormMarkup.spec.js.snap
@@ -20,6 +20,7 @@ exports[`\`getFormMarkup\` should render the right structure 1`] = `
   </Paragraph>
   <Link
     href="Bup"
+    isFluid={false}
     isPositionedRight={false}
     onClick={[Function]}
     willOpenInNewTab={true}

--- a/src/components/general-widgets/EmailCapture/utils/__snapshots__/getPrivacyCheckboxMarkup.spec.js.snap
+++ b/src/components/general-widgets/EmailCapture/utils/__snapshots__/getPrivacyCheckboxMarkup.spec.js.snap
@@ -23,6 +23,7 @@ exports[`getPrivacyCheckboxMarkup should return the correct structure 1`] = `
       </Paragraph>
       <Link
         href="privacyConsentLabelLinkUrl"
+        isFluid={false}
         isPositionedRight={false}
         onClick={[Function]}
         willOpenInNewTab={true}

--- a/src/components/general-widgets/OwnerLogin/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/OwnerLogin/__snapshots__/component.spec.js.snap
@@ -270,6 +270,7 @@ exports[`<OwnerLogin /> if \`props.errorMessage\` is passed should render the er
                 </Message>
                 <Link
                   href={null}
+                  isFluid={false}
                   isPositionedRight={false}
                   onClick={[Function]}
                   willOpenInNewTab={false}
@@ -278,6 +279,7 @@ exports[`<OwnerLogin /> if \`props.errorMessage\` is passed should render the er
                     as={null}
                     basic={true}
                     floated="left"
+                    fluid={false}
                     href={null}
                     onClick={[Function]}
                     target="_self"
@@ -692,6 +694,7 @@ exports[`<OwnerLogin /> if \`props.successMessage\` is passed should render the 
                 </Message>
                 <Link
                   href={null}
+                  isFluid={false}
                   isPositionedRight={false}
                   onClick={[Function]}
                   willOpenInNewTab={false}
@@ -700,6 +703,7 @@ exports[`<OwnerLogin /> if \`props.successMessage\` is passed should render the 
                     as={null}
                     basic={true}
                     floated="left"
+                    fluid={false}
                     href={null}
                     onClick={[Function]}
                     target="_self"
@@ -1094,6 +1098,7 @@ exports[`<OwnerLogin /> should render the correct structure 1`] = `
                 </FormField>
                 <Link
                   href={null}
+                  isFluid={false}
                   isPositionedRight={false}
                   onClick={[Function]}
                   willOpenInNewTab={false}
@@ -1102,6 +1107,7 @@ exports[`<OwnerLogin /> should render the correct structure 1`] = `
                     as={null}
                     basic={true}
                     floated="left"
+                    fluid={false}
                     href={null}
                     onClick={[Function]}
                     target="_self"

--- a/src/components/general-widgets/PropertySearchResultList/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/PropertySearchResultList/__snapshots__/component.spec.js.snap
@@ -1071,44 +1071,62 @@ exports[`<PropertySearchResultList /> render if \`props.isShowingPlaceholder\` i
     <div
       className="result-list-container"
     >
-      <Divider
-        className=""
-        hasLine={false}
-        size="small"
-      >
-        <Divider
-          className="is-size-small"
-          hidden={true}
-          section={false}
-        >
-          <div
-            className="ui hidden divider is-size-small"
-          />
-        </Divider>
-      </Divider>
-      <TextPlaceholder
-        isFluid={true}
-        length="short"
+      <FlexContainer
+        alignContent={null}
+        alignItems="center"
+        flexDirection={null}
+        flexWrap={null}
+        justifyContent="space-between"
       >
         <div
-          className="placeholder text short fluid"
-        />
-      </TextPlaceholder>
-      <Divider
-        className=""
-        hasLine={false}
-        size="small"
-      >
-        <Divider
-          className="is-size-small"
-          hidden={true}
-          section={false}
+          className="flex-container"
+          style={
+            Object {
+              "alignContent": null,
+              "alignItems": "center",
+              "display": "flex",
+              "flexDirection": null,
+              "flexGrow": "1",
+              "flexWrap": null,
+              "height": "100%",
+              "justifyContent": "space-between",
+            }
+          }
         >
-          <div
-            className="ui hidden divider is-size-small"
-          />
-        </Divider>
-      </Divider>
+          <FlexContainer
+            alignContent={null}
+            alignItems={null}
+            flexDirection={null}
+            flexWrap={null}
+            justifyContent={null}
+          >
+            <div
+              className="flex-container"
+              style={
+                Object {
+                  "alignContent": null,
+                  "alignItems": null,
+                  "display": "flex",
+                  "flexDirection": null,
+                  "flexGrow": "1",
+                  "flexWrap": null,
+                  "height": "100%",
+                  "justifyContent": null,
+                }
+              }
+            >
+              <TextPlaceholder
+                isFluid={true}
+                length="short"
+              >
+                <div
+                  className="placeholder text short fluid"
+                />
+              </TextPlaceholder>
+            </div>
+          </FlexContainer>
+        </div>
+      </FlexContainer>
       <Divider
         className=""
         hasLine={false}

--- a/src/components/general-widgets/PropertySearchResultList/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/PropertySearchResultList/__snapshots__/component.spec.js.snap
@@ -66,68 +66,68 @@ exports[`<PropertySearchResultList /> render by default should render the right 
   <div
     className="property-search-result-list"
   >
-    <FlexContainer
-      alignContent={null}
-      alignItems="center"
-      flexDirection={null}
-      flexWrap={null}
-      justifyContent="space-between"
-    >
-      <div
-        className="flex-container"
-        style={
-          Object {
-            "alignContent": null,
-            "alignItems": "center",
-            "display": "flex",
-            "flexDirection": null,
-            "flexGrow": "1",
-            "flexWrap": null,
-            "height": "100%",
-            "justifyContent": "space-between",
-          }
-        }
-      >
-        <Heading
-          className={null}
-          hasMargin={true}
-          isColorInverted={false}
-          size="small"
-          textAlign={null}
-        >
-          <Header
-            as="h4"
-            className=""
-            inverted={false}
-            textAlign={null}
-          >
-            <h4
-              className="ui header"
-            >
-              2 results
-            </h4>
-          </Header>
-        </Heading>
-      </div>
-    </FlexContainer>
-    <Divider
-      className=""
-      hasLine={false}
-      size="small"
-    >
-      <Divider
-        className="is-size-small"
-        hidden={true}
-        section={false}
-      >
-        <div
-          className="ui hidden divider is-size-small"
-        />
-      </Divider>
-    </Divider>
     <div
       className="result-list-container"
     >
+      <FlexContainer
+        alignContent={null}
+        alignItems="center"
+        flexDirection={null}
+        flexWrap={null}
+        justifyContent="space-between"
+      >
+        <div
+          className="flex-container"
+          style={
+            Object {
+              "alignContent": null,
+              "alignItems": "center",
+              "display": "flex",
+              "flexDirection": null,
+              "flexGrow": "1",
+              "flexWrap": null,
+              "height": "100%",
+              "justifyContent": "space-between",
+            }
+          }
+        >
+          <Heading
+            className={null}
+            hasMargin={true}
+            isColorInverted={false}
+            size="small"
+            textAlign={null}
+          >
+            <Header
+              as="h4"
+              className=""
+              inverted={false}
+              textAlign={null}
+            >
+              <h4
+                className="ui header"
+              >
+                2 results
+              </h4>
+            </Header>
+          </Heading>
+        </div>
+      </FlexContainer>
+      <Divider
+        className=""
+        hasLine={false}
+        size="small"
+      >
+        <Divider
+          className="is-size-small"
+          hidden={true}
+          section={false}
+        >
+          <div
+            className="ui hidden divider is-size-small"
+          />
+        </Divider>
+      </Divider>
       <FlexContainer
         alignContent={null}
         alignItems={null}
@@ -282,68 +282,68 @@ exports[`<PropertySearchResultList /> render if \`props.activePage\` is defined 
   <div
     className="property-search-result-list"
   >
-    <FlexContainer
-      alignContent={null}
-      alignItems="center"
-      flexDirection={null}
-      flexWrap={null}
-      justifyContent="space-between"
-    >
-      <div
-        className="flex-container"
-        style={
-          Object {
-            "alignContent": null,
-            "alignItems": "center",
-            "display": "flex",
-            "flexDirection": null,
-            "flexGrow": "1",
-            "flexWrap": null,
-            "height": "100%",
-            "justifyContent": "space-between",
-          }
-        }
-      >
-        <Heading
-          className={null}
-          hasMargin={true}
-          isColorInverted={false}
-          size="small"
-          textAlign={null}
-        >
-          <Header
-            as="h4"
-            className=""
-            inverted={false}
-            textAlign={null}
-          >
-            <h4
-              className="ui header"
-            >
-              2 results
-            </h4>
-          </Header>
-        </Heading>
-      </div>
-    </FlexContainer>
-    <Divider
-      className=""
-      hasLine={false}
-      size="small"
-    >
-      <Divider
-        className="is-size-small"
-        hidden={true}
-        section={false}
-      >
-        <div
-          className="ui hidden divider is-size-small"
-        />
-      </Divider>
-    </Divider>
     <div
       className="result-list-container"
     >
+      <FlexContainer
+        alignContent={null}
+        alignItems="center"
+        flexDirection={null}
+        flexWrap={null}
+        justifyContent="space-between"
+      >
+        <div
+          className="flex-container"
+          style={
+            Object {
+              "alignContent": null,
+              "alignItems": "center",
+              "display": "flex",
+              "flexDirection": null,
+              "flexGrow": "1",
+              "flexWrap": null,
+              "height": "100%",
+              "justifyContent": "space-between",
+            }
+          }
+        >
+          <Heading
+            className={null}
+            hasMargin={true}
+            isColorInverted={false}
+            size="small"
+            textAlign={null}
+          >
+            <Header
+              as="h4"
+              className=""
+              inverted={false}
+              textAlign={null}
+            >
+              <h4
+                className="ui header"
+              >
+                2 results
+              </h4>
+            </Header>
+          </Heading>
+        </div>
+      </FlexContainer>
+      <Divider
+        className=""
+        hasLine={false}
+        size="small"
+      >
+        <Divider
+          className="is-size-small"
+          hidden={true}
+          section={false}
+        >
+          <div
+            className="ui hidden divider is-size-small"
+          />
+        </Divider>
+      </Divider>
       <FlexContainer
         alignContent={null}
         alignItems={null}
@@ -506,244 +506,244 @@ exports[`<PropertySearchResultList /> render if \`props.dropdownOptions\` is pas
   <div
     className="property-search-result-list"
   >
-    <FlexContainer
-      alignContent={null}
-      alignItems="center"
-      flexDirection={null}
-      flexWrap={null}
-      justifyContent="space-between"
+    <div
+      className="result-list-container"
     >
-      <div
-        className="flex-container"
-        style={
-          Object {
-            "alignContent": null,
-            "alignItems": "center",
-            "display": "flex",
-            "flexDirection": null,
-            "flexGrow": "1",
-            "flexWrap": null,
-            "height": "100%",
-            "justifyContent": "space-between",
-          }
-        }
+      <FlexContainer
+        alignContent={null}
+        alignItems="center"
+        flexDirection={null}
+        flexWrap={null}
+        justifyContent="space-between"
       >
-        <Heading
-          className={null}
-          hasMargin={true}
-          isColorInverted={false}
-          size="small"
-          textAlign={null}
+        <div
+          className="flex-container"
+          style={
+            Object {
+              "alignContent": null,
+              "alignItems": "center",
+              "display": "flex",
+              "flexDirection": null,
+              "flexGrow": "1",
+              "flexWrap": null,
+              "height": "100%",
+              "justifyContent": "space-between",
+            }
+          }
         >
-          <Header
-            as="h4"
-            className=""
-            inverted={false}
+          <Heading
+            className={null}
+            hasMargin={true}
+            isColorInverted={false}
+            size="small"
             textAlign={null}
           >
-            <h4
-              className="ui header"
+            <Header
+              as="h4"
+              className=""
+              inverted={false}
+              textAlign={null}
             >
-              2 results
-            </h4>
-          </Header>
-        </Heading>
-        <Dropdown
-          error={false}
-          getOptionsWithSearch={null}
-          icon={null}
-          initialValue={null}
-          isCompact={true}
-          isDisabled={false}
-          isSearchable={false}
-          isValid={false}
-          label="some label"
-          name=""
-          noResultsText="No results"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          options={
-            Array [
-              Object {
-                "content": "Price (lowest to highest)",
-                "text": "Sort by price (lowest first)",
-                "value": "price",
-              },
-            ]
-          }
-          value="price"
-          willOpenAbove={false}
-        >
-          <div
-            className="dropdown-container is-compact dirty"
+              <h4
+                className="ui header"
+              >
+                2 results
+              </h4>
+            </Header>
+          </Heading>
+          <Dropdown
+            error={false}
+            getOptionsWithSearch={null}
+            icon={null}
+            initialValue={null}
+            isCompact={true}
+            isDisabled={false}
+            isSearchable={false}
+            isValid={false}
+            label="some label"
+            name=""
+            noResultsText="No results"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            options={
+              Array [
+                Object {
+                  "content": "Price (lowest to highest)",
+                  "text": "Sort by price (lowest first)",
+                  "value": "price",
+                },
+              ]
+            }
+            value="price"
+            willOpenAbove={false}
           >
-            <Dropdown
-              additionLabel="Add "
-              additionPosition="top"
-              closeOnBlur={true}
-              compact={true}
-              deburr={false}
-              disabled={false}
-              icon={
-                <Icon
-                  color={null}
-                  hasBorder={false}
-                  isButton={false}
-                  isCircular={false}
-                  isColorInverted={false}
-                  isDisabled={false}
-                  isLabelLeft={false}
-                  labelText={null}
-                  labelWeight={null}
-                  name="caret down"
-                  path={null}
-                  size="small"
-                />
-              }
-              minCharacters={1}
-              noResultsMessage="No results"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onClick={[Function]}
-              open={false}
-              openOnFocus={true}
-              options={
-                Array [
-                  Object {
-                    "content": "Price (lowest to highest)",
-                    "key": "0",
-                    "label": undefined,
-                    "text": "Sort by price (lowest first)",
-                    "value": "price",
-                  },
-                ]
-              }
-              placeholder="some label"
-              renderLabel={[Function]}
-              search={false}
-              searchInput="text"
-              selectOnBlur={false}
-              selectOnNavigation={true}
-              selection={true}
-              upward={false}
-              value="price"
-              wrapSelection={true}
+            <div
+              className="dropdown-container is-compact dirty"
             >
-              <div
-                aria-disabled={false}
-                aria-expanded={false}
-                className="ui compact selection dropdown"
+              <Dropdown
+                additionLabel="Add "
+                additionPosition="top"
+                closeOnBlur={true}
+                compact={true}
+                deburr={false}
+                disabled={false}
+                icon={
+                  <Icon
+                    color={null}
+                    hasBorder={false}
+                    isButton={false}
+                    isCircular={false}
+                    isColorInverted={false}
+                    isDisabled={false}
+                    isLabelLeft={false}
+                    labelText={null}
+                    labelWeight={null}
+                    name="caret down"
+                    path={null}
+                    size="small"
+                  />
+                }
+                minCharacters={1}
+                noResultsMessage="No results"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onClick={[Function]}
-                onFocus={[Function]}
-                onMouseDown={[Function]}
-                role="listbox"
-                tabIndex={0}
+                open={false}
+                openOnFocus={true}
+                options={
+                  Array [
+                    Object {
+                      "content": "Price (lowest to highest)",
+                      "key": "0",
+                      "label": undefined,
+                      "text": "Sort by price (lowest first)",
+                      "value": "price",
+                    },
+                  ]
+                }
+                placeholder="some label"
+                renderLabel={[Function]}
+                search={false}
+                searchInput="text"
+                selectOnBlur={false}
+                selectOnNavigation={true}
+                selection={true}
+                upward={false}
+                value="price"
+                wrapSelection={true}
               >
                 <div
-                  aria-live="polite"
-                  className="text"
-                  role="alert"
-                >
-                  Sort by price (lowest first)
-                </div>
-                <Icon
-                  color={null}
-                  hasBorder={false}
-                  isButton={false}
-                  isCircular={false}
-                  isColorInverted={false}
-                  isDisabled={false}
-                  isLabelLeft={false}
-                  labelText={null}
-                  labelWeight={null}
-                  name="caret down"
+                  aria-disabled={false}
+                  aria-expanded={false}
+                  className="ui compact selection dropdown"
+                  onBlur={[Function]}
+                  onChange={[Function]}
                   onClick={[Function]}
-                  path={null}
-                  size="small"
-                >
-                  <i
-                    className="icon small"
-                    onClick={[Function]}
-                  >
-                    <svg
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M20,8.5l-8,7-8-7Z"
-                        fill="currentColor"
-                      />
-                    </svg>
-                  </i>
-                </Icon>
-                <DropdownMenu
-                  open={false}
+                  onFocus={[Function]}
+                  onMouseDown={[Function]}
+                  role="listbox"
+                  tabIndex={0}
                 >
                   <div
-                    className="menu transition"
+                    aria-live="polite"
+                    className="text"
+                    role="alert"
                   >
-                    <DropdownItem
-                      active={true}
-                      content="Price (lowest to highest)"
-                      key="0"
+                    Sort by price (lowest first)
+                  </div>
+                  <Icon
+                    color={null}
+                    hasBorder={false}
+                    isButton={false}
+                    isCircular={false}
+                    isColorInverted={false}
+                    isDisabled={false}
+                    isLabelLeft={false}
+                    labelText={null}
+                    labelWeight={null}
+                    name="caret down"
+                    onClick={[Function]}
+                    path={null}
+                    size="small"
+                  >
+                    <i
+                      className="icon small"
                       onClick={[Function]}
-                      selected={true}
-                      style={
-                        Object {
-                          "pointerEvents": "all",
-                        }
-                      }
-                      text="Sort by price (lowest first)"
-                      value="price"
                     >
-                      <div
-                        aria-checked={true}
-                        aria-selected={true}
-                        className="active selected item"
+                      <svg
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M20,8.5l-8,7-8-7Z"
+                          fill="currentColor"
+                        />
+                      </svg>
+                    </i>
+                  </Icon>
+                  <DropdownMenu
+                    open={false}
+                  >
+                    <div
+                      className="menu transition"
+                    >
+                      <DropdownItem
+                        active={true}
+                        content="Price (lowest to highest)"
+                        key="0"
                         onClick={[Function]}
-                        role="option"
+                        selected={true}
                         style={
                           Object {
                             "pointerEvents": "all",
                           }
                         }
+                        text="Sort by price (lowest first)"
+                        value="price"
                       >
-                        <span
-                          className="text"
-                          key="Price (lowest to highest)"
+                        <div
+                          aria-checked={true}
+                          aria-selected={true}
+                          className="active selected item"
+                          onClick={[Function]}
+                          role="option"
+                          style={
+                            Object {
+                              "pointerEvents": "all",
+                            }
+                          }
                         >
-                          Price (lowest to highest)
-                        </span>
-                      </div>
-                    </DropdownItem>
-                  </div>
-                </DropdownMenu>
-              </div>
-            </Dropdown>
-          </div>
-        </Dropdown>
-      </div>
-    </FlexContainer>
-    <Divider
-      className=""
-      hasLine={false}
-      size="small"
-    >
+                          <span
+                            className="text"
+                            key="Price (lowest to highest)"
+                          >
+                            Price (lowest to highest)
+                          </span>
+                        </div>
+                      </DropdownItem>
+                    </div>
+                  </DropdownMenu>
+                </div>
+              </Dropdown>
+            </div>
+          </Dropdown>
+        </div>
+      </FlexContainer>
       <Divider
-        className="is-size-small"
-        hidden={true}
-        section={false}
+        className=""
+        hasLine={false}
+        size="small"
       >
-        <div
-          className="ui hidden divider is-size-small"
-        />
+        <Divider
+          className="is-size-small"
+          hidden={true}
+          section={false}
+        >
+          <div
+            className="ui hidden divider is-size-small"
+          />
+        </Divider>
       </Divider>
-    </Divider>
-    <div
-      className="result-list-container"
-    >
       <FlexContainer
         alignContent={null}
         alignItems={null}
@@ -848,62 +848,62 @@ exports[`<PropertySearchResultList /> render if \`props.isShowingPlaceholder\` i
   <div
     className="property-search-result-list"
   >
-    <Divider
-      className=""
-      hasLine={false}
-      size="small"
-    >
-      <Divider
-        className="is-size-small"
-        hidden={true}
-        section={false}
-      >
-        <div
-          className="ui hidden divider is-size-small"
-        />
-      </Divider>
-    </Divider>
-    <TextPlaceholder
-      isFluid={true}
-      length="short"
-    >
-      <div
-        className="placeholder text short fluid"
-      />
-    </TextPlaceholder>
-    <Divider
-      className=""
-      hasLine={false}
-      size="small"
-    >
-      <Divider
-        className="is-size-small"
-        hidden={true}
-        section={false}
-      >
-        <div
-          className="ui hidden divider is-size-small"
-        />
-      </Divider>
-    </Divider>
-    <Divider
-      className=""
-      hasLine={false}
-      size="small"
-    >
-      <Divider
-        className="is-size-small"
-        hidden={true}
-        section={false}
-      >
-        <div
-          className="ui hidden divider is-size-small"
-        />
-      </Divider>
-    </Divider>
     <div
       className="result-list-container"
     >
+      <Divider
+        className=""
+        hasLine={false}
+        size="small"
+      >
+        <Divider
+          className="is-size-small"
+          hidden={true}
+          section={false}
+        >
+          <div
+            className="ui hidden divider is-size-small"
+          />
+        </Divider>
+      </Divider>
+      <TextPlaceholder
+        isFluid={true}
+        length="short"
+      >
+        <div
+          className="placeholder text short fluid"
+        />
+      </TextPlaceholder>
+      <Divider
+        className=""
+        hasLine={false}
+        size="small"
+      >
+        <Divider
+          className="is-size-small"
+          hidden={true}
+          section={false}
+        >
+          <div
+            className="ui hidden divider is-size-small"
+          />
+        </Divider>
+      </Divider>
+      <Divider
+        className=""
+        hasLine={false}
+        size="small"
+      >
+        <Divider
+          className="is-size-small"
+          hidden={true}
+          section={false}
+        >
+          <div
+            className="ui hidden divider is-size-small"
+          />
+        </Divider>
+      </Divider>
       <FlexContainer
         alignContent={null}
         alignItems={null}
@@ -1155,115 +1155,115 @@ exports[`<PropertySearchResultList /> render if \`props.messageText\` is passed 
   <div
     className="property-search-result-list"
   >
-    <FlexContainer
-      alignContent={null}
-      alignItems="center"
-      flexDirection={null}
-      flexWrap={null}
-      justifyContent="space-between"
-    >
-      <div
-        className="flex-container"
-        style={
-          Object {
-            "alignContent": null,
-            "alignItems": "center",
-            "display": "flex",
-            "flexDirection": null,
-            "flexGrow": "1",
-            "flexWrap": null,
-            "height": "100%",
-            "justifyContent": "space-between",
-          }
-        }
-      >
-        <Heading
-          className={null}
-          hasMargin={true}
-          isColorInverted={false}
-          size="small"
-          textAlign={null}
-        >
-          <Header
-            as="h4"
-            className=""
-            inverted={false}
-            textAlign={null}
-          >
-            <h4
-              className="ui header"
-            >
-              2 results
-            </h4>
-          </Header>
-        </Heading>
-      </div>
-    </FlexContainer>
-    <Message>
-      <Message
-        className="padded"
-      >
-        <div
-          className="ui message padded"
-        >
-          <FlexContainer
-            alignContent={null}
-            alignItems="center"
-            flexDirection={null}
-            flexWrap={null}
-            justifyContent="space-between"
-          >
-            <div
-              className="flex-container"
-              style={
-                Object {
-                  "alignContent": null,
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flexDirection": null,
-                  "flexGrow": "1",
-                  "flexWrap": null,
-                  "height": "100%",
-                  "justifyContent": "space-between",
-                }
-              }
-            >
-              Some message text
-              <Link
-                href={null}
-                isPositionedRight={false}
-                onClick={[Function]}
-                willOpenInNewTab={false}
-              >
-                <Button
-                  as={null}
-                  basic={true}
-                  floated="left"
-                  href={null}
-                  onClick={[Function]}
-                  target="_self"
-                  type="button"
-                >
-                  <button
-                    className="ui basic left floated button"
-                    href={null}
-                    onClick={[Function]}
-                    role="button"
-                    target="_self"
-                    type="button"
-                  >
-                    Some button text
-                  </button>
-                </Button>
-              </Link>
-            </div>
-          </FlexContainer>
-        </div>
-      </Message>
-    </Message>
     <div
       className="result-list-container"
     >
+      <FlexContainer
+        alignContent={null}
+        alignItems="center"
+        flexDirection={null}
+        flexWrap={null}
+        justifyContent="space-between"
+      >
+        <div
+          className="flex-container"
+          style={
+            Object {
+              "alignContent": null,
+              "alignItems": "center",
+              "display": "flex",
+              "flexDirection": null,
+              "flexGrow": "1",
+              "flexWrap": null,
+              "height": "100%",
+              "justifyContent": "space-between",
+            }
+          }
+        >
+          <Heading
+            className={null}
+            hasMargin={true}
+            isColorInverted={false}
+            size="small"
+            textAlign={null}
+          >
+            <Header
+              as="h4"
+              className=""
+              inverted={false}
+              textAlign={null}
+            >
+              <h4
+                className="ui header"
+              >
+                2 results
+              </h4>
+            </Header>
+          </Heading>
+        </div>
+      </FlexContainer>
+      <Message>
+        <Message
+          className="padded"
+        >
+          <div
+            className="ui message padded"
+          >
+            <FlexContainer
+              alignContent={null}
+              alignItems="center"
+              flexDirection={null}
+              flexWrap={null}
+              justifyContent="space-between"
+            >
+              <div
+                className="flex-container"
+                style={
+                  Object {
+                    "alignContent": null,
+                    "alignItems": "center",
+                    "display": "flex",
+                    "flexDirection": null,
+                    "flexGrow": "1",
+                    "flexWrap": null,
+                    "height": "100%",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
+                Some message text
+                <Link
+                  href={null}
+                  isPositionedRight={false}
+                  onClick={[Function]}
+                  willOpenInNewTab={false}
+                >
+                  <Button
+                    as={null}
+                    basic={true}
+                    floated="left"
+                    href={null}
+                    onClick={[Function]}
+                    target="_self"
+                    type="button"
+                  >
+                    <button
+                      className="ui basic left floated button"
+                      href={null}
+                      onClick={[Function]}
+                      role="button"
+                      target="_self"
+                      type="button"
+                    >
+                      Some button text
+                    </button>
+                  </Button>
+                </Link>
+              </div>
+            </FlexContainer>
+          </div>
+        </Message>
+      </Message>
       <FlexContainer
         alignContent={null}
         alignItems={null}
@@ -1683,68 +1683,68 @@ exports[`<PropertySearchResultList /> render if \`props.propertySearchResults.le
   <div
     className="property-search-result-list"
   >
-    <FlexContainer
-      alignContent={null}
-      alignItems="center"
-      flexDirection={null}
-      flexWrap={null}
-      justifyContent="space-between"
-    >
-      <div
-        className="flex-container"
-        style={
-          Object {
-            "alignContent": null,
-            "alignItems": "center",
-            "display": "flex",
-            "flexDirection": null,
-            "flexGrow": "1",
-            "flexWrap": null,
-            "height": "100%",
-            "justifyContent": "space-between",
-          }
-        }
-      >
-        <Heading
-          className={null}
-          hasMargin={true}
-          isColorInverted={false}
-          size="small"
-          textAlign={null}
-        >
-          <Header
-            as="h4"
-            className=""
-            inverted={false}
-            textAlign={null}
-          >
-            <h4
-              className="ui header"
-            >
-              13 results
-            </h4>
-          </Header>
-        </Heading>
-      </div>
-    </FlexContainer>
-    <Divider
-      className=""
-      hasLine={false}
-      size="small"
-    >
-      <Divider
-        className="is-size-small"
-        hidden={true}
-        section={false}
-      >
-        <div
-          className="ui hidden divider is-size-small"
-        />
-      </Divider>
-    </Divider>
     <div
       className="result-list-container"
     >
+      <FlexContainer
+        alignContent={null}
+        alignItems="center"
+        flexDirection={null}
+        flexWrap={null}
+        justifyContent="space-between"
+      >
+        <div
+          className="flex-container"
+          style={
+            Object {
+              "alignContent": null,
+              "alignItems": "center",
+              "display": "flex",
+              "flexDirection": null,
+              "flexGrow": "1",
+              "flexWrap": null,
+              "height": "100%",
+              "justifyContent": "space-between",
+            }
+          }
+        >
+          <Heading
+            className={null}
+            hasMargin={true}
+            isColorInverted={false}
+            size="small"
+            textAlign={null}
+          >
+            <Header
+              as="h4"
+              className=""
+              inverted={false}
+              textAlign={null}
+            >
+              <h4
+                className="ui header"
+              >
+                13 results
+              </h4>
+            </Header>
+          </Heading>
+        </div>
+      </FlexContainer>
+      <Divider
+        className=""
+        hasLine={false}
+        size="small"
+      >
+        <Divider
+          className="is-size-small"
+          hidden={true}
+          section={false}
+        >
+          <div
+            className="ui hidden divider is-size-small"
+          />
+        </Divider>
+      </Divider>
       <FlexContainer
         alignContent={null}
         alignItems={null}
@@ -2510,68 +2510,68 @@ exports[`<PropertySearchResultList /> render if \`props.resultsCountText\` is pa
   <div
     className="property-search-result-list"
   >
-    <FlexContainer
-      alignContent={null}
-      alignItems="center"
-      flexDirection={null}
-      flexWrap={null}
-      justifyContent="space-between"
-    >
-      <div
-        className="flex-container"
-        style={
-          Object {
-            "alignContent": null,
-            "alignItems": "center",
-            "display": "flex",
-            "flexDirection": null,
-            "flexGrow": "1",
-            "flexWrap": null,
-            "height": "100%",
-            "justifyContent": "space-between",
-          }
-        }
-      >
-        <Heading
-          className={null}
-          hasMargin={true}
-          isColorInverted={false}
-          size="small"
-          textAlign={null}
-        >
-          <Header
-            as="h4"
-            className=""
-            inverted={false}
-            textAlign={null}
-          >
-            <h4
-              className="ui header"
-            >
-              2 My god I love Cliff Richard
-            </h4>
-          </Header>
-        </Heading>
-      </div>
-    </FlexContainer>
-    <Divider
-      className=""
-      hasLine={false}
-      size="small"
-    >
-      <Divider
-        className="is-size-small"
-        hidden={true}
-        section={false}
-      >
-        <div
-          className="ui hidden divider is-size-small"
-        />
-      </Divider>
-    </Divider>
     <div
       className="result-list-container"
     >
+      <FlexContainer
+        alignContent={null}
+        alignItems="center"
+        flexDirection={null}
+        flexWrap={null}
+        justifyContent="space-between"
+      >
+        <div
+          className="flex-container"
+          style={
+            Object {
+              "alignContent": null,
+              "alignItems": "center",
+              "display": "flex",
+              "flexDirection": null,
+              "flexGrow": "1",
+              "flexWrap": null,
+              "height": "100%",
+              "justifyContent": "space-between",
+            }
+          }
+        >
+          <Heading
+            className={null}
+            hasMargin={true}
+            isColorInverted={false}
+            size="small"
+            textAlign={null}
+          >
+            <Header
+              as="h4"
+              className=""
+              inverted={false}
+              textAlign={null}
+            >
+              <h4
+                className="ui header"
+              >
+                2 My god I love Cliff Richard
+              </h4>
+            </Header>
+          </Heading>
+        </div>
+      </FlexContainer>
+      <Divider
+        className=""
+        hasLine={false}
+        size="small"
+      >
+        <Divider
+          className="is-size-small"
+          hidden={true}
+          section={false}
+        >
+          <div
+            className="ui hidden divider is-size-small"
+          />
+        </Divider>
+      </Divider>
       <FlexContainer
         alignContent={null}
         alignItems={null}

--- a/src/components/general-widgets/PropertySearchResultList/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/PropertySearchResultList/__snapshots__/component.spec.js.snap
@@ -6,6 +6,223 @@ exports[`<PropertySearchResultList /> render by default should render the right 
   dropdownOnChange={[Function]}
   dropdownOptions={null}
   isShowingPlaceholder={false}
+  isUserOnMobile={false}
+  messageButtonOnClick={[Function]}
+  messageButtonText={null}
+  messageText={null}
+  onChange={[Function]}
+  propertySearchResults={
+    Array [
+      Object {
+        "bathsNumber": 2,
+        "bathsText": "baths",
+        "bedroomsNumber": 2,
+        "bedroomsText": "bedrooms",
+        "bedsNumber": 2,
+        "bedsText": "beds",
+        "guestsNumber": 2,
+        "guestsText": "guests",
+        "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
+        "priceLabelPeriodText": "per month",
+        "priceLabelPricePerPeriod": "$28000",
+        "priceLabelPricePerPeriodPrefix": "from",
+        "propertyAmenities": Array [
+          "Pool",
+          "Wifi",
+          "Washer",
+          "Kitchen",
+        ],
+        "propertyName": "The Cat House",
+        "propertyType": "Bed and breakfast",
+        "propertyUrl": "/",
+        "ratingNumber": 4.7,
+      },
+      Object {
+        "bathsNumber": 1,
+        "bathsText": "baths",
+        "bedroomsNumber": 2,
+        "bedroomsText": "bedrooms",
+        "bedsNumber": 3,
+        "bedsText": "beds",
+        "guestsNumber": 4,
+        "guestsText": "guests",
+        "imageUrl": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
+        "priceLabelPricePerPeriod": "$1280",
+        "propertyAmenities": Array [
+          "Pool",
+          "Wifi",
+          "Washer",
+          "Kitchen",
+        ],
+        "propertyName": "Space Hub A-675",
+        "propertyType": "Space Station",
+        "propertyUrl": "/",
+        "ratingNumber": 4.7,
+      },
+    ]
+  }
+  renderShowingResultsText={[Function]}
+  resultsCountText="results"
+>
+  <div
+    className="property-search-result-list"
+  >
+    <div
+      className="result-list-container"
+    >
+      <FlexContainer
+        alignContent={null}
+        alignItems="center"
+        flexDirection={null}
+        flexWrap={null}
+        justifyContent="space-between"
+      >
+        <div
+          className="flex-container"
+          style={
+            Object {
+              "alignContent": null,
+              "alignItems": "center",
+              "display": "flex",
+              "flexDirection": null,
+              "flexGrow": "1",
+              "flexWrap": null,
+              "height": "100%",
+              "justifyContent": "space-between",
+            }
+          }
+        >
+          <Heading
+            className={null}
+            hasMargin={true}
+            isColorInverted={false}
+            size="small"
+            textAlign={null}
+          >
+            <Header
+              as="h4"
+              className=""
+              inverted={false}
+              textAlign={null}
+            >
+              <h4
+                className="ui header"
+              >
+                2 results
+              </h4>
+            </Header>
+          </Heading>
+        </div>
+      </FlexContainer>
+      <Divider
+        className=""
+        hasLine={false}
+        size="small"
+      >
+        <Divider
+          className="is-size-small"
+          hidden={true}
+          section={false}
+        >
+          <div
+            className="ui hidden divider is-size-small"
+          />
+        </Divider>
+      </Divider>
+      <FlexContainer
+        alignContent={null}
+        alignItems={null}
+        flexDirection={null}
+        flexWrap="wrap"
+        justifyContent={null}
+      >
+        <div
+          className="flex-container"
+          style={
+            Object {
+              "alignContent": null,
+              "alignItems": null,
+              "display": "flex",
+              "flexDirection": null,
+              "flexGrow": "1",
+              "flexWrap": "wrap",
+              "height": "100%",
+              "justifyContent": null,
+            }
+          }
+        >
+          <PropertySearchResult
+            bathsNumber={2}
+            bathsText="baths"
+            bedroomsNumber={2}
+            bedroomsText="bedrooms"
+            bedsNumber={2}
+            bedsText="beds"
+            guestsNumber={2}
+            guestsText="guests"
+            imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
+            isShowingPlaceholder={false}
+            key="The Cat House0"
+            priceLabelPeriodText="per month"
+            priceLabelPricePerPeriod="$28000"
+            priceLabelPricePerPeriodPrefix="from"
+            propertyAmenities={
+              Array [
+                "Pool",
+                "Wifi",
+                "Washer",
+                "Kitchen",
+              ]
+            }
+            propertyName="The Cat House"
+            propertyType="Bed and breakfast"
+            propertyUrl="/"
+            ratingNumber={4.7}
+          >
+            <div />
+          </PropertySearchResult>
+          <PropertySearchResult
+            bathsNumber={1}
+            bathsText="baths"
+            bedroomsNumber={2}
+            bedroomsText="bedrooms"
+            bedsNumber={3}
+            bedsText="beds"
+            guestsNumber={4}
+            guestsText="guests"
+            imageUrl="https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg"
+            isShowingPlaceholder={false}
+            key="Space Hub A-6751"
+            priceLabelPricePerPeriod="$1280"
+            propertyAmenities={
+              Array [
+                "Pool",
+                "Wifi",
+                "Washer",
+                "Kitchen",
+              ]
+            }
+            propertyName="Space Hub A-675"
+            propertyType="Space Station"
+            propertyUrl="/"
+            ratingNumber={4.7}
+          >
+            <div />
+          </PropertySearchResult>
+        </div>
+      </FlexContainer>
+    </div>
+  </div>
+</PropertySearchResultList>
+`;
+
+exports[`<PropertySearchResultList /> render if \`isUserOnMobile\` === true should return the right structure 1`] = `
+<PropertySearchResultList
+  dropdownLabel={null}
+  dropdownOnChange={[Function]}
+  dropdownOptions={null}
+  isShowingPlaceholder={false}
+  isUserOnMobile={true}
   messageButtonOnClick={[Function]}
   messageButtonText={null}
   messageText={null}
@@ -222,6 +439,7 @@ exports[`<PropertySearchResultList /> render if \`props.activePage\` is defined 
   dropdownOnChange={[Function]}
   dropdownOptions={null}
   isShowingPlaceholder={false}
+  isUserOnMobile={false}
   messageButtonOnClick={[Function]}
   messageButtonText={null}
   messageText={null}
@@ -446,6 +664,7 @@ exports[`<PropertySearchResultList /> render if \`props.dropdownOptions\` is pas
   }
   dropdownValue="price"
   isShowingPlaceholder={false}
+  isUserOnMobile={false}
   messageButtonOnClick={[Function]}
   messageButtonText={null}
   messageText={null}
@@ -837,6 +1056,7 @@ exports[`<PropertySearchResultList /> render if \`props.isShowingPlaceholder\` i
   dropdownOnChange={[Function]}
   dropdownOptions={null}
   isShowingPlaceholder={true}
+  isUserOnMobile={false}
   messageButtonOnClick={[Function]}
   messageButtonText={null}
   messageText={null}
@@ -1095,6 +1315,7 @@ exports[`<PropertySearchResultList /> render if \`props.messageText\` is passed 
   dropdownOnChange={[Function]}
   dropdownOptions={null}
   isShowingPlaceholder={false}
+  isUserOnMobile={false}
   messageButtonOnClick={[Function]}
   messageButtonText="Some button text"
   messageText="Some message text"
@@ -1202,7 +1423,9 @@ exports[`<PropertySearchResultList /> render if \`props.messageText\` is passed 
           </Heading>
         </div>
       </FlexContainer>
-      <Message>
+      <Message
+        isTextAlignedCenter={false}
+      >
         <Message
           className="padded"
         >
@@ -1234,6 +1457,7 @@ exports[`<PropertySearchResultList /> render if \`props.messageText\` is passed 
                 Some message text
                 <Link
                   href={null}
+                  isFluid={false}
                   isPositionedRight={false}
                   onClick={[Function]}
                   willOpenInNewTab={false}
@@ -1242,6 +1466,7 @@ exports[`<PropertySearchResultList /> render if \`props.messageText\` is passed 
                     as={null}
                     basic={true}
                     floated="left"
+                    fluid={false}
                     href={null}
                     onClick={[Function]}
                     target="_self"
@@ -1357,6 +1582,7 @@ exports[`<PropertySearchResultList /> render if \`props.propertySearchResults.le
   dropdownOnChange={[Function]}
   dropdownOptions={null}
   isShowingPlaceholder={false}
+  isUserOnMobile={false}
   messageButtonOnClick={[Function]}
   messageButtonText={null}
   messageText={null}
@@ -2450,6 +2676,7 @@ exports[`<PropertySearchResultList /> render if \`props.resultsCountText\` is pa
   dropdownOnChange={[Function]}
   dropdownOptions={null}
   isShowingPlaceholder={false}
+  isUserOnMobile={false}
   messageButtonOnClick={[Function]}
   messageButtonText={null}
   messageText={null}

--- a/src/components/general-widgets/PropertySearchResultList/component.js
+++ b/src/components/general-widgets/PropertySearchResultList/component.js
@@ -14,6 +14,7 @@ import { FlexContainer } from 'layout/FlexContainer';
 import { PropertySearchResult } from 'general-widgets/PropertySearchResult';
 import { buildKeyFromStrings } from 'utils/build-key-from-strings';
 import { RESULTS } from 'utils/default-strings';
+import { withResponsive } from 'utils/with-responsive';
 
 import { PLACEHOLDERS, NUMBER_OF_PROPERTIES_PER_PAGE } from './constants';
 import { getNumberOfPages } from './utils/getNumberOfPages';
@@ -21,12 +22,13 @@ import { getPropertySearchResultsToDisplay } from './utils/getPropertySearchResu
 import { getFirstPropertyPositionOfActivePage } from './utils/getFirstPropertyPositionOfActivePage';
 import { getLastPropertyPositionOfActivePage } from './utils/getLastPropertyPositionOfActivePage';
 import { getShowingResultsText } from './utils/getShowingResultsText';
+import { getFlexDirection } from './utils/getFlexDirection';
 
 /**
  * The standard widget for displaying a list of property search results.
  */
 // eslint-disable-next-line jsdoc/require-jsdoc
-export class Component extends PureComponent {
+class Component extends PureComponent {
   state = {
     activePage: 1,
   };
@@ -57,6 +59,7 @@ export class Component extends PureComponent {
       dropdownOptions,
       dropdownValue,
       isShowingPlaceholder,
+      isUserOnMobile,
       messageButtonOnClick,
       messageButtonText,
       messageText,
@@ -94,10 +97,16 @@ export class Component extends PureComponent {
             </FlexContainer>
           )}
           {messageText ? (
-            <Message>
-              <FlexContainer alignItems="center" justifyContent="space-between">
+            <Message isTextAlignedCenter={isUserOnMobile}>
+              <FlexContainer
+                alignItems="center"
+                flexDirection={getFlexDirection(isUserOnMobile)}
+                justifyContent="space-between"
+              >
                 {messageText}
-                <Link onClick={messageButtonOnClick}>{messageButtonText}</Link>
+                <Link isFluid={isUserOnMobile} onClick={messageButtonOnClick}>
+                  {messageButtonText}
+                </Link>
               </FlexContainer>
             </Message>
           ) : (
@@ -194,6 +203,12 @@ Component.propTypes = {
   ]),
   /** Is the component showing placeholders to reserve space for content which will appear. */
   isShowingPlaceholder: PropTypes.bool,
+  /**
+   * Is the user on a mobile device.
+   * Provided by `withResponsive` so ignored in the styleguide.
+   * @ignore
+   */
+  isUserOnMobile: PropTypes.bool.isRequired,
   /** Function called when the clickable button in the message is clicked. */
   messageButtonOnClick: PropTypes.func,
   /** Text to show as a clickable button in the message above the search results. */
@@ -217,3 +232,5 @@ Component.propTypes = {
   /** The text to display alongside the results count. */
   resultsCountText: PropTypes.string,
 };
+
+export const ComponentWithResponsive = withResponsive(Component);

--- a/src/components/general-widgets/PropertySearchResultList/component.js
+++ b/src/components/general-widgets/PropertySearchResultList/component.js
@@ -1,4 +1,4 @@
-import React, { Fragment, PureComponent } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
 import { Message } from 'elements/Message';
@@ -76,26 +76,24 @@ class Component extends PureComponent {
     return (
       <div className="property-search-result-list">
         <div className="result-list-container">
-          {isShowingPlaceholder ? (
-            <Fragment>
-              <Divider size="small" />
-              <TextPlaceholder length="short" />
-              <Divider size="small" />
-            </Fragment>
-          ) : (
-            <FlexContainer alignItems="center" justifyContent="space-between">
+          <FlexContainer alignItems="center" justifyContent="space-between">
+            {isShowingPlaceholder ? (
+              <FlexContainer>
+                <TextPlaceholder length="short" />
+              </FlexContainer>
+            ) : (
               <Heading size="small">{`${length} ${resultsCountText}`}</Heading>
-              {!!size(dropdownOptions) && (
-                <Dropdown
-                  isCompact
-                  label={dropdownLabel}
-                  onChange={dropdownOnChange}
-                  options={dropdownOptions}
-                  value={dropdownValue}
-                />
-              )}
-            </FlexContainer>
-          )}
+            )}
+            {!!size(dropdownOptions) && (
+              <Dropdown
+                isCompact
+                label={dropdownLabel}
+                onChange={dropdownOnChange}
+                options={dropdownOptions}
+                value={dropdownValue}
+              />
+            )}
+          </FlexContainer>
           {messageText ? (
             <Message isTextAlignedCenter={isUserOnMobile}>
               <FlexContainer

--- a/src/components/general-widgets/PropertySearchResultList/component.js
+++ b/src/components/general-widgets/PropertySearchResultList/component.js
@@ -72,37 +72,37 @@ export class Component extends PureComponent {
 
     return (
       <div className="property-search-result-list">
-        {isShowingPlaceholder ? (
-          <Fragment>
-            <Divider size="small" />
-            <TextPlaceholder length="short" />
-            <Divider size="small" />
-          </Fragment>
-        ) : (
-          <FlexContainer alignItems="center" justifyContent="space-between">
-            <Heading size="small">{`${length} ${resultsCountText}`}</Heading>
-            {!!size(dropdownOptions) && (
-              <Dropdown
-                isCompact
-                label={dropdownLabel}
-                onChange={dropdownOnChange}
-                options={dropdownOptions}
-                value={dropdownValue}
-              />
-            )}
-          </FlexContainer>
-        )}
-        {messageText ? (
-          <Message>
-            <FlexContainer alignItems="center" justifyContent="space-between">
-              {messageText}
-              <Link onClick={messageButtonOnClick}>{messageButtonText}</Link>
-            </FlexContainer>
-          </Message>
-        ) : (
-          <Divider size="small" />
-        )}
         <div className="result-list-container">
+          {isShowingPlaceholder ? (
+            <Fragment>
+              <Divider size="small" />
+              <TextPlaceholder length="short" />
+              <Divider size="small" />
+            </Fragment>
+          ) : (
+            <FlexContainer alignItems="center" justifyContent="space-between">
+              <Heading size="small">{`${length} ${resultsCountText}`}</Heading>
+              {!!size(dropdownOptions) && (
+                <Dropdown
+                  isCompact
+                  label={dropdownLabel}
+                  onChange={dropdownOnChange}
+                  options={dropdownOptions}
+                  value={dropdownValue}
+                />
+              )}
+            </FlexContainer>
+          )}
+          {messageText ? (
+            <Message>
+              <FlexContainer alignItems="center" justifyContent="space-between">
+                {messageText}
+                <Link onClick={messageButtonOnClick}>{messageButtonText}</Link>
+              </FlexContainer>
+            </Message>
+          ) : (
+            <Divider size="small" />
+          )}
           <FlexContainer flexWrap="wrap">
             {(isShowingPlaceholder
               ? PLACEHOLDERS

--- a/src/components/general-widgets/PropertySearchResultList/component.spec.js
+++ b/src/components/general-widgets/PropertySearchResultList/component.spec.js
@@ -16,7 +16,7 @@ import { shallow, mount } from 'enzyme';
 import { expectComponentToHaveDisplayName } from '@lodgify/enzyme-jest-expect-helpers';
 
 import { getPropertySearchResultsToDisplay } from './utils/getPropertySearchResultsToDisplay';
-import { Component as PropertySearchResultList } from './component';
+import { ComponentWithResponsive as PropertySearchResultList } from './component';
 import {
   propertySearchResults,
   moreThan12PropertySearchResults,
@@ -26,20 +26,44 @@ getPropertySearchResultsToDisplay.mockImplementation(
   (activePage, propertySearchResults) => propertySearchResults
 );
 
-const getShallowPropertySearchResultList = otherProps =>
+const getWrappedPropertySearchResultList = otherProps =>
   shallow(
     <PropertySearchResultList
       propertySearchResults={propertySearchResults}
       {...otherProps}
     />
+  ).prop('as');
+
+const getShallowPropertySearchResultList = otherProps => {
+  const WrappedPropertySearchResultList = getWrappedPropertySearchResultList(
+    otherProps
   );
-const getMountedPropertySearchResultList = otherProps =>
-  mount(
-    <PropertySearchResultList
+
+  return shallow(
+    <WrappedPropertySearchResultList
       propertySearchResults={propertySearchResults}
       {...otherProps}
+      isUserOnMobile={false}
     />
   );
+};
+
+const getMountedPropertySearchResultList = (
+  otherProps,
+  isUserOnMobile = false
+) => {
+  const WrappedPropertySearchResultList = getWrappedPropertySearchResultList(
+    otherProps
+  );
+
+  return mount(
+    <WrappedPropertySearchResultList
+      propertySearchResults={propertySearchResults}
+      {...otherProps}
+      isUserOnMobile={isUserOnMobile}
+    />
+  );
+};
 
 describe('<PropertySearchResultList />', () => {
   describe('componentDidUpdate', () => {
@@ -127,6 +151,14 @@ describe('<PropertySearchResultList />', () => {
       });
     });
 
+    describe('if `isUserOnMobile` === true', () => {
+      it('should return the right structure', () => {
+        const actual = getMountedPropertySearchResultList({}, true);
+
+        expect(actual).toMatchSnapshot();
+      });
+    });
+
     describe('if `props.activePage` is defined', () => {
       it('should render the right structure', () => {
         const actual = getMountedPropertySearchResultList({
@@ -199,9 +231,8 @@ describe('<PropertySearchResultList />', () => {
   });
 
   it('should have `displayName` `PropertySearchResultList`', () => {
-    expectComponentToHaveDisplayName(
-      PropertySearchResultList,
-      'PropertySearchResultList'
-    );
+    const component = shallow(<PropertySearchResultList />).prop('as');
+
+    expectComponentToHaveDisplayName(component, 'PropertySearchResultList');
   });
 });

--- a/src/components/general-widgets/PropertySearchResultList/index.js
+++ b/src/components/general-widgets/PropertySearchResultList/index.js
@@ -1,1 +1,3 @@
-export { Component as PropertySearchResultList } from './component';
+export {
+  ComponentWithResponsive as PropertySearchResultList,
+} from './component';

--- a/src/components/general-widgets/PropertySearchResultList/utils/getFlexDirection.js
+++ b/src/components/general-widgets/PropertySearchResultList/utils/getFlexDirection.js
@@ -1,0 +1,6 @@
+/**
+ * @param  {boolean} isUserOnMobile
+ * @return {string|undefined}
+ */
+export const getFlexDirection = isUserOnMobile =>
+  isUserOnMobile ? 'column' : undefined;

--- a/src/components/general-widgets/PropertySearchResultList/utils/getFlexDirection.spec.js
+++ b/src/components/general-widgets/PropertySearchResultList/utils/getFlexDirection.spec.js
@@ -1,0 +1,19 @@
+import { getFlexDirection } from './getFlexDirection';
+
+describe('getFlexDirection', () => {
+  describe('if `isUserOnMobile === true`', () => {
+    it('should return the correct value', () => {
+      const actual = getFlexDirection(true);
+
+      expect(actual).toBe('column');
+    });
+  });
+
+  describe('if `isUserOnMobile === false`', () => {
+    it('should return the correct value', () => {
+      const actual = getFlexDirection(false);
+
+      expect(actual).toBe(undefined);
+    });
+  });
+});

--- a/src/components/property-page-widgets/Pictures/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Pictures/__snapshots__/component.spec.js.snap
@@ -1268,6 +1268,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                 trigger={
                   <Link
                     href={null}
+                    isFluid={false}
                     isPositionedRight={false}
                     onClick={[Function]}
                     willOpenInNewTab={false}
@@ -1287,6 +1288,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                   trigger={
                     <Link
                       href={null}
+                      isFluid={false}
                       isPositionedRight={false}
                       onClick={[Function]}
                       willOpenInNewTab={false}
@@ -1322,6 +1324,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                     trigger={
                       <Link
                         href={null}
+                        isFluid={false}
                         isPositionedRight={false}
                         onClick={[Function]}
                         willOpenInNewTab={false}
@@ -1345,6 +1348,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                       trigger={
                         <Link
                           href={null}
+                          isFluid={false}
                           isPositionedRight={false}
                           onClick={[Function]}
                           willOpenInNewTab={false}
@@ -1358,6 +1362,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                       >
                         <Link
                           href={null}
+                          isFluid={false}
                           isPositionedRight={false}
                           onBlur={[Function]}
                           onClick={[Function]}
@@ -1370,6 +1375,7 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                             as={null}
                             basic={true}
                             floated="left"
+                            fluid={false}
                             href={null}
                             onClick={[Function]}
                             target="_self"

--- a/src/components/property-page-widgets/PolicyAndNotes/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/PolicyAndNotes/__snapshots__/component.spec.js.snap
@@ -388,6 +388,7 @@ exports[`<PolicyAndNotes /> if \`props.extraNotesText\` is passed should have th
                       trigger={
                         <Link
                           href={null}
+                          isFluid={false}
                           isPositionedRight={false}
                           onClick={[Function]}
                           willOpenInNewTab={false}
@@ -423,6 +424,7 @@ exports[`<PolicyAndNotes /> if \`props.extraNotesText\` is passed should have th
                         trigger={
                           <Link
                             href={null}
+                            isFluid={false}
                             isPositionedRight={false}
                             onClick={[Function]}
                             willOpenInNewTab={false}
@@ -446,6 +448,7 @@ exports[`<PolicyAndNotes /> if \`props.extraNotesText\` is passed should have th
                           trigger={
                             <Link
                               href={null}
+                              isFluid={false}
                               isPositionedRight={false}
                               onClick={[Function]}
                               willOpenInNewTab={false}
@@ -459,6 +462,7 @@ exports[`<PolicyAndNotes /> if \`props.extraNotesText\` is passed should have th
                           >
                             <Link
                               href={null}
+                              isFluid={false}
                               isPositionedRight={false}
                               onBlur={[Function]}
                               onClick={[Function]}
@@ -471,6 +475,7 @@ exports[`<PolicyAndNotes /> if \`props.extraNotesText\` is passed should have th
                                 as={null}
                                 basic={true}
                                 floated="left"
+                                fluid={false}
                                 href={null}
                                 onClick={[Function]}
                                 target="_self"

--- a/src/components/property-page-widgets/RoomType/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/RoomType/__snapshots__/component.spec.js.snap
@@ -520,6 +520,7 @@ exports[`<RoomType /> by default should render the correct structure 1`] = `
                                             trigger={
                                               <Link
                                                 href={null}
+                                                isFluid={false}
                                                 isPositionedRight={false}
                                                 onClick={[Function]}
                                                 willOpenInNewTab={false}
@@ -555,6 +556,7 @@ exports[`<RoomType /> by default should render the correct structure 1`] = `
                                               trigger={
                                                 <Link
                                                   href={null}
+                                                  isFluid={false}
                                                   isPositionedRight={false}
                                                   onClick={[Function]}
                                                   willOpenInNewTab={false}
@@ -578,6 +580,7 @@ exports[`<RoomType /> by default should render the correct structure 1`] = `
                                                 trigger={
                                                   <Link
                                                     href={null}
+                                                    isFluid={false}
                                                     isPositionedRight={false}
                                                     onClick={[Function]}
                                                     willOpenInNewTab={false}
@@ -591,6 +594,7 @@ exports[`<RoomType /> by default should render the correct structure 1`] = `
                                                 >
                                                   <Link
                                                     href={null}
+                                                    isFluid={false}
                                                     isPositionedRight={false}
                                                     onBlur={[Function]}
                                                     onClick={[Function]}
@@ -603,6 +607,7 @@ exports[`<RoomType /> by default should render the correct structure 1`] = `
                                                       as={null}
                                                       basic={true}
                                                       floated="left"
+                                                      fluid={false}
                                                       href={null}
                                                       onClick={[Function]}
                                                       target="_self"
@@ -1463,6 +1468,7 @@ exports[`<RoomType /> if \`isUserOnMobile === true\` should render the correct s
                                             trigger={
                                               <Link
                                                 href={null}
+                                                isFluid={false}
                                                 isPositionedRight={false}
                                                 onClick={[Function]}
                                                 willOpenInNewTab={false}
@@ -1498,6 +1504,7 @@ exports[`<RoomType /> if \`isUserOnMobile === true\` should render the correct s
                                               trigger={
                                                 <Link
                                                   href={null}
+                                                  isFluid={false}
                                                   isPositionedRight={false}
                                                   onClick={[Function]}
                                                   willOpenInNewTab={false}
@@ -1521,6 +1528,7 @@ exports[`<RoomType /> if \`isUserOnMobile === true\` should render the correct s
                                                 trigger={
                                                   <Link
                                                     href={null}
+                                                    isFluid={false}
                                                     isPositionedRight={false}
                                                     onClick={[Function]}
                                                     willOpenInNewTab={false}
@@ -1534,6 +1542,7 @@ exports[`<RoomType /> if \`isUserOnMobile === true\` should render the correct s
                                                 >
                                                   <Link
                                                     href={null}
+                                                    isFluid={false}
                                                     isPositionedRight={false}
                                                     onBlur={[Function]}
                                                     onClick={[Function]}
@@ -1546,6 +1555,7 @@ exports[`<RoomType /> if \`isUserOnMobile === true\` should render the correct s
                                                       as={null}
                                                       basic={true}
                                                       floated="left"
+                                                      fluid={false}
                                                       href={null}
                                                       onClick={[Function]}
                                                       target="_self"

--- a/src/components/property-page-widgets/RoomTypes/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/RoomTypes/__snapshots__/component.spec.js.snap
@@ -2164,6 +2164,7 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                                   trigger={
                                                     <Link
                                                       href={null}
+                                                      isFluid={false}
                                                       isPositionedRight={false}
                                                       onClick={[Function]}
                                                       willOpenInNewTab={false}
@@ -2199,6 +2200,7 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                                     trigger={
                                                       <Link
                                                         href={null}
+                                                        isFluid={false}
                                                         isPositionedRight={false}
                                                         onClick={[Function]}
                                                         willOpenInNewTab={false}
@@ -2222,6 +2224,7 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                                       trigger={
                                                         <Link
                                                           href={null}
+                                                          isFluid={false}
                                                           isPositionedRight={false}
                                                           onClick={[Function]}
                                                           willOpenInNewTab={false}
@@ -2235,6 +2238,7 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                                       >
                                                         <Link
                                                           href={null}
+                                                          isFluid={false}
                                                           isPositionedRight={false}
                                                           onBlur={[Function]}
                                                           onClick={[Function]}
@@ -2247,6 +2251,7 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                                             as={null}
                                                             basic={true}
                                                             floated="left"
+                                                            fluid={false}
                                                             href={null}
                                                             onClick={[Function]}
                                                             target="_self"
@@ -3072,6 +3077,7 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                                   trigger={
                                                     <Link
                                                       href={null}
+                                                      isFluid={false}
                                                       isPositionedRight={false}
                                                       onClick={[Function]}
                                                       willOpenInNewTab={false}
@@ -3107,6 +3113,7 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                                     trigger={
                                                       <Link
                                                         href={null}
+                                                        isFluid={false}
                                                         isPositionedRight={false}
                                                         onClick={[Function]}
                                                         willOpenInNewTab={false}
@@ -3130,6 +3137,7 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                                       trigger={
                                                         <Link
                                                           href={null}
+                                                          isFluid={false}
                                                           isPositionedRight={false}
                                                           onClick={[Function]}
                                                           willOpenInNewTab={false}
@@ -3143,6 +3151,7 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                                       >
                                                         <Link
                                                           href={null}
+                                                          isFluid={false}
                                                           isPositionedRight={false}
                                                           onBlur={[Function]}
                                                           onClick={[Function]}
@@ -3155,6 +3164,7 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                                             as={null}
                                                             basic={true}
                                                             floated="left"
+                                                            fluid={false}
                                                             href={null}
                                                             onClick={[Function]}
                                                             target="_self"

--- a/src/styles/semantic/definitions/lodgify-ui-components/counter.less
+++ b/src/styles/semantic/definitions/lodgify-ui-components/counter.less
@@ -18,4 +18,10 @@
   .flex-container * {
     margin: 0;
   }
+
+  .ui.button.basic.has-outline.circular:active {
+    background-color: @themeActionColorDefault !important;
+    background-color: var(@themeActionColorIdentifier, @themeActionColorDefault) !important;
+    color: @white !important;
+  }
 }

--- a/src/styles/semantic/definitions/lodgify-ui-components/filter-trigger.less
+++ b/src/styles/semantic/definitions/lodgify-ui-components/filter-trigger.less
@@ -16,6 +16,7 @@
   display: flex;
 
   button {
+    background-color: inherit;
     border-radius: @filterTriggerButtonBorderRadius;
     border: none;
     cursor: pointer;

--- a/src/styles/semantic/definitions/lodgify-ui-components/filter-trigger.less
+++ b/src/styles/semantic/definitions/lodgify-ui-components/filter-trigger.less
@@ -32,18 +32,18 @@
     }
   }
 
-  button:first-of-type {
-    padding: @filterTriggerFilterButtonPadding;
-    border-radius: @filterTriggerFilterButtonBorderRadius;
-  }
-
-  button:last-of-type {
-    border-radius: @filterTriggerClearFiltersButtonBorderRadius;
-  }
-
   &.has-filter {
 
     button {
+
+      &:first-of-type {
+        padding: @filterTriggerFilterButtonPadding;
+        border-radius: @filterTriggerFilterButtonBorderRadius;
+      }
+
+      &:last-of-type {
+        border-radius: @filterTriggerClearFiltersButtonBorderRadius;
+      }
 
       & > i.icon p {
         font-weight: normal;

--- a/src/styles/semantic/definitions/lodgify-ui-components/property-search-result-list.less
+++ b/src/styles/semantic/definitions/lodgify-ui-components/property-search-result-list.less
@@ -20,6 +20,7 @@
 
   .result-list-container {
     margin-right: @resultListContainerMarginRight;
+    padding-right: @resultListContainerPaddingRight;
     overflow-x: hidden;
     overflow-y: scroll;
   }

--- a/src/styles/semantic/definitions/lodgify-ui-components/property-search-result-list.less
+++ b/src/styles/semantic/definitions/lodgify-ui-components/property-search-result-list.less
@@ -23,5 +23,10 @@
     padding-right: @resultListContainerPaddingRight;
     overflow-x: hidden;
     overflow-y: scroll;
+
+    & > .flex-container:first-child,
+    .ui.message {
+      margin-right: @resultListContainerMarginRight;
+    }
   }
 }

--- a/src/styles/semantic/themes/default/lodgify-ui-components/property-search-result-list.variables
+++ b/src/styles/semantic/themes/default/lodgify-ui-components/property-search-result-list.variables
@@ -2,5 +2,5 @@
   Property search result list
 --------------------------*/
 
-@resultListContainerMarginRight: -15px;
-@resultListContainerPaddingRight: 15px;
+@resultListContainerMarginRight: -10px;
+@resultListContainerPaddingRight: 10px;

--- a/src/styles/semantic/themes/default/lodgify-ui-components/property-search-result-list.variables
+++ b/src/styles/semantic/themes/default/lodgify-ui-components/property-search-result-list.variables
@@ -3,3 +3,4 @@
 --------------------------*/
 
 @resultListContainerMarginRight: -15px;
+@resultListContainerPaddingRight: 15px;

--- a/src/styles/semantic/themes/livingstone/collections/menu.overrides
+++ b/src/styles/semantic/themes/livingstone/collections/menu.overrides
@@ -280,6 +280,10 @@
         @media @mobileScreen {
           margin: @hasPageNumbersLastButtonMobileMargin;
         }
+
+        svg {
+          margin-left: @hasPageNumbersLastSVGMarginLeft;
+        }
       }
     }
   }

--- a/src/styles/semantic/themes/livingstone/collections/menu.variables
+++ b/src/styles/semantic/themes/livingstone/collections/menu.variables
@@ -179,6 +179,7 @@
 @hasPageNumbersActiveItemBorderRadius: 50%;
 @hasPageNumbersFirstButtonMobileMargin: 0 @10px 0 0;
 @hasPageNumbersLastButtonMobileMargin: 0 0 0 @10px;
+@hasPageNumbersLastSVGMarginLeft: @5px;
 
 /* Labeled Icon */
 

--- a/src/styles/semantic/themes/livingstone/collections/message.overrides
+++ b/src/styles/semantic/themes/livingstone/collections/message.overrides
@@ -20,6 +20,9 @@
 /* Default font size */
 
 /* Paragraph */
+.ui.message p {
+  margin: 0;
+}
 
 /* List */
 
@@ -72,6 +75,11 @@
 /*--------------
      Types
 ---------------*/
+
+/* Text aligned center */
+.ui.message.text-aligned-center {
+  text-align: center;
+}
 
 /* Positive */
 

--- a/src/styles/semantic/themes/livingstone/collections/message.variables
+++ b/src/styles/semantic/themes/livingstone/collections/message.variables
@@ -10,7 +10,7 @@
 @verticalPadding: @12px;
 @horizontalPadding: @15px;
 
-@paddedPadding: @35px;
+@paddedPadding: 1.5rem;
 
 @borderRadius: 0;
 @borderWidth: 0;

--- a/src/styles/semantic/themes/livingstone/elements/button.overrides
+++ b/src/styles/semantic/themes/livingstone/elements/button.overrides
@@ -107,6 +107,11 @@
     -moz-appearance: none;
     -webkit-appearance: none;
   }
+
+  &.fluid {
+    margin-right: 0;
+    padding: @basicVerticalPadding @basicHorizontalPadding;
+  }
 }
 
 /* Basic Hover */

--- a/src/styles/semantic/themes/livingstone/elements/button.overrides
+++ b/src/styles/semantic/themes/livingstone/elements/button.overrides
@@ -57,17 +57,17 @@
         States
 --------------------*/
 
-/* Hovered */
-.ui.button:hover {
+/* Hovered, Focused and Active */
+.ui.button:hover,
+.ui.button:focus,
+.ui.button:active {
   background-color: var(@themeActionDarkerColorIdentifier, @themeActionDarkerColorDefault);
   color: var(@themeActionContrastColorIdentifier, @themeActionContrastColorDefault);
 }
 
+/* Hovered */
+
 /* Focused */
-.ui.button:focus {
-  background-color: var(@themeActionDarkerColorIdentifier, @themeActionDarkerColorDefault) !important;
-  color: var(@themeActionColorIdentifier, @themeActionColorDefault) !important;
-}
 
 /* Disabled */
 .ui.disabled.button {
@@ -78,6 +78,9 @@
 /* Pressed Down */
 
 /* Active */
+.ui.button:active {
+  transform: @activeTransform;
+}
 
 /* Active + Hovered */
 

--- a/src/styles/semantic/themes/livingstone/elements/button.variables
+++ b/src/styles/semantic/themes/livingstone/elements/button.variables
@@ -57,6 +57,7 @@
 /* Pressed Down */
 
 /* Active */
+@activeTransform: scale(0.96);
 
 /* Active + Hovered */
 

--- a/src/styles/semantic/themes/livingstone/elements/label.overrides
+++ b/src/styles/semantic/themes/livingstone/elements/label.overrides
@@ -93,6 +93,12 @@
     word-break: break-word;
     transition: @priceLabelTransitionOnHover;
 
+    .ui.label,
+    .ui.label .ui.label {
+      color: @themeActionContrastColorDefault;
+      color: var(@themeActionContrastColorIdentifier, @themeActionContrastColorDefault);
+    }
+
     &.is-clickable {
       cursor: pointer;
     }
@@ -174,15 +180,22 @@
 
       p {
         margin-right: @priceLabelTextMargin;
-        color: @black;
       }
 
       .ui.label {
         padding: @priceLabelPeriodTextPadding;
         background: transparent;
         border-radius: @priceLabelPeriodBorderRadius;
+        color: @themeActionContrastColorDefault;
+        color: var(@themeActionContrastColorIdentifier, @themeActionContrastColorDefault);
         box-shadow: @priceLabelPeriodBoxShadow;
-        color: @black;
+      }
+
+      .ui.label,
+      p,
+      h3 {
+        color: @themeActionContrastColorDefault;
+        color: var(@themeActionContrastColorIdentifier, @themeActionContrastColorDefault);
       }
     }
   }

--- a/src/styles/semantic/themes/livingstone/elements/label.variables
+++ b/src/styles/semantic/themes/livingstone/elements/label.variables
@@ -77,7 +77,7 @@
 @priceLabelTextMargin: 3px;
 @priceLabelPeriodTextPadding: 5px;
 @priceLabelPeriodBorderRadius: 2px;
-@priceLabelPeriodBoxShadow: 0 0 0 1px @black;
+@priceLabelPeriodBoxShadow: 0 0 0 1px;
 @priceLabelTransitionOnHover: all 0.2s cubic-bezier(0.48, 0.73, 0.49, 1.29) 0s;
 @priceLabelPricePerPeriodContainerMaxHeight: 26px;
 

--- a/src/styles/semantic/themes/livingstone/views/card.overrides
+++ b/src/styles/semantic/themes/livingstone/views/card.overrides
@@ -262,7 +262,7 @@
     > .flex-container {
       color: @black;
 
-      p {
+      p:not(:first-child) {
         margin-left: @summaryCardPropertyTypeMarginLeft;
       }
     }

--- a/src/styles/semantic/themes/livingstone/views/card.overrides
+++ b/src/styles/semantic/themes/livingstone/views/card.overrides
@@ -211,6 +211,7 @@
 
         > .header .ui.header {
           font-size: @searchResultHeaderFontSize;
+          margin-right: 0;
         }
       }
 
@@ -257,6 +258,10 @@
       font-size: @summaryCardFontSize;
       line-height: @summaryCardLineHeight;
       height: @summaryCardHeight;
+      max-width: @summaryCardHeaderMaxWidth;
+      text-overflow: ellipsis;
+      overflow: hidden;
+      white-space: nowrap;
     }
 
     > .flex-container {

--- a/src/styles/semantic/themes/livingstone/views/card.overrides
+++ b/src/styles/semantic/themes/livingstone/views/card.overrides
@@ -208,6 +208,10 @@
           text-overflow: ellipsis;
           white-space: nowrap;
         }
+
+        > .header .ui.header {
+          font-size: @searchResultHeaderFontSize;
+        }
       }
 
       img {

--- a/src/styles/semantic/themes/livingstone/views/card.overrides
+++ b/src/styles/semantic/themes/livingstone/views/card.overrides
@@ -172,6 +172,8 @@
 
       > .flex-container {
         position: relative;
+        min-height: @searchResultImageHeight;
+        max-height: @searchResultImageHeight;
 
         > .ui.raised.segment {
           background-color: @themeActionColorDefault;

--- a/src/styles/semantic/themes/livingstone/views/card.variables
+++ b/src/styles/semantic/themes/livingstone/views/card.variables
@@ -133,6 +133,7 @@
 @summaryCardBoxShadow: 0 2px 8px 0 rgba(0, 0, 0, 0.18);
 @summaryCardHeight: 20px;
 @summaryCardLineHeight: 20px;
+@summaryCardHeaderMaxWidth: 220px;
 
 /* Colored */
 

--- a/src/styles/semantic/themes/livingstone/views/card.variables
+++ b/src/styles/semantic/themes/livingstone/views/card.variables
@@ -87,6 +87,8 @@
 @searchResultBoxShadow: 0 8px 20px 0 rgba(0, 0, 0, 0.2);
 @searchResultBoxShadowTransition: all 0.3s cubic-bezier(0.59, 0.25, 0, 1.13);
 
+@searchResultImageHeight: 184px;
+
 @searchResultContentPadding: 25px 20px;
 @searchResultContentPaddingTop: 15px;
 

--- a/src/styles/semantic/themes/livingstone/views/card.variables
+++ b/src/styles/semantic/themes/livingstone/views/card.variables
@@ -92,6 +92,8 @@
 @searchResultContentPadding: 25px 20px;
 @searchResultContentPaddingTop: 15px;
 
+@searchResultHeaderFontSize: @20px;
+
 @searchResultDescriptionFontSize: 12px;
 
 @searchResultLabelMargin: 10px;

--- a/src/utils/get-privacy-consent-label/__snapshots__/getPrivacyConsentLabel.spec.js.snap
+++ b/src/utils/get-privacy-consent-label/__snapshots__/getPrivacyConsentLabel.spec.js.snap
@@ -17,6 +17,7 @@ exports[`getPrivacyConsentLabel if \`privacyConsentLabelLinkUrl\` is passed shou
   </Paragraph>
   <Link
     href="labelLinkUrl"
+    isFluid={false}
     isPositionedRight={false}
     onClick={[Function]}
     willOpenInNewTab={true}
@@ -25,6 +26,7 @@ exports[`getPrivacyConsentLabel if \`privacyConsentLabelLinkUrl\` is passed shou
       as="a"
       basic={true}
       floated="left"
+      fluid={false}
       href="labelLinkUrl"
       onClick={[Function]}
       target="_blank"
@@ -62,6 +64,7 @@ exports[`getPrivacyConsentLabel if both \`privacyConsentLabelLinkUrl\` and \`pri
   </Paragraph>
   <Link
     href="labelLinkUrl"
+    isFluid={false}
     isPositionedRight={false}
     onClick={[Function]}
     willOpenInNewTab={true}
@@ -70,6 +73,7 @@ exports[`getPrivacyConsentLabel if both \`privacyConsentLabelLinkUrl\` and \`pri
       as="a"
       basic={true}
       floated="left"
+      fluid={false}
       href="labelLinkUrl"
       onClick={[Function]}
       target="_blank"

--- a/tools/jest/jest.framework-setup.js
+++ b/tools/jest/jest.framework-setup.js
@@ -18,6 +18,8 @@ const consoleWarn = console.warn;
 const consoleError = console.error;
 
 const elevateLogToError = (...args) => {
+  // Remove this grim ting https://github.com/Semantic-Org/Semantic-UI-React/issues/3741
+  if (args[0].includes('UNSAFE_')) return;
   throw new Error(
     util.format.apply(this, args).replace(/^Error: (?:Warning: )?/, '')
   );


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-2570)

### What **one** thing does this PR do?
1. `PropertySearchResultList` Message, results number and dropdown are scrollable.
2. `PropertySearchResultList` Message is stack on mobile.
3. `PropertySearchResultList` Dropdown is visible when in placeholder state.
4. `PropertySearchResult` Header can fit more text.
5. `PropertySearchResult` Image height is fixed.
6. `FilterTrigger` has no background color.
7. `PriceLabel` text color contrasts with the action color.
8. `Button` active state gives visual feedback. Focus state is more readable.
9. `SummaryCard` ratings are hidden if they are not larger than 0.
10. `SummaryCard` header has an ellipsis when larger than max width.
11. `Counter` buttons have an active state.
12. `Pagination` next button icon is centered.
13. `Message` has a reduced height.

### Any other notes
1.
![Kapture 2019-08-14 at 12 51 09](https://user-images.githubusercontent.com/10498995/63015796-39754480-be92-11e9-882a-69218d049a9f.gif)

2.
![image](https://user-images.githubusercontent.com/10498995/63015819-4c881480-be92-11e9-9fc4-284b915e9b08.png)

3.
<img width="1440" alt="Screenshot 2019-08-14 at 12 53 13" src="https://user-images.githubusercontent.com/10498995/63015926-8e18bf80-be92-11e9-8ad2-f0f42fff785d.png">

4.
![image](https://user-images.githubusercontent.com/10498995/63015960-a25cbc80-be92-11e9-8de5-689a977f30ae.png)

5. 
![image](https://user-images.githubusercontent.com/10498995/63015987-b56f8c80-be92-11e9-93aa-fda7265287b5.png)

6.
![image](https://user-images.githubusercontent.com/10498995/63016017-cfa96a80-be92-11e9-94c0-dbe7cf71e91b.png)

7.
<img width="948" alt="Screenshot 2019-08-14 at 12 56 40" src="https://user-images.githubusercontent.com/10498995/63016077-fbc4eb80-be92-11e9-8a4b-4f4cc230846e.png">

8.
![Kapture 2019-08-14 at 12 57 39](https://user-images.githubusercontent.com/10498995/63016125-1d25d780-be93-11e9-99b6-3552de343429.gif)

9.
![image](https://user-images.githubusercontent.com/10498995/63016164-36c71f00-be93-11e9-8568-2b103800c580.png)

10.
![image](https://user-images.githubusercontent.com/10498995/63016435-f320e500-be93-11e9-9590-de39dd936908.png)


11.
![Kapture 2019-08-14 at 13 00 15](https://user-images.githubusercontent.com/10498995/63016254-7aba2400-be93-11e9-8d0b-6fe81c23675e.gif)

12.
![image](https://user-images.githubusercontent.com/10498995/63016286-902f4e00-be93-11e9-8105-c9f91743c0f3.png)



