### PR TITLE
TE-2832 input width fits children

### DIFF
--- a/src/styles/semantic/themes/livingstone/modules/popup.overrides
+++ b/src/styles/semantic/themes/livingstone/modules/popup.overrides
@@ -57,7 +57,6 @@
 /* Counter popup */
 .ui.popup.counter-dropdown {
   box-shadow: @subMenuShadow;
-  width: @inputWidth;
 
   &:before {
     display: none;


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-2832)

### What **one** thing does this PR do?
CounterDropdown dropdown width is the same width as the counter

### Any other notes
![image](https://user-images.githubusercontent.com/10498995/67965493-69ff8b80-fc02-11e9-81af-28074f46750b.png)
