### PR TITLE
fix(HTML): add width rules for iframes

### DIFF
--- a/src/styles/semantic/definitions/lodgify-ui-components/html.less
+++ b/src/styles/semantic/definitions/lodgify-ui-components/html.less
@@ -19,6 +19,13 @@
     max-width: @htmlContainerImmediateChildMaxWidth;
   }
 
+  iframe {
+    max-width: @htmlContainerChildWidth;
+    @media @tabletScreen {
+      width: @htmlContainerChildWidth;
+    }
+  }
+
   & * {
     img,
     figure,


### PR DESCRIPTION
[Related Jira issue](https://lodgify.atlassian.net/browse/WEB-516)

### What **one** thing does this PR do?
Add width rule for iframe inside HTML to avoid horizontal scroll on mobile

### Any other notes
|before|after|
|---|---|
|<img width="447" alt="image" src="https://user-images.githubusercontent.com/5032333/68784466-dcc62900-063c-11ea-8e9e-fcba200c79e1.png">|<img width="447" alt="image" src="https://user-images.githubusercontent.com/5032333/68784421-ccae4980-063c-11ea-90ac-3e9ba2fc79e1.png">|
