### PR TITLE
TE-2668 Search app - Event triggers on second interaction

### DIFF
--- a/src/utils/google-map-react/components/GoogleMapReact/component.js
+++ b/src/utils/google-map-react/components/GoogleMapReact/component.js
@@ -45,18 +45,8 @@ export class Component extends PureComponent {
   };
 
   componentDidUpdate = ({ bounds: previousControlledBounds }) => {
-    const { areBoundsChanged, bounds, isDragged, isZoomed, size } = this.state;
-    const { bounds: controlledBounds, onBoundsChange } = this.props;
-
-    if (areBoundsChanged) {
-      onBoundsChange(adaptNESWtoENSW(bounds), isZoomed || isDragged);
-      this.setState({
-        areBoundsChanged: false,
-        areBoundsChangedProgramatically: false,
-        isDragged: false,
-        isZoomed: false,
-      });
-    }
+    const { size } = this.state;
+    const { bounds: controlledBounds } = this.props;
 
     if (isEqual(previousControlledBounds, controlledBounds)) return;
 
@@ -74,6 +64,19 @@ export class Component extends PureComponent {
   };
 
   handleChange = ({ bounds, center, size, zoom }) => {
+    const { onBoundsChange } = this.props;
+    const { areBoundsChanged, isDragged, isZoomed } = this.state;
+
+    if (areBoundsChanged) {
+      onBoundsChange(adaptNESWtoENSW(bounds), isZoomed || isDragged);
+      this.setState({
+        areBoundsChanged: false,
+        areBoundsChangedProgramatically: false,
+        isDragged: false,
+        isZoomed: false,
+      });
+    }
+
     if (!this.props.bounds) return;
     this.setState({ areBoundsChanged: true, bounds, center, size, zoom });
   };

--- a/src/utils/google-map-react/components/GoogleMapReact/component.spec.js
+++ b/src/utils/google-map-react/components/GoogleMapReact/component.spec.js
@@ -75,77 +75,6 @@ describe('<GoogleMapReacts />', () => {
   });
 
   describe('componentDidUpdate', () => {
-    describe('if `state.areBoundsChanged` is false', () => {
-      it('should not call `props.onBoundsChange`', () => {
-        const onBoundsChange = jest.fn();
-        const wrapper = getGoogleMapReact({ onBoundsChange });
-
-        wrapper.setState({ areBoundsChanged: false });
-        onBoundsChange.mockClear();
-        wrapper.instance().componentDidUpdate({ bounds: null });
-
-        expect(onBoundsChange).not.toHaveBeenCalled();
-      });
-    });
-
-    describe('if `state.areBoundsChanged` is true', () => {
-      it('should call `props.onBoundsChange` with the right arguments', () => {
-        const onBoundsChange = jest.fn();
-        const wrapper = getGoogleMapReact({ onBoundsChange });
-        const bounds = 'some bounds';
-        const ADAPTED_BOUNDS = 'adapted bounds';
-
-        adaptNESWtoENSW.mockClear();
-        adaptNESWtoENSW.mockReturnValueOnce(ADAPTED_BOUNDS);
-        wrapper.instance().setState({ areBoundsChanged: true, bounds });
-        wrapper.instance().componentDidUpdate({ bounds: null });
-
-        expect(adaptNESWtoENSW).toHaveBeenCalledWith(bounds);
-        expect(onBoundsChange).toHaveBeenCalledWith(ADAPTED_BOUNDS, false);
-      });
-
-      describe('if either `state.isZoomed` or `state.isDragged` is true', () => {
-        it('should call `props.onBoundsChange` with the right arguments', () => {
-          const testCases = [[true, false], [false, true]];
-
-          testCases.forEach(([isZoomed, isDragged]) => {
-            const onBoundsChange = jest.fn();
-            const wrapper = getGoogleMapReact({ onBoundsChange });
-            const bounds = 'some bounds';
-            const ADAPTED_BOUNDS = 'adapted bounds';
-
-            adaptNESWtoENSW.mockClear();
-            adaptNESWtoENSW.mockReturnValueOnce(ADAPTED_BOUNDS);
-            wrapper.instance().setState({
-              areBoundsChanged: true,
-              bounds,
-              isZoomed,
-              isDragged,
-            });
-            wrapper.instance().componentDidUpdate({ bounds: null });
-
-            expect(adaptNESWtoENSW).toHaveBeenCalledWith(bounds);
-            expect(onBoundsChange).toHaveBeenCalledWith(ADAPTED_BOUNDS, true);
-          });
-        });
-      });
-
-      it('should call `setState` with the right arguments', () => {
-        const wrapper = getGoogleMapReact();
-
-        wrapper.instance().setState = jest.fn(wrapper.instance().setState);
-        wrapper.instance().setState({ areBoundsChanged: true });
-        wrapper.instance().componentDidUpdate({ bounds: null });
-
-        expect(wrapper.instance().setState).toHaveBeenCalledWith({
-          areBoundsChanged: false,
-          areBoundsChangedProgramatically: false,
-          isDragged: false,
-          isZoomed: false,
-        });
-      });
-    });
-
     describe('if `props.bounds` has not changed', () => {
       it('should not call `fitBounds`', () => {
         const bounds = {
@@ -208,9 +137,53 @@ describe('<GoogleMapReacts />', () => {
   });
 
   describe('handleChange', () => {
+    describe('if `state.areBoundsChanged` is false', () => {
+      it('should not call `props.onBoundsChange`', () => {
+        const onBoundsChange = jest.fn();
+        const wrapper = getGoogleMapReact({ onBoundsChange });
+
+        wrapper.setState({ areBoundsChanged: false });
+        onBoundsChange.mockClear();
+        wrapper.instance().handleChange({});
+
+        expect(onBoundsChange).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('if `state.areBoundsChanged` is true', () => {
+      it('should call `props.onBoundsChange` with the right arguments', () => {
+        const onBoundsChange = jest.fn();
+        const wrapper = getGoogleMapReact({ onBoundsChange });
+        const bounds = 'some bounds';
+        const ADAPTED_BOUNDS = 'adapted bounds';
+
+        adaptNESWtoENSW.mockClear();
+        adaptNESWtoENSW.mockReturnValueOnce(ADAPTED_BOUNDS);
+        wrapper.instance().setState({ areBoundsChanged: true, bounds });
+        wrapper.instance().handleChange({ bounds });
+
+        expect(adaptNESWtoENSW).toHaveBeenCalledWith(bounds);
+        expect(onBoundsChange).toHaveBeenCalledWith(ADAPTED_BOUNDS, false);
+      });
+
+      it('should call `setState` with the right arguments', () => {
+        const wrapper = getGoogleMapReact();
+
+        wrapper.instance().setState = jest.fn(wrapper.instance().setState);
+        wrapper.instance().setState({ areBoundsChanged: true });
+        wrapper.instance().handleChange({ bounds: null });
+        expect(wrapper.instance().setState).toHaveBeenCalledWith({
+          areBoundsChanged: false,
+          areBoundsChangedProgramatically: false,
+          isDragged: false,
+          isZoomed: false,
+        });
+      });
+    });
+
     describe('if `props.bounds` is `null`', () => {
       it('should not call `setState`', () => {
-        const wrapper = getGoogleMapReact();
+        const wrapper = getGoogleMapReact({ areBoundsChanged: false });
 
         wrapper.instance().setState = jest.fn();
         wrapper.instance().handleChange({});


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-2668)

### What **one** thing does this PR do?
Fires `onBoundsChange` event every time the user `zooms` or `drags` the map.

### Any other notes
![Kapture 2019-09-26 at 16 22 48](https://user-images.githubusercontent.com/33876435/65696880-4df45180-e07a-11e9-8ac6-38dfd077cf6d.gif)
