### PR TITLE
TE-2617 Homepage - Hero headingText is off center

### DIFF
--- a/src/styles/semantic/definitions/lodgify-ui-components/flex-container.less
+++ b/src/styles/semantic/definitions/lodgify-ui-components/flex-container.less
@@ -16,7 +16,7 @@
 
   p,
   h1,
-  h1.ui.header,
+  h1.ui.header:not(.full-bleed .flex-container .ui-header),
   h2,
   h2.ui.header,
   h3,


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-2617)

### What **one** thing does this PR do?
Removes unnecessary margin from `HomePageHero` h1.

### Any other notes
<img width="1440" alt="Screenshot 2019-10-07 at 18 11 37" src="https://user-images.githubusercontent.com/33876435/66329004-f97c8c00-e92d-11e9-8e88-2299b6650440.png">
