### PR TITLE
TE-2659 Fix Input label behaviour

### DIFF
--- a/src/components/inputs/InputController/component.js
+++ b/src/components/inputs/InputController/component.js
@@ -21,21 +21,6 @@ import { getValueFromEvent } from './utils/getValueFromEvent';
 export class Component extends PureComponent {
   state = {
     value: this.props.initialValue,
-    isDirty: undefined,
-  };
-
-  componentDidMount = () => {
-    if (!!this.state.value || !!this.props.value) {
-      const value = getControlledInputValue(
-        this.props.value,
-        this.props.initialValue,
-        this.state.value
-      );
-
-      const isDirty = some(value);
-
-      this.setState({ isDirty });
-    }
   };
 
   componentDidUpdate(previousProps, previousState) {
@@ -54,9 +39,7 @@ export class Component extends PureComponent {
         this.state.value
       );
 
-      const isDirty = some(value);
-
-      this.setState({ isDirty, value });
+      this.setState({ value });
       return;
     }
 
@@ -99,7 +82,7 @@ export class Component extends PureComponent {
       <Input
         className={getClassNames({
           compact: isCompact,
-          dirty: this.state.isDirty,
+          dirty: some(value),
           error: error,
           focus: isFocused,
           valid: isValid,

--- a/src/components/inputs/InputController/component.spec.js
+++ b/src/components/inputs/InputController/component.spec.js
@@ -28,9 +28,6 @@ const props = {
 const children = <input />;
 
 const CONTROLLED_VALUE = '🐑';
-const SOME_VALUE = '🔢';
-
-some.mockReturnValue(SOME_VALUE);
 
 const getInputController = extraProps =>
   shallow(
@@ -49,7 +46,8 @@ describe('<InputController />', () => {
     });
 
     it('should default to no classNames on `Input`', () => {
-      const semanticInput = getInputControllerInput();
+      const wrapper = getInputController();
+      const semanticInput = wrapper.find('Input');
       const classNames = ['dirty', 'valid', 'error'];
 
       classNames.forEach(className => {
@@ -275,59 +273,6 @@ describe('<InputController />', () => {
     });
   });
 
-  describe('`componentDidMount`', () => {
-    describe('if `this.state.value` or `this.props.value` are truthy', () => {
-      it('should call `getControlledInputValue` with the correct arguments', () => {
-        const PROPS_VALUE = '🌴';
-        const PROPS_INITIAL_VALUE = '🌲';
-        const STATE_VALUE = '🌳';
-
-        const wrapper = getInputController({
-          value: PROPS_VALUE,
-          initialValue: PROPS_INITIAL_VALUE,
-        });
-
-        wrapper.instance().state = {
-          value: STATE_VALUE,
-        };
-        wrapper.instance().componentDidMount();
-
-        expect(getControlledInputValue).toHaveBeenCalledWith(
-          PROPS_VALUE,
-          PROPS_INITIAL_VALUE,
-          STATE_VALUE
-        );
-      });
-
-      it('should call `some` with the correct arguments', () => {
-        const PROPS_VALUE = '🌴';
-        const PROPS_INITIAL_VALUE = '🌲';
-
-        getControlledInputValue.mockReturnValue(CONTROLLED_VALUE);
-        const wrapper = getInputController({
-          value: PROPS_VALUE,
-          initialValue: PROPS_INITIAL_VALUE,
-        });
-
-        wrapper.instance().componentDidMount();
-
-        expect(some).toHaveBeenCalledWith(CONTROLLED_VALUE);
-      });
-
-      it('should call `this.setState` with the correct arguments', () => {
-        const PROPS_VALUE = '🌴';
-        const wrapper = getInputController({ value: PROPS_VALUE });
-
-        wrapper.instance().setState = jest.fn();
-        wrapper.instance().componentDidMount();
-
-        expect(wrapper.instance().setState).toHaveBeenCalledWith({
-          isDirty: SOME_VALUE,
-        });
-      });
-    });
-  });
-
   describe('`componentDidUpdate`', () => {
     it('should call `getIsInputValueReset` with the right arguments', () => {
       const PROPS_VALUE = '🌴';
@@ -425,7 +370,6 @@ describe('<InputController />', () => {
           .componentDidUpdate({ value: PREVIOUS_PROPS_VALUE }, {});
 
         expect(wrapper.instance().setState).toHaveBeenCalledWith({
-          isDirty: SOME_VALUE,
           value: CONTROLLED_VALUE,
         });
       });


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-2659)

### What **one** thing does this PR do?
Fix the problem with labels in input that overlap the value when the input is dirty.

### Any other notes
|before|after|
|-|-|
|![input-before](https://user-images.githubusercontent.com/49396812/65157104-7a7fec00-da30-11e9-8596-1c5efb1d1461.gif)|![input after](https://user-images.githubusercontent.com/49396812/65157125-853a8100-da30-11e9-9e41-ecda26bb8484.gif)|

