### PR TITLE
TE-2669 Add amenitiesConjunctionText to RoomType

### DIFF
--- a/src/components/property-page-widgets/Amenities/utils/getExtraItemsMarkup.js
+++ b/src/components/property-page-widgets/Amenities/utils/getExtraItemsMarkup.js
@@ -27,7 +27,11 @@ export const getExtraItemsMarkup = (
       <Modal hasPadding trigger={<Link>{modalTriggerText}</Link>}>
         <SemanticModal.Content>
           <Grid className="is-amenities" columns={1} isStackable padded>
-            <GridRow>{amenities.map(getCategoryMarkup)}</GridRow>
+            <GridRow>
+              {amenities.map((amenity, index) =>
+                getCategoryMarkup(amenity, index, amenitiesConjunctionText)
+              )}
+            </GridRow>
           </Grid>
         </SemanticModal.Content>
       </Modal>

--- a/src/components/property-page-widgets/RoomType/Readme.md
+++ b/src/components/property-page-widgets/RoomType/Readme.md
@@ -77,6 +77,7 @@ const roomTypeFeatures = [
   extraFeatures={extraRoomTypeFeatures}
   slideShowImages={images}
   amenities={availableAmenities}
+  amenitiesConjunctionText="and"
   amenitiesHeadingText="House Amenities"
   moreInfoText="More info"
 />

--- a/src/components/property-page-widgets/RoomType/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/RoomType/__snapshots__/component.spec.js.snap
@@ -24,6 +24,7 @@ exports[`<RoomType /> by default should render the correct structure 1`] = `
       },
     ]
   }
+  amenitiesConjunctionText="and"
   amenitiesHeadingText="Stiff Stoff Stuff"
   description="yayayay"
   extraFeatures={
@@ -789,6 +790,7 @@ exports[`<RoomType /> if \`isShowingPlaceholder\` is \`true\` should render the 
       },
     ]
   }
+  amenitiesConjunctionText="and"
   amenitiesHeadingText="Stiff Stoff Stuff"
   description="yayayay"
   extraFeatures={
@@ -1044,6 +1046,7 @@ exports[`<RoomType /> if \`isUserOnMobile === true\` should render the correct s
       },
     ]
   }
+  amenitiesConjunctionText="and"
   amenitiesHeadingText="Stiff Stoff Stuff"
   description="yayayay"
   extraFeatures={

--- a/src/components/property-page-widgets/RoomType/component.js
+++ b/src/components/property-page-widgets/RoomType/component.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Card } from 'semantic-ui-react';
 
 import {
+  AND,
   PER_NIGHT,
   FROM_PRICE_PER_PERIOD,
   MORE_INFO,
@@ -32,6 +33,7 @@ import { getModalContentMarkup } from './utils/getModalContentMarkup';
 // eslint-disable-next-line jsdoc/require-jsdoc
 const Component = ({
   amenities,
+  amenitiesConjunctionText,
   amenitiesHeadingText,
   description,
   extraFeatures,
@@ -99,6 +101,7 @@ const Component = ({
                   >
                     {getModalContentMarkup(
                       amenities,
+                      amenitiesConjunctionText,
                       amenitiesHeadingText,
                       description,
                       extraFeatures,
@@ -128,6 +131,7 @@ const Component = ({
                     >
                       {getModalContentMarkup(
                         amenities,
+                        amenitiesConjunctionText,
                         amenitiesHeadingText,
                         description,
                         extraFeatures,
@@ -169,6 +173,7 @@ Component.displayName = 'RoomType';
 
 Component.defaultProps = {
   description: null,
+  amenitiesConjunctionText: AND,
   amenitiesHeadingText: ROOM_AMENITIES,
   extraFeatures: [],
   isShowingPlaceholder: false,
@@ -193,6 +198,8 @@ Component.propTypes = {
       name: PropTypes.string.isRequired,
     })
   ).isRequired,
+  /** The conjunction to display after the penultimate amenity in the array. */
+  amenitiesConjunctionText: PropTypes.string,
   /** The text displayed when amenities are available. */
   amenitiesHeadingText: PropTypes.string,
   /** A description to be displayed in the modal */

--- a/src/components/property-page-widgets/RoomType/utils/__snapshots__/getModalContentMarkup.spec.js.snap
+++ b/src/components/property-page-widgets/RoomType/utils/__snapshots__/getModalContentMarkup.spec.js.snap
@@ -690,7 +690,7 @@ exports[`getModalContentMarkup if \`props.description\` === null should not rend
           },
         ]
       }
-      amenitiesConjunctionText="and"
+      amenitiesConjunctionText="WALL-E"
       hasExtraItemsInModal={false}
       headingText="bibip-bop"
       isStacked={false}
@@ -814,7 +814,7 @@ exports[`getModalContentMarkup if \`props.description\` === null should not rend
                             className=""
                           >
                             Toaster, 
-                            Microwave and 
+                            Microwave WALL-E 
                             Coffee Machine
                           </p>
                         </Paragraph>
@@ -881,7 +881,7 @@ exports[`getModalContentMarkup if \`props.description\` === null should not rend
                             className=""
                           >
                             Bidet, 
-                            Hair Dryer and 
+                            Hair Dryer WALL-E 
                             Iron & Board
                           </p>
                         </Paragraph>
@@ -1126,7 +1126,7 @@ exports[`getModalContentMarkup if \`props.ratingNumber\` === null should not ren
           },
         ]
       }
-      amenitiesConjunctionText="and"
+      amenitiesConjunctionText="WALL-E"
       hasExtraItemsInModal={false}
       headingText="bibip-bop"
       isStacked={false}
@@ -1250,7 +1250,7 @@ exports[`getModalContentMarkup if \`props.ratingNumber\` === null should not ren
                             className=""
                           >
                             Toaster, 
-                            Microwave and 
+                            Microwave WALL-E 
                             Coffee Machine
                           </p>
                         </Paragraph>
@@ -1317,7 +1317,7 @@ exports[`getModalContentMarkup if \`props.ratingNumber\` === null should not ren
                             className=""
                           >
                             Bidet, 
-                            Hair Dryer and 
+                            Hair Dryer WALL-E 
                             Iron & Board
                           </p>
                         </Paragraph>
@@ -1721,7 +1721,7 @@ exports[`getModalContentMarkup if \`props.slideShowImages.length\` > 1 should re
           },
         ]
       }
-      amenitiesConjunctionText="and"
+      amenitiesConjunctionText="WALL-E"
       hasExtraItemsInModal={false}
       headingText="bibip-bop"
       isStacked={false}
@@ -1845,7 +1845,7 @@ exports[`getModalContentMarkup if \`props.slideShowImages.length\` > 1 should re
                             className=""
                           >
                             Toaster, 
-                            Microwave and 
+                            Microwave WALL-E 
                             Coffee Machine
                           </p>
                         </Paragraph>
@@ -1912,7 +1912,7 @@ exports[`getModalContentMarkup if \`props.slideShowImages.length\` > 1 should re
                             className=""
                           >
                             Bidet, 
-                            Hair Dryer and 
+                            Hair Dryer WALL-E 
                             Iron & Board
                           </p>
                         </Paragraph>
@@ -2304,7 +2304,7 @@ exports[`getModalContentMarkup should return the correct structure 1`] = `
           },
         ]
       }
-      amenitiesConjunctionText="and"
+      amenitiesConjunctionText="WALL-E"
       hasExtraItemsInModal={false}
       headingText="bibip-bop"
       isStacked={false}
@@ -2428,7 +2428,7 @@ exports[`getModalContentMarkup should return the correct structure 1`] = `
                             className=""
                           >
                             Toaster, 
-                            Microwave and 
+                            Microwave WALL-E 
                             Coffee Machine
                           </p>
                         </Paragraph>
@@ -2495,7 +2495,7 @@ exports[`getModalContentMarkup should return the correct structure 1`] = `
                             className=""
                           >
                             Bidet, 
-                            Hair Dryer and 
+                            Hair Dryer WALL-E 
                             Iron & Board
                           </p>
                         </Paragraph>

--- a/src/components/property-page-widgets/RoomType/utils/getModalContentMarkup.js
+++ b/src/components/property-page-widgets/RoomType/utils/getModalContentMarkup.js
@@ -14,6 +14,7 @@ import { Slideshow } from 'media/Slideshow';
 
 /**
  * @param  {Object[]}    amenities
+ * @param  {string}      amenitiesConjunctionText
  * @param  {string}      amenitiesHeadingText
  * @param  {string}      description
  * @param  {Object[]}    extraFeatures
@@ -29,6 +30,7 @@ import { Slideshow } from 'media/Slideshow';
  */
 export const getModalContentMarkup = (
   amenities,
+  amenitiesConjunctionText,
   amenitiesHeadingText,
   description,
   extraFeatures,
@@ -65,6 +67,7 @@ export const getModalContentMarkup = (
     {!!size(amenities) && (
       <Amenities
         amenities={amenities}
+        amenitiesConjunctionText={amenitiesConjunctionText}
         headingText={amenitiesHeadingText}
         isStacked={isUserOnMobile}
       />

--- a/src/components/property-page-widgets/RoomType/utils/getModalContentMarkup.spec.js
+++ b/src/components/property-page-widgets/RoomType/utils/getModalContentMarkup.spec.js
@@ -29,6 +29,7 @@ const amenities = [
 ];
 
 const amenitiesHeadingText = 'bibip-bop';
+const amenitiesConjunctionText = 'WALL-E';
 const extraFeatures = [{ labelText: '1 Dining-Room' }];
 const features = [{ iconName: 'double bed', labelText: '1 Bedroom' }];
 const name = 'yoyo name';
@@ -52,6 +53,7 @@ const getMarkup = ({
   mount(
     getModalContentMarkup(
       amenities,
+      amenitiesConjunctionText,
       amenitiesHeadingText,
       description,
       extraFeatures,

--- a/src/components/property-page-widgets/RoomTypes/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/RoomTypes/__snapshots__/component.spec.js.snap
@@ -29,6 +29,7 @@ exports[`<RoomTypes /> if \`isShowingPlaceholder\` is \`true\` if \`roomTypes.le
     >
       <RoomType
         amenities={Array []}
+        amenitiesConjunctionText="and"
         amenitiesHeadingText="Room Amenities"
         description={null}
         extraFeatures={Array []}
@@ -251,6 +252,7 @@ exports[`<RoomTypes /> if \`isShowingPlaceholder\` is \`true\` if \`roomTypes.le
     >
       <RoomType
         amenities={Array []}
+        amenitiesConjunctionText="and"
         amenitiesHeadingText="Room Amenities"
         description={null}
         extraFeatures={Array []}
@@ -730,6 +732,7 @@ exports[`<RoomTypes /> if \`isShowingPlaceholder\` is \`true\` should render the
             },
           ]
         }
+        amenitiesConjunctionText="and"
         amenitiesHeadingText="Room Amenities"
         bathroomsNumber={2}
         bedsNumber={3}
@@ -1095,6 +1098,7 @@ exports[`<RoomTypes /> if \`isShowingPlaceholder\` is \`true\` should render the
             },
           ]
         }
+        amenitiesConjunctionText="and"
         amenitiesHeadingText="Room Amenities"
         bathroomsNumber={2}
         bedsNumber={3}
@@ -1607,6 +1611,7 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
             },
           ]
         }
+        amenitiesConjunctionText="and"
         amenitiesHeadingText="Room Amenities"
         bathroomsNumber={2}
         bedsNumber={3}
@@ -2568,6 +2573,7 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
             },
           ]
         }
+        amenitiesConjunctionText="and"
         amenitiesHeadingText="Room Amenities"
         bathroomsNumber={2}
         bedsNumber={3}


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-2669)

### What **one** thing does this PR do?
* Allows `RoomType` to consume `amenitiesConjunctionText`
* Amends a regression caused by my previous PR.


### Prop Consumption

![roomtype](https://user-images.githubusercontent.com/33876435/66035910-53371d80-e50c-11e9-8cd4-d3fbebce2b20.gif)


### Regression

Before

![Screenshot 2019-10-02 at 11 53 45](https://user-images.githubusercontent.com/33876435/66035740-ffc4cf80-e50b-11e9-98fd-75c47001bc78.png)

After
![Screenshot 2019-10-02 at 11 53 28](https://user-images.githubusercontent.com/33876435/66035738-ffc4cf80-e50b-11e9-9164-2af1df8cfd1f.png)

