### PR TITLE
TE-2684 dropdown styles

### DIFF
--- a/src/components/property-page-widgets/Availability/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Availability/__snapshots__/component.spec.js.snap
@@ -377,7 +377,7 @@ exports[`<Availability /> the wrapped component if \`size(props.roomOptionsWithI
               getOptionsWithSearch={null}
               icon="map pin"
               initialValue={null}
-              isClearable={true}
+              isClearable={false}
               isCompact={false}
               isDisabled={false}
               isSearchable={false}

--- a/src/components/property-page-widgets/Availability/component.js
+++ b/src/components/property-page-widgets/Availability/component.js
@@ -116,6 +116,7 @@ class Component extends PureComponent {
                   <GridColumn computer={7} mobile={7} tablet={12}>
                     <Dropdown
                       icon={ICON_NAMES.MAP_PIN}
+                      isClearable={false}
                       label={propertyDropdownPlaceholderLabel}
                       onChange={this.reloadCalendarOnRoomSelection}
                       options={roomOptionsWithImages}

--- a/src/components/property-page-widgets/Rates/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Rates/__snapshots__/component.spec.js.snap
@@ -89,7 +89,7 @@ exports[`<Rates /> by default should have the right structure 1`] = `
         getOptionsWithSearch={null}
         icon={null}
         initialValue={null}
-        isClearable={true}
+        isClearable={false}
         isCompact={false}
         isDisabled={false}
         isSearchable={true}
@@ -124,7 +124,7 @@ exports[`<Rates /> by default should have the right structure 1`] = `
           <Dropdown
             additionLabel="Add "
             additionPosition="top"
-            clearable={true}
+            clearable={false}
             closeOnBlur={true}
             closeOnEscape={true}
             compact={false}
@@ -1797,7 +1797,7 @@ exports[`<Rates /> by default should have the right structure 1`] = `
               getOptionsWithSearch={null}
               icon={null}
               initialValue={null}
-              isClearable={true}
+              isClearable={false}
               isCompact={false}
               isDisabled={false}
               isSearchable={true}
@@ -1874,7 +1874,7 @@ exports[`<Rates /> by default should have the right structure 1`] = `
                             getOptionsWithSearch={null}
                             icon={null}
                             initialValue={null}
-                            isClearable={true}
+                            isClearable={false}
                             isCompact={false}
                             isDisabled={false}
                             isSearchable={true}
@@ -1909,7 +1909,7 @@ exports[`<Rates /> by default should have the right structure 1`] = `
                               <Dropdown
                                 additionLabel="Add "
                                 additionPosition="top"
-                                clearable={true}
+                                clearable={false}
                                 closeOnBlur={true}
                                 closeOnEscape={true}
                                 compact={false}
@@ -4383,7 +4383,7 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
         getOptionsWithSearch={null}
         icon={null}
         initialValue={null}
-        isClearable={true}
+        isClearable={false}
         isCompact={false}
         isDisabled={false}
         isSearchable={true}
@@ -4418,7 +4418,7 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
           <Dropdown
             additionLabel="Add "
             additionPosition="top"
-            clearable={true}
+            clearable={false}
             closeOnBlur={true}
             closeOnEscape={true}
             compact={false}
@@ -6091,7 +6091,7 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
               getOptionsWithSearch={null}
               icon={null}
               initialValue={null}
-              isClearable={true}
+              isClearable={false}
               isCompact={false}
               isDisabled={false}
               isSearchable={true}
@@ -6168,7 +6168,7 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
                             getOptionsWithSearch={null}
                             icon={null}
                             initialValue={null}
-                            isClearable={true}
+                            isClearable={false}
                             isCompact={false}
                             isDisabled={false}
                             isSearchable={true}
@@ -6203,7 +6203,7 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
                               <Dropdown
                                 additionLabel="Add "
                                 additionPosition="top"
-                                clearable={true}
+                                clearable={false}
                                 closeOnBlur={true}
                                 closeOnEscape={true}
                                 compact={false}

--- a/src/components/property-page-widgets/Rates/component.js
+++ b/src/components/property-page-widgets/Rates/component.js
@@ -53,6 +53,7 @@ export const Component = ({
         getCurrencyDropdownPlaceholderMarkup()
       ) : (
         <Dropdown
+          isClearable={false}
           isSearchable
           noResultsText={currencyNoResultsText}
           onChange={onChangeCurrency}
@@ -100,6 +101,7 @@ export const Component = ({
           ])}
           tableHeadings={[
             <Dropdown
+              isClearable={false}
               isSearchable
               noResultsText={currencyNoResultsText}
               onChange={onChangeCurrency}

--- a/src/styles/semantic/themes/livingstone/modules/dropdown.overrides
+++ b/src/styles/semantic/themes/livingstone/modules/dropdown.overrides
@@ -54,6 +54,30 @@
         color: @themeActionContrastColorDefault;
         color: var(@themeActionContrastColorIdentifier, @themeActionContrastColorDefault);
       }
+
+      /*With label*/
+      &.has-label {
+        display: flex;
+        flex-direction: row-reverse;
+        justify-content: flex-end;
+        align-items: center;
+
+        .ui.label {
+          background: transparent;
+          padding: @withLabelPadding;
+          color: @itemColor;
+          font-size: @withLabelFontSize;
+          text-align: left;
+          min-width: @labelMinWidth;
+        }
+
+        .text {
+          margin-right: @withLabelTextMarginRight;
+          font-weight: bold;
+          color: @withLabelTextColor;
+          font-size: @withLabelFontSize;
+        }
+      }
     }
   }
 

--- a/src/styles/semantic/themes/livingstone/modules/dropdown.variables
+++ b/src/styles/semantic/themes/livingstone/modules/dropdown.variables
@@ -124,6 +124,13 @@
 @dropdownMinWidthWithImage: 118px;
 @dropdownWithImagesCaretPaddingTop: @15px;
 
+@labelMinWidth: 20px;
+
+@withLabelPadding: 5px;
+@withLabelFontSize: 14px;
+@withLabelTextMarginRight: 20px;
+@withLabelTextColor: @black;
+
 /*--------------
      Search
 --------------*/


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-2684)

### What **one** thing does this PR do?
Adds styles for the dropdown with text labels.
Availability, Rates and PhoneInput dropdowns aren't clearable

### Any other notes

#### After
<img width="269" alt="Screenshot 2019-10-03 at 13 08 00" src="https://user-images.githubusercontent.com/10498995/66122014-ea6ca580-e5de-11e9-94f4-b5123faeb752.png">

#### Before
<img width="248" alt="Screenshot 2019-10-03 at 13 08 10" src="https://user-images.githubusercontent.com/10498995/66122015-eb053c00-e5de-11e9-8e2f-242ef6010891.png">
