### PR TITLE
TE-2732 Property Page picture fit image section to image size

### DIFF
--- a/src/styles/semantic/definitions/third-party-components/react-image-gallery.less
+++ b/src/styles/semantic/definitions/third-party-components/react-image-gallery.less
@@ -20,14 +20,6 @@
   > .image-gallery-content {
     height: @imageGalleryImageMaxHeight;
 
-    @media @tabletViewport {
-      height: @imageGalleryImageMaxHeightTablet;
-    }
-
-    @media @mobileViewport {
-      height: @imageGalleryImageMaxHeightMobile;
-    }
-
     .image-gallery-slide-wrapper {
       height: 100%;
 

--- a/src/styles/semantic/themes/default/third-party-components/react-image-gallery.variables
+++ b/src/styles/semantic/themes/default/third-party-components/react-image-gallery.variables
@@ -7,11 +7,9 @@
 --------------------*/
 @imageGalleryBottomMargin: @30px;
 @imageGalleryZindex: @zIndexLevelOne;
+@imageGalleryImageMaxHeight: 390px;
 
 @imageGalleryImagesBorderRadius: @4px;
-@imageGalleryImageMaxHeight: 390px;
-@imageGalleryImageMaxHeightTablet: 325px;
-@imageGalleryImageMaxHeightMobile: 245px;
 
 @imageGalleryButtonHorizontalPadding: @30px;
 @imageGalleryButtonHeightOffset: (@38px / 2);

--- a/src/styles/semantic/themes/livingstone/modules/modal.overrides
+++ b/src/styles/semantic/themes/livingstone/modules/modal.overrides
@@ -163,10 +163,18 @@
 /* Derived Responsive Sizes */
 
 /* Room Type Image Gallery */
-.ui.modal > .content.has-room-type-gallery {
+.ui.modal .content.has-room-type-gallery {
 
   .image-gallery-image {
-    height: @roomTypeModalSlideshowImageHeight;
+    height: @roomTypeModalImageHeight;
+
+    @media @tabletViewport {
+      height: @roomTypeModalImageTabletHeight;
+    }
+
+    @media @mobileViewport {
+      height: @roomTypeModalImageMobileHeight;
+    }
 
     > img {
       height: auto;
@@ -180,7 +188,7 @@
       width: auto;
 
       > img {
-        height: @roomTypeModalSlideshowImageHeight;
+        height: 100%;
         object-fit: cover;
         position: static;
         width: 100%;

--- a/src/styles/semantic/themes/livingstone/modules/modal.variables
+++ b/src/styles/semantic/themes/livingstone/modules/modal.variables
@@ -77,7 +77,9 @@
 @halfContainerWidthWithPadding: (@horizontalGutterMaxWidth / 2) - (@horizontalGutterLeftRightPadding * 2);
 @withHorizontalCloseIconLeft: ~"calc(50% + @{halfContainerWidthWithPadding})";
 
-@roomTypeModalSlideshowImageHeight: 270px;
+@roomTypeModalImageHeight: 390px;
+@roomTypeModalImageTabletHeight: 325px;
+@roomTypeModalImageMobileHeight: 245px;
 
 /*Has rounded corners*/
 @modalBorderRadius: 5px;

--- a/src/styles/semantic/themes/livingstone/views/card.overrides
+++ b/src/styles/semantic/themes/livingstone/views/card.overrides
@@ -282,6 +282,7 @@
   .image-gallery {
 
     .image-gallery-content {
+      height: initial;
 
       .image-gallery-image {
         position: relative;


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-2732)

### What **one** thing does this PR do?
Sets the modal `RoomType` image to the height of its container for each viewport. 

### Before
![before](https://user-images.githubusercontent.com/33876435/66588778-7ce7e880-eb8d-11e9-8cff-b73a1b4ded8e.gif)

### After
![after](https://user-images.githubusercontent.com/33876435/66588788-82ddc980-eb8d-11e9-9b8f-6394da350b92.gif)
