### PR TITLE
TE-2644 Search bar responsive layouts

### DIFF
--- a/src/styles/semantic/definitions/lodgify-ui-components/search-bar.less
+++ b/src/styles/semantic/definitions/lodgify-ui-components/search-bar.less
@@ -53,6 +53,9 @@
         flex-wrap: wrap;
 
         .input-container {
+          width: 100%;
+          min-width: auto;
+          max-width: none;
           padding-bottom: @searchBarInputSpacing;
           padding-right: 0;
         }
@@ -73,11 +76,15 @@
       @media @searchBarTabletScreen {
 
         .location-input-container {
+          width: 50%;
+          max-width: 50%;
+          min-width: 50%;
           order: @searchBarTabletScreenLocationInputOrder;
           padding-right: @searchBarInputSpacing;
         }
 
         .guests-input-container {
+          width: 50%;
           order: @searchBarTabletScreenGuestsInputOrder;
         }
       }


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-2644)

### What **one** thing does this PR do?
Searchbar input widths adjust with device size

### Any other notes
<img width="488" alt="Screenshot 2019-10-09 at 15 15 25" src="https://user-images.githubusercontent.com/10498995/66484754-eb527b00-eaa7-11e9-95fb-73e1ec9dadb7.png">
<img width="671" alt="Screenshot 2019-10-09 at 15 15 33" src="https://user-images.githubusercontent.com/10498995/66484755-eb527b00-eaa7-11e9-8e73-e1a814c7574a.png">
<img width="774" alt="Screenshot 2019-10-09 at 15 15 50" src="https://user-images.githubusercontent.com/10498995/66484756-ebeb1180-eaa7-11e9-82d1-836b0434cb54.png">
