### PR TITLE
TE-2669 Consume amenitiesHeadingText in RoomType component

### DIFF
--- a/src/components/property-page-widgets/RoomType/Readme.md
+++ b/src/components/property-page-widgets/RoomType/Readme.md
@@ -77,6 +77,7 @@ const roomTypeFeatures = [
   extraFeatures={extraRoomTypeFeatures}
   slideShowImages={images}
   amenities={availableAmenities}
+  amenitiesHeadingText="House Amenities"
   moreInfoText="More info"
 />
 ```

--- a/src/components/property-page-widgets/RoomType/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/RoomType/__snapshots__/component.spec.js.snap
@@ -24,7 +24,7 @@ exports[`<RoomType /> by default should render the correct structure 1`] = `
       },
     ]
   }
-  amenitiesHeadingText="Room Amenities"
+  amenitiesHeadingText="Stiff Stoff Stuff"
   description="yayayay"
   extraFeatures={
     Array [
@@ -789,7 +789,7 @@ exports[`<RoomType /> if \`isShowingPlaceholder\` is \`true\` should render the 
       },
     ]
   }
-  amenitiesHeadingText="Room Amenities"
+  amenitiesHeadingText="Stiff Stoff Stuff"
   description="yayayay"
   extraFeatures={
     Array [
@@ -1044,7 +1044,7 @@ exports[`<RoomType /> if \`isUserOnMobile === true\` should render the correct s
       },
     ]
   }
-  amenitiesHeadingText="Room Amenities"
+  amenitiesHeadingText="Stiff Stoff Stuff"
   description="yayayay"
   extraFeatures={
     Array [

--- a/src/components/property-page-widgets/RoomType/component.js
+++ b/src/components/property-page-widgets/RoomType/component.js
@@ -4,9 +4,9 @@ import { Card } from 'semantic-ui-react';
 
 import {
   PER_NIGHT,
+  FROM_PRICE_PER_PERIOD,
   MORE_INFO,
   ROOM_AMENITIES,
-  FROM_PRICE_PER_PERIOD,
 } from 'utils/default-strings';
 import { Divider } from 'elements/Divider';
 import { Grid } from 'layout/Grid';

--- a/src/components/property-page-widgets/RoomType/component.spec.js
+++ b/src/components/property-page-widgets/RoomType/component.spec.js
@@ -29,6 +29,7 @@ const props = {
       items: ['Bidet', 'Hair Dryer', 'Iron & Board'],
     },
   ],
+  amenitiesHeadingText: 'Stiff Stoff Stuff',
   description: 'yayayay',
   locationName: 'Catania',
   pricePerPeriod: '$280',

--- a/src/components/property-page-widgets/RoomType/utils/__snapshots__/getModalContentMarkup.spec.js.snap
+++ b/src/components/property-page-widgets/RoomType/utils/__snapshots__/getModalContentMarkup.spec.js.snap
@@ -692,7 +692,7 @@ exports[`getModalContentMarkup if \`props.description\` === null should not rend
       }
       amenitiesConjunctionText="and"
       hasExtraItemsInModal={false}
-      headingText="Room Amenities"
+      headingText="bibip-bop"
       isStacked={false}
       modalTriggerText="View more"
     >
@@ -747,7 +747,7 @@ exports[`getModalContentMarkup if \`props.description\` === null should not rend
                             <h3
                               className="ui header"
                             >
-                              Room Amenities
+                              bibip-bop
                             </h3>
                           </Header>
                         </Heading>
@@ -1128,7 +1128,7 @@ exports[`getModalContentMarkup if \`props.ratingNumber\` === null should not ren
       }
       amenitiesConjunctionText="and"
       hasExtraItemsInModal={false}
-      headingText="Room Amenities"
+      headingText="bibip-bop"
       isStacked={false}
       modalTriggerText="View more"
     >
@@ -1183,7 +1183,7 @@ exports[`getModalContentMarkup if \`props.ratingNumber\` === null should not ren
                             <h3
                               className="ui header"
                             >
-                              Room Amenities
+                              bibip-bop
                             </h3>
                           </Header>
                         </Heading>
@@ -1723,7 +1723,7 @@ exports[`getModalContentMarkup if \`props.slideShowImages.length\` > 1 should re
       }
       amenitiesConjunctionText="and"
       hasExtraItemsInModal={false}
-      headingText="Room Amenities"
+      headingText="bibip-bop"
       isStacked={false}
       modalTriggerText="View more"
     >
@@ -1778,7 +1778,7 @@ exports[`getModalContentMarkup if \`props.slideShowImages.length\` > 1 should re
                             <h3
                               className="ui header"
                             >
-                              Room Amenities
+                              bibip-bop
                             </h3>
                           </Header>
                         </Heading>
@@ -2306,7 +2306,7 @@ exports[`getModalContentMarkup should return the correct structure 1`] = `
       }
       amenitiesConjunctionText="and"
       hasExtraItemsInModal={false}
-      headingText="Room Amenities"
+      headingText="bibip-bop"
       isStacked={false}
       modalTriggerText="View more"
     >
@@ -2361,7 +2361,7 @@ exports[`getModalContentMarkup should return the correct structure 1`] = `
                             <h3
                               className="ui header"
                             >
-                              Room Amenities
+                              bibip-bop
                             </h3>
                           </Header>
                         </Heading>

--- a/src/components/property-page-widgets/RoomType/utils/getModalContentMarkup.js
+++ b/src/components/property-page-widgets/RoomType/utils/getModalContentMarkup.js
@@ -65,7 +65,7 @@ export const getModalContentMarkup = (
     {!!size(amenities) && (
       <Amenities
         amenities={amenities}
-        headingText="Room Amenities"
+        headingText={amenitiesHeadingText}
         isStacked={isUserOnMobile}
       />
     )}


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-2669)

### What **one** thing does this PR do?
Fixes the hardcoded `Room Amenities` string; left behind in my previous PR.

### Any other notes
![ameni](https://user-images.githubusercontent.com/33876435/65959792-38ed3900-e453-11e9-9fea-c1feb5c011d2.gif)

