### PR TITLE
WEB-519 HTML widget max width

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-X)
+[Related Jira issue](https://lodgify.atlassian.net/browse/WEB-X)
 
 ### What **one** thing does this PR do?
 

--- a/src/styles/semantic/definitions/lodgify-ui-components/html.less
+++ b/src/styles/semantic/definitions/lodgify-ui-components/html.less
@@ -16,13 +16,17 @@
   overflow-x: auto;
 
   > img {
-    max-width: @htmlContainerImmediateImageChildMaxWidth;
+    max-width: @htmlContainerImmediateChildMaxWidth;
   }
 
   & * {
 
-    img {
-      width: @htmlContainerImageChildWidth;
+    img,
+    figure,
+    object,
+    iframe {
+      width: @htmlContainerChildWidth;
+      max-width: @htmlContainerChildWidth;
     }
   }
 }

--- a/src/styles/semantic/themes/default/lodgify-ui-components/html.variables
+++ b/src/styles/semantic/themes/default/lodgify-ui-components/html.variables
@@ -1,5 +1,5 @@
 /*----------------------
           HTML
 -----------------------*/
-@htmlContainerImmediateImageChildMaxWidth: 100%;
-@htmlContainerImageChildWidth: 100%;
+@htmlContainerImmediateChildMaxWidth: 100%;
+@htmlContainerChildWidth: 100%;


### PR DESCRIPTION
[Related Jira issue](https://lodgify.atlassian.net/browse/WEB-519)

### What **one** thing does this PR do?
Image based content doesn't extend passed the width of the component

### Any other notes
#### Before
![image](https://user-images.githubusercontent.com/10498995/68486729-03055680-0242-11ea-84b6-07acf6756f88.png)

#### After
![image](https://user-images.githubusercontent.com/10498995/68486714-f84ac180-0241-11ea-9863-b2e6df02dcc0.png)
