### PR TITLE
WEB-651 Hide the main icons guests/bedrooms/bathrooms when property has room types.

### DIFF
--- a/src/components/property-page-widgets/Description/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Description/__snapshots__/component.spec.js.snap
@@ -1,7 +1,239 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<Description /> if \`props.arePropertyMainCharacteristicsShown\` is false should not render the property main characteristics 1`] = `
+<Description
+  arePropertyMainCharacteristicsShown={false}
+  descriptionText={null}
+  extraDescriptionButtonText="View more"
+  homeHighlights={
+    Array [
+      Object {
+        "iconName": "credit card",
+        "text": "credit cards",
+      },
+      Object {
+        "iconName": "no children",
+        "text": "no children allowed",
+      },
+    ]
+  }
+  homeHighlightsHeadingText="Highlights"
+  mainCharacteristicsIcons={
+    Object {
+      "color": null,
+      "hasBorder": false,
+      "isCircular": false,
+      "isColorInverted": false,
+      "isDisabled": false,
+      "isLabelLeft": false,
+      "labelText": Any<String>,
+      "labelWeight": null,
+      "name": Any<String>,
+      "path": null,
+      "size": null,
+    }
+  }
+  propertyMainCharacteristics={
+    Array [
+      Object {
+        "iconName": "users",
+        "text": "2 guests",
+      },
+      Object {
+        "iconName": "home",
+        "text": "1 bedroom",
+      },
+      Object {
+        "iconName": "single bed",
+        "text": "2 beds",
+      },
+      Object {
+        "iconName": "bathroom",
+        "text": "1 bathroom",
+      },
+    ]
+  }
+  propertyName="Yolo"
+  propertyType="Bed & Breakfast"
+>
+  <Grid
+    areColumnsCentered={false}
+    columns={1}
+    isStackable={false}
+  >
+    <Grid
+      centered={false}
+      columns={1}
+      stackable={false}
+    >
+      <div
+        className="ui one column grid"
+      >
+        <GridColumn
+          verticalAlignContent="top"
+          width={12}
+        >
+          <GridColumn
+            verticalAlign="top"
+            width={12}
+          >
+            <div
+              className="top aligned twelve wide column"
+            >
+              <Subheading>
+                <span
+                  className="ui sub header"
+                >
+                  Bed & Breakfast
+                </span>
+              </Subheading>
+              <Heading
+                className={null}
+                hasMargin={true}
+                isColorInverted={false}
+                size="large"
+                textAlign={null}
+              >
+                <Header
+                  as="h2"
+                  className=""
+                  inverted={false}
+                  textAlign={null}
+                >
+                  <h2
+                    className="ui header"
+                  >
+                    Yolo
+                  </h2>
+                </Header>
+              </Heading>
+            </div>
+          </GridColumn>
+        </GridColumn>
+        <GridColumn
+          verticalAlignContent="top"
+          width={12}
+        >
+          <GridColumn
+            verticalAlign="top"
+            width={12}
+          >
+            <div
+              className="top aligned twelve wide column"
+            >
+              <Subheading>
+                <span
+                  className="ui sub header"
+                >
+                  Highlights
+                </span>
+              </Subheading>
+            </div>
+          </GridColumn>
+        </GridColumn>
+        <GridColumn
+          verticalAlignContent="top"
+          width={12}
+        >
+          <GridColumn
+            verticalAlign="top"
+            width={12}
+          >
+            <div
+              className="top aligned twelve wide column"
+            >
+              <Icon
+                className={null}
+                color={null}
+                hasBorder={true}
+                isButton={false}
+                isCircular={false}
+                isColorInverted={false}
+                isDisabled={false}
+                isLabelLeft={false}
+                key="credit cards"
+                labelText="credit cards"
+                labelWeight={null}
+                name="credit card"
+                path={null}
+                size={null}
+              >
+                <i
+                  className="icon has-border has-label"
+                >
+                  <svg
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M19.84,5.17H4.16A1.82,1.82,0,0,0,2.34,7V17.66a1.81,1.81,0,0,0,1.82,1.81H19.84a1.81,1.81,0,0,0,1.82-1.81V7A1.82,1.82,0,0,0,19.84,5.17Zm-15.68,1H19.84a.82.82,0,0,1,.82.82V7H3.34V7A.82.82,0,0,1,4.16,6.17ZM3.34,8H20.65V9.54H3.34Zm16.5,10.46H4.16a.82.82,0,0,1-.82-.81V10.54H20.66v7.12A.82.82,0,0,1,19.84,18.47Zm-2.29-4.63H14.12A1.13,1.13,0,0,0,13,15v.84a1.12,1.12,0,0,0,1.12,1.12h3.43a1.12,1.12,0,0,0,1.12-1.12V15A1.13,1.13,0,0,0,17.55,13.84Zm.12,2a.12.12,0,0,1-.12.12H14.12a.12.12,0,0,1-.12-.12V15a.12.12,0,0,1,.12-.13h3.43a.13.13,0,0,1,.12.13Z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                  <Paragraph
+                    isCompact={false}
+                    size="medium"
+                    weight={null}
+                  >
+                    <p
+                      className=""
+                    >
+                      credit cards
+                    </p>
+                  </Paragraph>
+                </i>
+              </Icon>
+              <Icon
+                className={null}
+                color={null}
+                hasBorder={true}
+                isButton={false}
+                isCircular={false}
+                isColorInverted={false}
+                isDisabled={false}
+                isLabelLeft={false}
+                key="no children allowed"
+                labelText="no children allowed"
+                labelWeight={null}
+                name="no children"
+                path={null}
+                size={null}
+              >
+                <i
+                  className="icon has-border has-label"
+                >
+                  <svg
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M12,1.79A10.19,10.19,0,0,0,6.13,20.33a.2.2,0,0,0,.07.06,10.15,10.15,0,0,0,11.38.15l0,0A10.2,10.2,0,0,0,12,1.79Zm0,19.42a9.17,9.17,0,0,1-4.94-1.45,3.45,3.45,0,0,1,3.21-2.22h3.17a3.45,3.45,0,0,1,3.28,2.36A9.27,9.27,0,0,1,12,21.21Zm5.58-1.9a4.44,4.44,0,0,0-3.37-2.7l.21-.11a.5.5,0,1,0-.53-.85,3.86,3.86,0,0,1-2,.57,4,4,0,0,1-3.95-3.95,3.74,3.74,0,0,1,.38-1.69.5.5,0,0,0-.23-.67.51.51,0,0,0-.67.23,4.82,4.82,0,0,0-.48,2.13,4.93,4.93,0,0,0,2.61,4.34,4.45,4.45,0,0,0-3.3,2.55A9.18,9.18,0,0,1,5,6L19.09,17.87A9.34,9.34,0,0,1,17.58,19.31ZM5.71,5.29a9.2,9.2,0,0,1,14,11.78ZM15.4,8.81a5,5,0,0,1,1.4,3.46,3.2,3.2,0,0,1-.06.7.45.45,0,0,1-.49.46.53.53,0,0,1-.5-.54s0-.07,0-.1a3,3,0,0,0,0-.52A4,4,0,0,0,14.12,9l-.06,0a3.87,3.87,0,0,0-1.71-.63h-.1l-.39,0a3.26,3.26,0,0,0-.92.12.5.5,0,0,1-.28-1A4.23,4.23,0,0,1,12,7.35a.49.49,0,0,1,.24,0,1.66,1.66,0,0,0,1.21-.24,1.51,1.51,0,0,0,.42-1.22.5.5,0,0,1,.5-.5.5.5,0,0,1,.5.5,2.42,2.42,0,0,1-.78,2c.13.07.26.12.38.2A2,2,0,0,0,16.26,6a.51.51,0,0,1,.5-.5.5.5,0,0,1,.5.5A2.84,2.84,0,0,1,15.4,8.81Z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                  <Paragraph
+                    isCompact={false}
+                    size="medium"
+                    weight={null}
+                  >
+                    <p
+                      className=""
+                    >
+                      no children allowed
+                    </p>
+                  </Paragraph>
+                </i>
+              </Icon>
+            </div>
+          </GridColumn>
+        </GridColumn>
+      </div>
+    </Grid>
+  </Grid>
+</Description>
+`;
+
 exports[`<Description /> if \`props.descriptionText\` is HTML should have the correct structure 1`] = `
 <Description
+  arePropertyMainCharacteristicsShown={true}
   descriptionText="
   Livingstone is a modern website template with clean and straight lines. Its special feature is a wide horizontal header photo slideshow in which logo and header navigation nicely blend in.
 
@@ -784,6 +1016,7 @@ exports[`<Description /> if \`props.descriptionText\` is HTML should have the co
 
 exports[`<Description /> if \`props.descriptionText\` is a plain string with fewer than 100 words should have the correct structure 1`] = `
 <Description
+  arePropertyMainCharacteristicsShown={true}
   descriptionText="
   Livingstone is a modern website template with clean and straight lines. Its special feature is a wide horizontal header photo slideshow in which logo and header navigation nicely blend in.
 
@@ -1552,6 +1785,7 @@ exports[`<Description /> if \`props.descriptionText\` is a plain string with few
 
 exports[`<Description /> if \`props.descriptionText\` is a plain string with more than 100 words should have the correct structure 1`] = `
 <Description
+  arePropertyMainCharacteristicsShown={true}
   descriptionText="
   Livingstone is a modern website template with clean and straight lines. Its special feature is a wide horizontal header photo slideshow in which logo and header navigation nicely blend in.
 
@@ -2462,6 +2696,7 @@ exports[`<Description /> if \`props.descriptionText\` is a plain string with mor
 
 exports[`<Description /> if \`props.homeHighlights\` is empty should not render the home highlights 1`] = `
 <Description
+  arePropertyMainCharacteristicsShown={true}
   descriptionText={null}
   extraDescriptionButtonText="View more"
   homeHighlights={Array []}
@@ -3062,6 +3297,7 @@ exports[`<Description /> if \`props.homeHighlights\` is empty should not render 
 
 exports[`<Description /> should have the correct structure 1`] = `
 <Description
+  arePropertyMainCharacteristicsShown={true}
   descriptionText={null}
   extraDescriptionButtonText="View more"
   homeHighlights={

--- a/src/components/property-page-widgets/Description/component.js
+++ b/src/components/property-page-widgets/Description/component.js
@@ -22,6 +22,7 @@ import { getDescriptionTextMarkup } from './utils/getDescriptionTextMarkup';
  */
 // eslint-disable-next-line jsdoc/require-jsdoc
 export const Component = ({
+  arePropertyMainCharacteristicsShown,
   descriptionText,
   extraDescriptionButtonText,
   homeHighlights,
@@ -35,36 +36,38 @@ export const Component = ({
       <Subheading>{propertyType}</Subheading>
       <Heading size="large">{propertyName}</Heading>
     </GridColumn>
-    <GridColumn width={12}>
-      <ShowOn
-        computer
-        parent={List}
-        parentProps={{ horizontal: true }}
-        tablet
-        widescreen
-      >
-        {getFirstFourItems(propertyMainCharacteristics).map(
-          ({ iconName, text }, index) => (
-            <List.Item key={buildKeyFromStrings(text, index)}>
-              <Icon labelText={text} name={iconName} />
-            </List.Item>
-          )
-        )}
-      </ShowOn>
-      <ShowOn mobile parent={Grid} parentProps={{ columns: 1 }}>
-        {getFirstFourItems(propertyMainCharacteristics).map(
-          ({ iconName, text }, index) => (
-            <GridColumn
-              computer={3}
-              key={buildKeyFromStrings(text, index)}
-              mobile={6}
-            >
-              <Icon labelText={text} name={iconName} />
-            </GridColumn>
-          )
-        )}
-      </ShowOn>
-    </GridColumn>
+    {arePropertyMainCharacteristicsShown && (
+      <GridColumn width={12}>
+        <ShowOn
+          computer
+          parent={List}
+          parentProps={{ horizontal: true }}
+          tablet
+          widescreen
+        >
+          {getFirstFourItems(propertyMainCharacteristics).map(
+            ({ iconName, text }, index) => (
+              <List.Item key={buildKeyFromStrings(text, index)}>
+                <Icon labelText={text} name={iconName} />
+              </List.Item>
+            )
+          )}
+        </ShowOn>
+        <ShowOn mobile parent={Grid} parentProps={{ columns: 1 }}>
+          {getFirstFourItems(propertyMainCharacteristics).map(
+            ({ iconName, text }, index) => (
+              <GridColumn
+                computer={3}
+                key={buildKeyFromStrings(text, index)}
+                mobile={6}
+              >
+                <Icon labelText={text} name={iconName} />
+              </GridColumn>
+            )
+          )}
+        </ShowOn>
+      </GridColumn>
+    )}
     {descriptionText && (
       <GridColumn width={12}>
         {isValidHTML(descriptionText) ? (
@@ -97,12 +100,15 @@ export const Component = ({
 Component.displayName = 'Description';
 
 Component.defaultProps = {
+  arePropertyMainCharacteristicsShown: true,
   descriptionText: null,
   homeHighlightsHeadingText: HOME_HIGHLIGHTS,
   extraDescriptionButtonText: VIEW_MORE,
 };
 
 Component.propTypes = {
+  /** Are the property main characteristics being shown. */
+  arePropertyMainCharacteristicsShown: PropTypes.bool,
   /** The description text to display. Long text will be partially displayed in a modal. HTML strings of any length will be respected. */
   descriptionText: PropTypes.string,
   /** The text for the button that opens the extra description modal. */

--- a/src/components/property-page-widgets/Description/component.spec.js
+++ b/src/components/property-page-widgets/Description/component.spec.js
@@ -78,6 +78,16 @@ describe('<Description />', () => {
     });
   });
 
+  describe('if `props.arePropertyMainCharacteristicsShown` is false', () => {
+    it('should not render the property main characteristics', () => {
+      const wrapper = getDescription({
+        arePropertyMainCharacteristicsShown: false,
+      });
+
+      expect(wrapper).toMatchSnapshot();
+    });
+  });
+
   it('should have `displayName` `Description`', () => {
     expectComponentToHaveDisplayName(Description, 'Description');
   });


### PR DESCRIPTION
[Related Jira issue](https://lodgify.atlassian.net/browse/WEB-651)

### What **one** thing does this PR do?
Exposes a new prop to control whether the `propertyMainCharacteristics` are shown or not, removing the markup accordingly.

![Kapture 2019-11-13 at 15 49 00](https://user-images.githubusercontent.com/33876435/68774746-dda38e80-062d-11ea-95ff-e5bed2580834.gif)

