### PR TITLE
WEB-496: review empty props

### DIFF
--- a/src/components/general-widgets/Review/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/Review/__snapshots__/component.spec.js.snap
@@ -651,7 +651,7 @@ exports[`<Review /> if \`props.reviewResponse\` is passed should render the righ
             <div
               className="right aligned description"
             >
-              someCategory | stayed in someDate
+              someCategory | someDate
             </div>
           </CardDescription>
         </div>
@@ -993,7 +993,7 @@ exports[`<Review /> should render the right structure 1`] = `
             <div
               className="right aligned description"
             >
-              someCategory | stayed in someDate
+              someCategory | someDate
             </div>
           </CardDescription>
         </div>

--- a/src/components/general-widgets/Review/component.js
+++ b/src/components/general-widgets/Review/component.js
@@ -108,6 +108,9 @@ Component.displayName = 'Review';
 Component.defaultProps = {
   isShowingPlaceholder: false,
   reviewResponse: null,
+  reviewerLocation: undefined,
+  reviewerStayDate: '',
+  reviewerCategory: '',
 };
 
 Component.propTypes = {
@@ -129,11 +132,11 @@ Component.propTypes = {
   /** The title of the review. */
   reviewTitle: PropTypes.string.isRequired,
   /** The category of the reviewer. */
-  reviewerCategory: PropTypes.string.isRequired,
+  reviewerCategory: PropTypes.string,
   /** The location of the reviewer. */
-  reviewerLocation: PropTypes.string.isRequired,
+  reviewerLocation: PropTypes.string,
   /** The name of the reviewer. */
   reviewerName: PropTypes.string.isRequired,
   /** The date the reviewer stayed. */
-  reviewerStayDate: PropTypes.string.isRequired,
+  reviewerStayDate: PropTypes.string,
 };

--- a/src/components/general-widgets/Review/utils/getReviewerCategoryAndStayDateString.js
+++ b/src/components/general-widgets/Review/utils/getReviewerCategoryAndStayDateString.js
@@ -6,4 +6,4 @@
 export const getReviewerCategoryAndStayDateString = (
   reviewerCategory,
   reviewerStayDate
-) => `${reviewerCategory} | stayed in ${reviewerStayDate}`;
+) => `${reviewerCategory} ${reviewerStayDate ? `| ${reviewerStayDate}` : ''}`;

--- a/src/components/general-widgets/Review/utils/getReviewerCategoryAndStayDateString.spec.js
+++ b/src/components/general-widgets/Review/utils/getReviewerCategoryAndStayDateString.spec.js
@@ -9,6 +9,13 @@ describe('getReviewerCategoryAndStayDateString', () => {
       reviewerStayDate
     );
 
-    expect(actual).toBe(`${reviewerCategory} | stayed in ${reviewerStayDate}`);
+    expect(actual).toContain(reviewerCategory);
+    expect(actual).toContain(reviewerStayDate);
+  });
+  it("shouldn't return a separator if reviewerStaysDate is missing", () => {
+    const reviewerCategory = 'someMarritalStatus';
+    const actual = getReviewerCategoryAndStayDateString(reviewerCategory);
+
+    expect(actual).not.toContain('|');
   });
 });

--- a/src/components/general-widgets/Review/utils/getReviewerNameAndLocationString.js
+++ b/src/components/general-widgets/Review/utils/getReviewerNameAndLocationString.js
@@ -1,9 +1,9 @@
 /**
- * @param  {string} reviewerLocation
  * @param  {string} reviewerName
+ * @param  {string} reviewerLocation
  * @return {string}
  */
 export const getReviewerNameAndLocationString = (
-  reviewerLocation,
-  reviewerName
-) => `${reviewerLocation} (${reviewerName})`;
+  reviewerName,
+  reviewerLocation
+) => `${reviewerName} ${reviewerLocation ? `(${reviewerLocation})` : ``}`;

--- a/src/components/general-widgets/Review/utils/getReviewerNameAndLocationString.spec.js
+++ b/src/components/general-widgets/Review/utils/getReviewerNameAndLocationString.spec.js
@@ -5,10 +5,18 @@ describe('getReviewerNameAndLocationString', () => {
     const reviewerLocation = 'someLabel';
     const reviewerName = '🚣';
     const actual = getReviewerNameAndLocationString(
-      reviewerLocation,
-      reviewerName
+      reviewerName,
+      reviewerLocation
     );
 
-    expect(actual).toBe(`${reviewerLocation} (${reviewerName})`);
+    expect(actual).toContain(reviewerLocation);
+    expect(actual).toContain(reviewerName);
+  });
+  it("should' return parenthesis if the location is missing", () => {
+    const reviewerName = '🚣';
+    const actual = getReviewerNameAndLocationString(reviewerName);
+
+    expect(actual).not.toContain('(');
+    expect(actual).not.toContain(')');
   });
 });

--- a/src/components/property-page-widgets/Reviews/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Reviews/__snapshots__/component.spec.js.snap
@@ -22,6 +22,7 @@ exports[`<Reviews /> if \`props.isShowingPlaceholder\` is \`true\` if \`props.re
   ratingInputLabel="Your review"
   reviewFormHeading="Add a Review"
   reviews={Array []}
+  reviewsStayDatePrefix="stayed on"
   roomTypeInputLabel="Room"
   roomTypeOptions={Array []}
   submitButtonText="Submit a review"
@@ -1114,6 +1115,7 @@ exports[`<Reviews /> if \`props.isShowingPlaceholder\` is \`true\` should render
       },
     ]
   }
+  reviewsStayDatePrefix="stayed on"
   roomTypeInputLabel="Room"
   roomTypeOptions={Array []}
   submitButtonText="Submit a review"
@@ -1476,7 +1478,7 @@ exports[`<Reviews /> if \`props.isShowingPlaceholder\` is \`true\` should render
                       reviewerCategory="Young people"
                       reviewerLocation="Lithuania"
                       reviewerName="Magellan"
-                      reviewerStayDate="9/2015"
+                      reviewerStayDate="stayed on 9/2015"
                     >
                       <Card
                         fluid={true}
@@ -1828,7 +1830,7 @@ exports[`<Reviews /> if \`props.isShowingPlaceholder\` is \`true\` should render
                       reviewerCategory="Young people"
                       reviewerLocation="Lithuania"
                       reviewerName="Magellan"
-                      reviewerStayDate="9/2015"
+                      reviewerStayDate="stayed on 9/2015"
                     >
                       <Card
                         fluid={true}
@@ -2090,6 +2092,7 @@ exports[`<Reviews /> should render the right structure 1`] = `
       },
     ]
   }
+  reviewsStayDatePrefix="stayed on"
   roomTypeInputLabel="Room"
   roomTypeOptions={Array []}
   submitButtonText="Submit a review"
@@ -2585,7 +2588,7 @@ exports[`<Reviews /> should render the right structure 1`] = `
                       reviewerCategory="Young people"
                       reviewerLocation="Lithuania"
                       reviewerName="Magellan"
-                      reviewerStayDate="9/2015"
+                      reviewerStayDate="stayed on 9/2015"
                     >
                       <Card
                         fluid={true}
@@ -3022,7 +3025,7 @@ exports[`<Reviews /> should render the right structure 1`] = `
                                 <div
                                   className="right aligned description"
                                 >
-                                  Young people | stayed in 9/2015
+                                  Young people | stayed on 9/2015
                                 </div>
                               </CardDescription>
                             </div>
@@ -3081,7 +3084,7 @@ exports[`<Reviews /> should render the right structure 1`] = `
                       reviewerCategory="Young people"
                       reviewerLocation="Lithuania"
                       reviewerName="Magellan"
-                      reviewerStayDate="9/2015"
+                      reviewerStayDate="stayed on 9/2015"
                     >
                       <Card
                         fluid={true}
@@ -3403,7 +3406,7 @@ exports[`<Reviews /> should render the right structure 1`] = `
                                 <div
                                   className="right aligned description"
                                 >
-                                  Young people | stayed in 9/2015
+                                  Young people | stayed on 9/2015
                                 </div>
                               </CardDescription>
                             </div>

--- a/src/components/property-page-widgets/Reviews/component.js
+++ b/src/components/property-page-widgets/Reviews/component.js
@@ -240,7 +240,7 @@ Component.propTypes = {
       reviewerStayDate: PropTypes.string.isRequired,
     })
   ),
-  /** the prefix to put before of the StayDate of each Reviewer */
+  /** the prefix to put before of the stayDate of each reviewer */
   reviewsStayDatePrefix: PropTypes.string,
   /** The label for the room type input. */
   // eslint-disable-next-line react/no-unused-prop-types

--- a/src/components/property-page-widgets/Reviews/component.js
+++ b/src/components/property-page-widgets/Reviews/component.js
@@ -240,7 +240,7 @@ Component.propTypes = {
       reviewerStayDate: PropTypes.string.isRequired,
     })
   ),
-  /** the prefix to put before of the stayDate of each reviewer */
+  /** The prefix to the stay date of a reviewer. */
   reviewsStayDatePrefix: PropTypes.string,
   /** The label for the room type input. */
   // eslint-disable-next-line react/no-unused-prop-types

--- a/src/components/property-page-widgets/Reviews/component.js
+++ b/src/components/property-page-widgets/Reviews/component.js
@@ -18,6 +18,7 @@ import {
   GUEST_TYPE,
   MONTH,
   REVIEWS,
+  REVIEWS_STAY_DATE_PREFIX,
   ROOM,
   SUBMIT_REVIEW,
   TITLE,
@@ -30,6 +31,7 @@ import {
 
 import { PLACEHOLDERS } from './constants';
 import { getModalFormMarkup } from './utils/getModalFormMarkup';
+import { transformReviewFactory } from './utils/transformReviewFactory';
 
 /**
  * The standard widget for displaying a collection of reviews.
@@ -40,6 +42,7 @@ export const Component = ({
   isShowingPlaceholder,
   ratingAverage,
   reviews,
+  reviewsStayDatePrefix,
   ...props
 }) => {
   const reviewsToMap =
@@ -77,14 +80,20 @@ export const Component = ({
           {getModalFormMarkup(props, isShowingPlaceholder)}
         </GridColumn>
       </GridRow>
-      {reviewsToMap.map((review, index) => (
-        <GridRow key={buildKeyFromStrings(review.reviewText, index)}>
-          <GridColumn width={12}>
-            <Review isShowingPlaceholder={isShowingPlaceholder} {...review} />
-            <Divider />
-          </GridColumn>
-        </GridRow>
-      ))}
+      {reviewsToMap
+        .map(
+          transformReviewFactory({
+            stayDatePrefix: reviewsStayDatePrefix,
+          })
+        )
+        .map((review, index) => (
+          <GridRow key={buildKeyFromStrings(review.reviewText, index)}>
+            <GridColumn width={12}>
+              <Review isShowingPlaceholder={isShowingPlaceholder} {...review} />
+              <Divider />
+            </GridColumn>
+          </GridRow>
+        ))}
     </Grid>
   );
 };
@@ -115,6 +124,7 @@ Component.defaultProps = {
   ratingInputLabel: YOUR_REVIEW,
   reviewFormHeading: ADD_A_REVIEW,
   reviews: [],
+  reviewsStayDatePrefix: REVIEWS_STAY_DATE_PREFIX,
   submitButtonText: SUBMIT_REVIEW,
   successMessage: '',
   titleInputLabel: TITLE,
@@ -230,6 +240,8 @@ Component.propTypes = {
       reviewerStayDate: PropTypes.string.isRequired,
     })
   ),
+  /** the prefix to put before of the StayDate of each Reviewer */
+  reviewsStayDatePrefix: PropTypes.string,
   /** The label for the room type input. */
   // eslint-disable-next-line react/no-unused-prop-types
   roomTypeInputLabel: PropTypes.string,

--- a/src/components/property-page-widgets/Reviews/utils/transformReviewFactory.js
+++ b/src/components/property-page-widgets/Reviews/utils/transformReviewFactory.js
@@ -1,0 +1,10 @@
+export const transformReviewFactory = ({
+  stayDatePrefix = undefined,
+} = {}) => ({ reviewerStayDate, ...otherFields }) => ({
+  ...otherFields,
+  reviewerStayDate: reviewerStayDate
+    ? stayDatePrefix
+      ? `${stayDatePrefix} ${reviewerStayDate}`
+      : reviewerStayDate
+    : reviewerStayDate,
+});

--- a/src/components/property-page-widgets/Reviews/utils/transformReviewFactory.spec.js
+++ b/src/components/property-page-widgets/Reviews/utils/transformReviewFactory.spec.js
@@ -1,0 +1,44 @@
+import { transformReviewFactory } from './transformReviewFactory';
+
+describe('transformReviewFactory', () => {
+  it('check if the result is a function', () => {
+    expect(transformReviewFactory() instanceof Function).toBe(true);
+  });
+  describe('when none parameter are passed', () => {
+    it('should return an identity function', () => {
+      const tranformer = transformReviewFactory();
+
+      const result = tranformer({ reviewerStayDate: 'bar' });
+
+      expect(result).toEqual({
+        reviewerStayDate: 'bar',
+      });
+    });
+  });
+  describe('when the right parameter is passed', () => {
+    describe('stayDatePrefix', () => {
+      describe('with review with `reviewerStayDate`', () => {
+        it('should return it prefixed', () => {
+          const review = {
+            reviewerStayDate: 'foo',
+          };
+          const result = transformReviewFactory({ stayDatePrefix: 'bar' })(
+            review
+          );
+
+          expect(result).toMatchObject({ reviewerStayDate: 'bar foo' });
+        });
+      });
+    });
+    describe('with review without `reviewerStayDate`', () => {
+      it('should return undefined', () => {
+        const review = {};
+        const result = transformReviewFactory({ stayDatePrefix: 'bar' })(
+          review
+        );
+
+        expect(result).toMatchObject({ reviewerStayDate: undefined });
+      });
+    });
+  });
+});

--- a/src/utils/default-strings/constants.js
+++ b/src/utils/default-strings/constants.js
@@ -65,6 +65,7 @@ export const PROPERTY_PICTURES = 'Property pictures';
 export const PROPERTY_URL_TARGET = '_self';
 export const RESULTS = 'results';
 export const REVIEWS = 'Reviews';
+export const REVIEWS_STAY_DATE_PREFIX = 'stayed on';
 export const ROOM = 'Room';
 export const ROOM_AMENITIES = 'Room Amenities';
 export const SAVE_UP_TO = 'Save up to';


### PR DESCRIPTION
[Related Jira issue](https://lodgify.atlassian.net/browse/WEB-496)

### What **one** thing does this PR do?
Reviews can now miss some parameters without showing the `undefined` value

### Any other notes
During the execution of this task I noticed a string fixed inside the review. So I made it a params of the reviews list


|before|after|
|---|---|
|<img width="700" alt="image" src="https://user-images.githubusercontent.com/5032333/68657358-dac47300-0533-11ea-8d83-78d508ed6df1.png">|<img width="688" alt="image" src="https://user-images.githubusercontent.com/5032333/68657516-2d9e2a80-0534-11ea-882d-724a2cc7347f.png">|
