### PR TITLE
TE-2644 Search bar tablet

### DIFF
--- a/src/styles/semantic/definitions/lodgify-ui-components/search-bar.less
+++ b/src/styles/semantic/definitions/lodgify-ui-components/search-bar.less
@@ -86,6 +86,7 @@
         .guests-input-container {
           width: 50%;
           order: @searchBarTabletScreenGuestsInputOrder;
+          flex-grow: 1;
         }
       }
     }


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-2644)

### What **one** thing does this PR do?
Guests input takes full width when there is no location options dropdown.

### Any other notes
<img width="471" alt="Screenshot 2019-10-09 at 16 41 50" src="https://user-images.githubusercontent.com/10498995/66492125-31154080-eab4-11e9-9573-b29c3d824373.png">
