### PR TITLE
WEB-496: remove separator when there aren't two values

### DIFF
--- a/src/components/general-widgets/Review/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/Review/__snapshots__/component.spec.js.snap
@@ -651,7 +651,7 @@ exports[`<Review /> if \`props.reviewResponse\` is passed should render the righ
             <div
               className="right aligned description"
             >
-              someCategory | someDate
+              someCategory |  someDate
             </div>
           </CardDescription>
         </div>
@@ -993,7 +993,7 @@ exports[`<Review /> should render the right structure 1`] = `
             <div
               className="right aligned description"
             >
-              someCategory | someDate
+              someCategory |  someDate
             </div>
           </CardDescription>
         </div>

--- a/src/components/general-widgets/Review/utils/getReviewerCategoryAndStayDateString.js
+++ b/src/components/general-widgets/Review/utils/getReviewerCategoryAndStayDateString.js
@@ -6,4 +6,9 @@
 export const getReviewerCategoryAndStayDateString = (
   reviewerCategory,
   reviewerStayDate
-) => `${reviewerCategory} ${reviewerStayDate ? `| ${reviewerStayDate}` : ''}`;
+) =>
+  `${reviewerCategory} ${
+    reviewerStayDate
+      ? `${reviewerCategory ? '| ' : ''} ${reviewerStayDate}`
+      : ''
+  }`;

--- a/src/components/general-widgets/Review/utils/getReviewerCategoryAndStayDateString.spec.js
+++ b/src/components/general-widgets/Review/utils/getReviewerCategoryAndStayDateString.spec.js
@@ -18,4 +18,13 @@ describe('getReviewerCategoryAndStayDateString', () => {
 
     expect(actual).not.toContain('|');
   });
+  it("shouldn't return a separator if reviewerCategory is missing", () => {
+    const reviewerStayDate = 'someMarritalStatus';
+    const actual = getReviewerCategoryAndStayDateString(
+      undefined,
+      reviewerStayDate
+    );
+
+    expect(actual).not.toContain('|');
+  });
 });

--- a/src/components/property-page-widgets/Reviews/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Reviews/__snapshots__/component.spec.js.snap
@@ -3025,7 +3025,7 @@ exports[`<Reviews /> should render the right structure 1`] = `
                                 <div
                                   className="right aligned description"
                                 >
-                                  Young people | stayed on 9/2015
+                                  Young people |  stayed on 9/2015
                                 </div>
                               </CardDescription>
                             </div>
@@ -3406,7 +3406,7 @@ exports[`<Reviews /> should render the right structure 1`] = `
                                 <div
                                   className="right aligned description"
                                 >
-                                  Young people | stayed on 9/2015
+                                  Young people |  stayed on 9/2015
                                 </div>
                               </CardDescription>
                             </div>

--- a/src/components/property-page-widgets/Reviews/component.js
+++ b/src/components/property-page-widgets/Reviews/component.js
@@ -231,13 +231,13 @@ Component.propTypes = {
       /** The title of the review. */
       reviewTitle: PropTypes.string.isRequired,
       /** The category of the reviewer. */
-      reviewerCategory: PropTypes.string.isRequired,
+      reviewerCategory: PropTypes.string,
       /** The location of the reviewer. */
-      reviewerLocation: PropTypes.string.isRequired,
+      reviewerLocation: PropTypes.string,
       /** The name of the reviewer. */
       reviewerName: PropTypes.string.isRequired,
       /** The date the reviewer stayed. */
-      reviewerStayDate: PropTypes.string.isRequired,
+      reviewerStayDate: PropTypes.string,
     })
   ),
   /** The prefix to the stay date of a reviewer. */


### PR DESCRIPTION
[Related Jira issue](https://lodgify.atlassian.net/browse/WEB-496)

### What **one** thing does this PR do?
Remove the separator in the bottom reviews when only one of the two value is present.

### Any other notes
|   |   |
|---|---|
|<img width="658" alt="image" src="https://user-images.githubusercontent.com/5032333/68770580-b39a9e00-0626-11ea-98a2-78b5d771bddf.png">|<img width="661" alt="image" src="https://user-images.githubusercontent.com/5032333/68770746-083e1900-0627-11ea-83c3-cf4e44935544.png">|