### PR TITLE
TE-2669 Fix missing translations

### DIFF
--- a/src/components/property-page-widgets/Amenities/Readme.md
+++ b/src/components/property-page-widgets/Amenities/Readme.md
@@ -121,7 +121,7 @@ const amenities = [
   },
 ];
 
-<Amenities amenities={amenities} modalTriggerText="See more" />
+<Amenities amenities={amenities} modalTriggerText="See more" amenitiesConjunctionText="and"/>
 ```
 
 ### Variations
@@ -171,7 +171,7 @@ const amenities = [
   },
 ];
 
-<Amenities amenities={amenities} headingText="Property Amenities" />
+<Amenities amenities={amenities} headingText="Property Amenities" amenitiesConjunctionText="and"/>
 
 ```
 
@@ -196,7 +196,7 @@ const amenities = [
   },
 ];
 
-<Amenities amenities={amenities} headingText="Property Amenities" isStacked />
+<Amenities amenities={amenities} headingText="Property Amenities" amenitiesConjunctionText="and" isStacked />
 
 ```
 
@@ -246,6 +246,6 @@ const amenities = [
 ];
 
 
-<Amenities hasExtraItemsInModal amenities={amenities} headingText="Property Amenities" />
+<Amenities hasExtraItemsInModal amenities={amenities} headingText="Property Amenities" amenitiesConjunctionText="and"/>
 
 ```

--- a/src/components/property-page-widgets/Amenities/component.js
+++ b/src/components/property-page-widgets/Amenities/component.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { VIEW_MORE } from 'utils/default-strings';
+import { AND, VIEW_MORE } from 'utils/default-strings';
 import { Grid } from 'layout/Grid';
 import { GridRow } from 'layout/GridRow';
 import { GridColumn } from 'layout/GridColumn';
@@ -23,6 +23,7 @@ export const Component = ({
   headingText,
   isStacked,
   modalTriggerText,
+  amenitiesConjunctionText,
 }) => (
   <Grid className="is-amenities" columns={isStacked ? 1 : 3} isStackable>
     <GridRow>
@@ -32,13 +33,14 @@ export const Component = ({
         </GridColumn>
       )}
       {getDefaultItems(amenities, isStacked).map((amenity, index) =>
-        getCategoryMarkup(amenity, index, isStacked)
+        getCategoryMarkup(amenity, index, amenitiesConjunctionText, isStacked)
       )}
       {hasExtraItems(amenities, isStacked) &&
         getExtraItemsMarkup(
           hasExtraItemsInModal,
           modalTriggerText,
-          getExtraItems(amenities, isStacked)
+          getExtraItems(amenities, isStacked),
+          amenitiesConjunctionText
         )}
     </GridRow>
   </Grid>
@@ -51,6 +53,7 @@ Component.defaultProps = {
   headingText: null,
   isStacked: false,
   modalTriggerText: VIEW_MORE,
+  amenitiesConjunctionText: AND,
 };
 
 Component.propTypes = {
@@ -67,12 +70,14 @@ Component.propTypes = {
       name: PropTypes.string.isRequired,
     })
   ).isRequired,
+  /** The conjunction to display after the penultimate amenity in the array.  */
+  amenitiesConjunctionText: PropTypes.string,
   /** Are the extra items displayed in a modal. */
   hasExtraItemsInModal: PropTypes.bool,
   /** The text to display as a heading at the top of the amenities. */
   headingText: PropTypes.string,
-  /** Are the amenities displayed stacked on top of one another */
+  /** Are the amenities displayed stacked on top of one another. */
   isStacked: PropTypes.bool,
-  /** The text for the modal trigger */
+  /** The text for the modal trigger. */
   modalTriggerText: PropTypes.string,
 };

--- a/src/components/property-page-widgets/Amenities/utils/getCategoryMarkup.js
+++ b/src/components/property-page-widgets/Amenities/utils/getCategoryMarkup.js
@@ -10,9 +10,14 @@ import { getFormattedAmenityItems } from './getFormattedAmenityItems';
 /**
  * @param  {Object}  category
  * @param  {number}  index
+ * @param  {string}  amenitiesConjunctionText
  * @return {Object}
  */
-export const getCategoryMarkup = (category, index) => (
+export const getCategoryMarkup = (
+  category,
+  index,
+  amenitiesConjunctionText
+) => (
   <GridColumn key={buildKeyFromStrings(category.name, index)}>
     <Icon
       isLabelLeft
@@ -20,6 +25,8 @@ export const getCategoryMarkup = (category, index) => (
       labelWeight="heavy"
       name={category.iconName}
     />
-    <Paragraph>{getFormattedAmenityItems(category.items)}</Paragraph>
+    <Paragraph>
+      {getFormattedAmenityItems(category.items, amenitiesConjunctionText)}
+    </Paragraph>
   </GridColumn>
 );

--- a/src/components/property-page-widgets/Amenities/utils/getExtraItemsMarkup.js
+++ b/src/components/property-page-widgets/Amenities/utils/getExtraItemsMarkup.js
@@ -10,15 +10,17 @@ import { Modal } from 'elements/Modal';
 import { getCategoryMarkup } from './getCategoryMarkup';
 
 /**
- * @param {boolean} hasExtraItemsInModal
- * @param {string} modalTriggerText
+ * @param {boolean}  hasExtraItemsInModal
+ * @param {string}   modalTriggerText
  * @param {Object[]} amenities
+ * @param {string}   amenitiesConjunctionText
  * @return {Object}
  */
 export const getExtraItemsMarkup = (
   hasExtraItemsInModal,
   modalTriggerText,
-  amenities
+  amenities,
+  amenitiesConjunctionText
 ) =>
   hasExtraItemsInModal ? (
     <GridColumn width={12}>
@@ -31,5 +33,7 @@ export const getExtraItemsMarkup = (
       </Modal>
     </GridColumn>
   ) : (
-    amenities.map((amenity, index) => getCategoryMarkup(amenity, index))
+    amenities.map((amenity, index) =>
+      getCategoryMarkup(amenity, index, amenitiesConjunctionText)
+    )
   );

--- a/src/components/property-page-widgets/Amenities/utils/getFormattedAmenityItems.js
+++ b/src/components/property-page-widgets/Amenities/utils/getFormattedAmenityItems.js
@@ -1,14 +1,13 @@
-import { AND } from 'utils/default-strings';
-
 /**
  * @param  {string[]} items
+ * @param  {string}   amenitiesConjunctionText
  * @return {string[]}
  */
-export const getFormattedAmenityItems = items =>
+export const getFormattedAmenityItems = (items, amenitiesConjunctionText) =>
   items.map((item, index) => {
     // Is penultimate item in array
     if (index === items.length - 2) {
-      return `${item} ${AND} `;
+      return `${item} ${amenitiesConjunctionText} `;
     }
     // Is last item in array
     if (index === items.length - 1) {

--- a/src/components/property-page-widgets/Amenities/utils/getFormattedAmenityItems.spec.js
+++ b/src/components/property-page-widgets/Amenities/utils/getFormattedAmenityItems.spec.js
@@ -2,7 +2,7 @@ import { getFormattedAmenityItems } from './getFormattedAmenityItems';
 
 describe('`getFormattedAmenityItems`', () => {
   it('should format the items in an array correctly', () => {
-    const actual = getFormattedAmenityItems(['yo', 'yo', 'yo']);
+    const actual = getFormattedAmenityItems(['yo', 'yo', 'yo'], 'and');
 
     expect(actual).toEqual(['yo, ', 'yo and ', 'yo']);
   });

--- a/src/components/property-page-widgets/RoomType/Readme.md
+++ b/src/components/property-page-widgets/RoomType/Readme.md
@@ -77,6 +77,7 @@ const roomTypeFeatures = [
   extraFeatures={extraRoomTypeFeatures}
   slideShowImages={images}
   amenities={availableAmenities}
+  moreInfoText="More info"
 />
 ```
 
@@ -93,5 +94,6 @@ const roomTypeFeatures = [
   pricePerPeriodPrefix=""
   isShowingPlaceholder
   slideShowImages={[]}
+  moreInfoText=""
 />
 ```

--- a/src/components/property-page-widgets/RoomType/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/RoomType/__snapshots__/component.spec.js.snap
@@ -44,6 +44,7 @@ exports[`<RoomType /> by default should render the correct structure 1`] = `
   isShowingPlaceholder={false}
   isUserOnMobile={false}
   locationName="Catania"
+  moreInfoText="Oof"
   name="The Cat House"
   periodText="per night"
   pricePerPeriod="$280"
@@ -535,7 +536,7 @@ exports[`<RoomType /> by default should render the correct structure 1`] = `
                                                 onClick={[Function]}
                                                 willOpenInNewTab={false}
                                               >
-                                                More Info
+                                                Oof
                                               </Link>
                                             }
                                           >
@@ -573,7 +574,7 @@ exports[`<RoomType /> by default should render the correct structure 1`] = `
                                                   onClick={[Function]}
                                                   willOpenInNewTab={false}
                                                 >
-                                                  More Info
+                                                  Oof
                                                 </Link>
                                               }
                                             >
@@ -595,7 +596,7 @@ exports[`<RoomType /> by default should render the correct structure 1`] = `
                                                     onClick={[Function]}
                                                     willOpenInNewTab={false}
                                                   >
-                                                    More Info
+                                                    Oof
                                                   </Link>
                                                 }
                                               >
@@ -634,7 +635,7 @@ exports[`<RoomType /> by default should render the correct structure 1`] = `
                                                                 target="_self"
                                                                 type="button"
                                                               >
-                                                                More Info
+                                                                Oof
                                                               </button>,
                                                             }
                                                           }
@@ -647,7 +648,7 @@ exports[`<RoomType /> by default should render the correct structure 1`] = `
                                                                   target="_self"
                                                                   type="button"
                                                                 >
-                                                                  More Info
+                                                                  Oof
                                                                 </button>,
                                                               }
                                                             }
@@ -659,7 +660,7 @@ exports[`<RoomType /> by default should render the correct structure 1`] = `
                                                               target="_self"
                                                               type="button"
                                                             >
-                                                              More Info
+                                                              Oof
                                                             </button>
                                                           </RefFindNode>
                                                         </Ref>
@@ -808,6 +809,7 @@ exports[`<RoomType /> if \`isShowingPlaceholder\` is \`true\` should render the 
   isShowingPlaceholder={true}
   isUserOnMobile={false}
   locationName="Catania"
+  moreInfoText="Oof"
   name="The Cat House"
   periodText="per night"
   pricePerPeriod="$280"
@@ -1062,6 +1064,7 @@ exports[`<RoomType /> if \`isUserOnMobile === true\` should render the correct s
   isShowingPlaceholder={false}
   isUserOnMobile={true}
   locationName="Catania"
+  moreInfoText="Oof"
   name="The Cat House"
   periodText="per night"
   pricePerPeriod="$280"
@@ -1525,7 +1528,7 @@ exports[`<RoomType /> if \`isUserOnMobile === true\` should render the correct s
                                                 onClick={[Function]}
                                                 willOpenInNewTab={false}
                                               >
-                                                More Info
+                                                Oof
                                               </Link>
                                             }
                                           >
@@ -1563,7 +1566,7 @@ exports[`<RoomType /> if \`isUserOnMobile === true\` should render the correct s
                                                   onClick={[Function]}
                                                   willOpenInNewTab={false}
                                                 >
-                                                  More Info
+                                                  Oof
                                                 </Link>
                                               }
                                             >
@@ -1585,7 +1588,7 @@ exports[`<RoomType /> if \`isUserOnMobile === true\` should render the correct s
                                                     onClick={[Function]}
                                                     willOpenInNewTab={false}
                                                   >
-                                                    More Info
+                                                    Oof
                                                   </Link>
                                                 }
                                               >
@@ -1624,7 +1627,7 @@ exports[`<RoomType /> if \`isUserOnMobile === true\` should render the correct s
                                                                 target="_self"
                                                                 type="button"
                                                               >
-                                                                More Info
+                                                                Oof
                                                               </button>,
                                                             }
                                                           }
@@ -1637,7 +1640,7 @@ exports[`<RoomType /> if \`isUserOnMobile === true\` should render the correct s
                                                                   target="_self"
                                                                   type="button"
                                                                 >
-                                                                  More Info
+                                                                  Oof
                                                                 </button>,
                                                               }
                                                             }
@@ -1649,7 +1652,7 @@ exports[`<RoomType /> if \`isUserOnMobile === true\` should render the correct s
                                                               target="_self"
                                                               type="button"
                                                             >
-                                                              More Info
+                                                              Oof
                                                             </button>
                                                           </RefFindNode>
                                                         </Ref>

--- a/src/components/property-page-widgets/RoomType/component.js
+++ b/src/components/property-page-widgets/RoomType/component.js
@@ -4,8 +4,9 @@ import { Card } from 'semantic-ui-react';
 
 import {
   PER_NIGHT,
-  FROM_PRICE_PER_PERIOD,
+  MORE_INFO,
   ROOM_AMENITIES,
+  FROM_PRICE_PER_PERIOD,
 } from 'utils/default-strings';
 import { Divider } from 'elements/Divider';
 import { Grid } from 'layout/Grid';
@@ -38,6 +39,7 @@ const Component = ({
   isShowingPlaceholder,
   isUserOnMobile,
   name,
+  moreInfoText,
   periodText,
   pricePerPeriod,
   pricePerPeriodPrefix,
@@ -122,7 +124,7 @@ const Component = ({
                     <Modal
                       hasPadding
                       size="small"
-                      trigger={<Link>More Info</Link>}
+                      trigger={<Link>{moreInfoText}</Link>}
                     >
                       {getModalContentMarkup(
                         amenities,
@@ -170,6 +172,7 @@ Component.defaultProps = {
   amenitiesHeadingText: ROOM_AMENITIES,
   extraFeatures: [],
   isShowingPlaceholder: false,
+  moreInfoText: MORE_INFO,
   periodText: PER_NIGHT,
   pricePerPeriodPrefix: FROM_PRICE_PER_PERIOD,
   ratingNumber: null,
@@ -221,6 +224,8 @@ Component.propTypes = {
    * @ignore
    */
   isUserOnMobile: PropTypes.bool.isRequired,
+  /** The text to display for the more info button. */
+  moreInfoText: PropTypes.string,
   /** The name of the room. */
   name: PropTypes.string.isRequired,
   /** The text describing the pricing period. */

--- a/src/components/property-page-widgets/RoomType/component.spec.js
+++ b/src/components/property-page-widgets/RoomType/component.spec.js
@@ -34,6 +34,7 @@ const props = {
   pricePerPeriod: '$280',
   pricePerPeriodPrefix: 'morf',
   name: 'The Cat House',
+  moreInfoText: 'Oof',
   propertyType: 'Bed and breakfast',
   propertyUrl: '/',
   ratingNumber: 4,

--- a/src/components/property-page-widgets/RoomType/utils/__snapshots__/getModalContentMarkup.spec.js.snap
+++ b/src/components/property-page-widgets/RoomType/utils/__snapshots__/getModalContentMarkup.spec.js.snap
@@ -690,6 +690,7 @@ exports[`getModalContentMarkup if \`props.description\` === null should not rend
           },
         ]
       }
+      amenitiesConjunctionText="and"
       hasExtraItemsInModal={false}
       headingText="Room Amenities"
       isStacked={false}
@@ -1125,6 +1126,7 @@ exports[`getModalContentMarkup if \`props.ratingNumber\` === null should not ren
           },
         ]
       }
+      amenitiesConjunctionText="and"
       hasExtraItemsInModal={false}
       headingText="Room Amenities"
       isStacked={false}
@@ -1719,6 +1721,7 @@ exports[`getModalContentMarkup if \`props.slideShowImages.length\` > 1 should re
           },
         ]
       }
+      amenitiesConjunctionText="and"
       hasExtraItemsInModal={false}
       headingText="Room Amenities"
       isStacked={false}
@@ -2301,6 +2304,7 @@ exports[`getModalContentMarkup should return the correct structure 1`] = `
           },
         ]
       }
+      amenitiesConjunctionText="and"
       hasExtraItemsInModal={false}
       headingText="Room Amenities"
       isStacked={false}

--- a/src/components/property-page-widgets/RoomTypes/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/RoomTypes/__snapshots__/component.spec.js.snap
@@ -35,6 +35,7 @@ exports[`<RoomTypes /> if \`isShowingPlaceholder\` is \`true\` if \`roomTypes.le
         features={Array []}
         isShowingPlaceholder={true}
         isUserOnMobile={false}
+        moreInfoText="More info"
         name=""
         periodText="per night"
         pricePerPeriod=""
@@ -256,6 +257,7 @@ exports[`<RoomTypes /> if \`isShowingPlaceholder\` is \`true\` if \`roomTypes.le
         features={Array []}
         isShowingPlaceholder={true}
         isUserOnMobile={false}
+        moreInfoText="More info"
         name=""
         periodText="per night"
         pricePerPeriod=""
@@ -753,6 +755,7 @@ exports[`<RoomTypes /> if \`isShowingPlaceholder\` is \`true\` should render the
         guestsNumber={3}
         isShowingPlaceholder={true}
         isUserOnMobile={false}
+        moreInfoText="More info"
         name="The Cat House"
         onClickCheckAvailability={[Function]}
         periodText="per night"
@@ -1117,6 +1120,7 @@ exports[`<RoomTypes /> if \`isShowingPlaceholder\` is \`true\` should render the
         guestsNumber={3}
         isShowingPlaceholder={true}
         isUserOnMobile={false}
+        moreInfoText="More info"
         name="The Other Cat House"
         onClickCheckAvailability={[Function]}
         periodText="per night"
@@ -1628,6 +1632,7 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
         guestsNumber={3}
         isShowingPlaceholder={false}
         isUserOnMobile={false}
+        moreInfoText="More info"
         name="The Cat House"
         onClickCheckAvailability={[Function]}
         periodText="per night"
@@ -2200,7 +2205,7 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                                       onClick={[Function]}
                                                       willOpenInNewTab={false}
                                                     >
-                                                      More Info
+                                                      More info
                                                     </Link>
                                                   }
                                                 >
@@ -2238,7 +2243,7 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                                         onClick={[Function]}
                                                         willOpenInNewTab={false}
                                                       >
-                                                        More Info
+                                                        More info
                                                       </Link>
                                                     }
                                                   >
@@ -2260,7 +2265,7 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                                           onClick={[Function]}
                                                           willOpenInNewTab={false}
                                                         >
-                                                          More Info
+                                                          More info
                                                         </Link>
                                                       }
                                                     >
@@ -2299,7 +2304,7 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                                                       target="_self"
                                                                       type="button"
                                                                     >
-                                                                      More Info
+                                                                      More info
                                                                     </button>,
                                                                   }
                                                                 }
@@ -2312,7 +2317,7 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                                                         target="_self"
                                                                         type="button"
                                                                       >
-                                                                        More Info
+                                                                        More info
                                                                       </button>,
                                                                     }
                                                                   }
@@ -2324,7 +2329,7 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                                                     target="_self"
                                                                     type="button"
                                                                   >
-                                                                    More Info
+                                                                    More info
                                                                   </button>
                                                                 </RefFindNode>
                                                               </Ref>
@@ -2588,6 +2593,7 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
         guestsNumber={3}
         isShowingPlaceholder={false}
         isUserOnMobile={false}
+        moreInfoText="More info"
         name="The Other Cat House"
         onClickCheckAvailability={[Function]}
         periodText="per night"
@@ -3160,7 +3166,7 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                                       onClick={[Function]}
                                                       willOpenInNewTab={false}
                                                     >
-                                                      More Info
+                                                      More info
                                                     </Link>
                                                   }
                                                 >
@@ -3198,7 +3204,7 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                                         onClick={[Function]}
                                                         willOpenInNewTab={false}
                                                       >
-                                                        More Info
+                                                        More info
                                                       </Link>
                                                     }
                                                   >
@@ -3220,7 +3226,7 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                                           onClick={[Function]}
                                                           willOpenInNewTab={false}
                                                         >
-                                                          More Info
+                                                          More info
                                                         </Link>
                                                       }
                                                     >
@@ -3259,7 +3265,7 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                                                       target="_self"
                                                                       type="button"
                                                                     >
-                                                                      More Info
+                                                                      More info
                                                                     </button>,
                                                                   }
                                                                 }
@@ -3272,7 +3278,7 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                                                         target="_self"
                                                                         type="button"
                                                                       >
-                                                                        More Info
+                                                                        More info
                                                                       </button>,
                                                                     }
                                                                   }
@@ -3284,7 +3290,7 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                                                     target="_self"
                                                                     type="button"
                                                                   >
-                                                                    More Info
+                                                                    More info
                                                                   </button>
                                                                 </RefFindNode>
                                                               </Ref>

--- a/src/utils/default-strings/constants.js
+++ b/src/utils/default-strings/constants.js
@@ -44,6 +44,7 @@ export const LOCATION = 'Location';
 export const LOGIN = 'Log in';
 export const MONTH = 'Month';
 export const MORE_FILTERS = 'More filters';
+export const MORE_INFO = 'More info';
 export const NAME = 'Name';
 export const NEXT = 'Next';
 export const NO_RESULTS = 'No results';


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-2669)

### What **one** thing does this PR do?
Implements a prop for `More info` translation for both `RoomType` and `RoomTypes` component.
Implements a prop for the conjunction which unites the last and the penultimate amenity items

### Any other notes
![Amenities](https://user-images.githubusercontent.com/33876435/65878253-e269f700-e38d-11e9-97b2-c69b7e0423a6.gif)
![More_info](https://user-images.githubusercontent.com/33876435/65878254-e3028d80-e38d-11e9-9511-1be7b7cb3b8a.gif)
