### PR TITLE
TE-2684 roomtype dropdown is not clearable

### DIFF
--- a/src/components/property-page-widgets/Rates/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Rates/__snapshots__/component.spec.js.snap
@@ -3661,7 +3661,7 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
         getOptionsWithSearch={null}
         icon={null}
         initialValue={null}
-        isClearable={true}
+        isClearable={false}
         isCompact={false}
         isDisabled={false}
         isSearchable={false}
@@ -3704,7 +3704,7 @@ exports[`<Rates /> if \`props.roomTypes\` is passed should have the right struct
           <Dropdown
             additionLabel="Add "
             additionPosition="top"
-            clearable={true}
+            clearable={false}
             closeOnBlur={true}
             closeOnEscape={true}
             compact={false}

--- a/src/components/property-page-widgets/Rates/utils/__snapshots__/getRoomTypeDropdownMarkup.spec.js.snap
+++ b/src/components/property-page-widgets/Rates/utils/__snapshots__/getRoomTypeDropdownMarkup.spec.js.snap
@@ -40,7 +40,7 @@ Array [
         getOptionsWithSearch={null}
         icon={null}
         initialValue={null}
-        isClearable={true}
+        isClearable={false}
         isCompact={false}
         isDisabled={false}
         isSearchable={false}
@@ -76,7 +76,7 @@ Array [
           <Dropdown
             additionLabel="Add "
             additionPosition="top"
-            clearable={true}
+            clearable={false}
             closeOnBlur={true}
             closeOnEscape={true}
             compact={false}
@@ -94,7 +94,7 @@ Array [
                 isLabelLeft={false}
                 labelText={null}
                 labelWeight={null}
-                name="close"
+                name="caret down"
                 path={null}
                 size={null}
               />
@@ -158,13 +158,13 @@ Array [
                       EUR €
                     </div>
                     <i
-                      class="icon clear"
+                      class="icon"
                     >
                       <svg
                         viewBox="0 0 24 24"
                       >
                         <path
-                          d="M17.44,16.73a.51.51,0,0,1,0,.71.52.52,0,0,1-.71,0L12,12.71,7.27,17.44a.52.52,0,0,1-.71,0,.51.51,0,0,1,0-.71L11.29,12,6.56,7.27a.5.5,0,1,1,.71-.71L12,11.29l4.73-4.73a.5.5,0,1,1,.71.71L12.71,12Z"
+                          d="M20,8.5l-8,7-8-7Z"
                           fill="currentColor"
                         />
                       </svg>
@@ -235,13 +235,13 @@ Array [
                         EUR €
                       </div>
                       <i
-                        class="icon clear"
+                        class="icon"
                       >
                         <svg
                           viewBox="0 0 24 24"
                         >
                           <path
-                            d="M17.44,16.73a.51.51,0,0,1,0,.71.52.52,0,0,1-.71,0L12,12.71,7.27,17.44a.52.52,0,0,1-.71,0,.51.51,0,0,1,0-.71L11.29,12,6.56,7.27a.5.5,0,1,1,.71-.71L12,11.29l4.73-4.73a.5.5,0,1,1,.71.71L12.71,12Z"
+                            d="M20,8.5l-8,7-8-7Z"
                             fill="currentColor"
                           />
                         </svg>
@@ -314,7 +314,7 @@ Array [
                     EUR €
                   </div>
                   <Icon
-                    className="clear"
+                    className=""
                     color={null}
                     hasBorder={false}
                     isButton={false}
@@ -324,20 +324,20 @@ Array [
                     isLabelLeft={false}
                     labelText={null}
                     labelWeight={null}
-                    name="close"
+                    name="caret down"
                     onClick={[Function]}
                     path={null}
                     size={null}
                   >
                     <i
-                      className="icon clear"
+                      className="icon"
                       onClick={[Function]}
                     >
                       <svg
                         viewBox="0 0 24 24"
                       >
                         <path
-                          d="M17.44,16.73a.51.51,0,0,1,0,.71.52.52,0,0,1-.71,0L12,12.71,7.27,17.44a.52.52,0,0,1-.71,0,.51.51,0,0,1,0-.71L11.29,12,6.56,7.27a.5.5,0,1,1,.71-.71L12,11.29l4.73-4.73a.5.5,0,1,1,.71.71L12.71,12Z"
+                          d="M20,8.5l-8,7-8-7Z"
                           fill="currentColor"
                         />
                       </svg>

--- a/src/components/property-page-widgets/Rates/utils/getRoomTypeDropdownMarkup.js
+++ b/src/components/property-page-widgets/Rates/utils/getRoomTypeDropdownMarkup.js
@@ -37,6 +37,7 @@ export const getRoomTypeDropdownMarkup = (
           {getStringWithColonSuffix(roomTypeInputLabel)}
         </Paragraph>
         <Dropdown
+          isClearable={false}
           onChange={onChange}
           options={options}
           value={roomTypesValue}


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-2684)

### What **one** thing does this PR do?
Adds styles for the dropdown with text labels.
Availability, Rates and PhoneInput dropdowns aren't clearable

### Any other notes

#### After
<img width="269" alt="Screenshot 2019-10-03 at 13 08 00" src="https://user-images.githubusercontent.com/10498995/66122014-ea6ca580-e5de-11e9-94f4-b5123faeb752.png">

#### Before
<img width="248" alt="Screenshot 2019-10-03 at 13 08 10" src="https://user-images.githubusercontent.com/10498995/66122015-eb053c00-e5de-11e9-8e2f-242ef6010891.png">
