### PR TITLE
WEB-682 Expose Lightbox component

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "test": "jest --coverage --config $npm_package_config_jest_config",
     "test:ci": "npm run test -- --runInBand",
     "test:no-cache": "npm run test -- --no-cache",
-    "test:watch": "jest --config $npm_package_config_jest_config --watch"
+    "test:watch": "jest --config $npm_package_config_jest_config --watch --coverage"
   },
   "repository": {
     "type": "git",

--- a/src/components/collections/Header/__snapshots__/component.spec.js.snap
+++ b/src/components/collections/Header/__snapshots__/component.spec.js.snap
@@ -845,6 +845,7 @@ exports[`<Header /> if \`isMenuHidden\` is \`true\` should render the right stru
                       onClick={[Function]}
                     >
                       <Modal
+                        className={null}
                         hasCloseIcon={true}
                         hasPadding={false}
                         hasRoundedCorners={false}
@@ -857,7 +858,6 @@ exports[`<Header /> if \`isMenuHidden\` is \`true\` should render the right stru
                             logoText="someLogoText"
                           />
                         }
-                        isDark={false}
                         isFullscreen={true}
                         onClose={[Function]}
                         size="tiny"

--- a/src/components/collections/Header/components/HiddenMenu/__snapshots__/component.spec.js.snap
+++ b/src/components/collections/Header/components/HiddenMenu/__snapshots__/component.spec.js.snap
@@ -56,6 +56,7 @@ exports[`HiddenMenu by default should render the right structure 1`] = `
       onClick={[Function]}
     >
       <Modal
+        className={null}
         hasCloseIcon={true}
         hasPadding={false}
         hasRoundedCorners={false}
@@ -68,7 +69,6 @@ exports[`HiddenMenu by default should render the right structure 1`] = `
             logoText="yo"
           />
         }
-        isDark={false}
         isFullscreen={true}
         onClose={[Function]}
         size="tiny"

--- a/src/components/elements/Modal/__snapshots__/component.spec.js.snap
+++ b/src/components/elements/Modal/__snapshots__/component.spec.js.snap
@@ -63,7 +63,7 @@ exports[`<Modal /> if \`props.isDark\` is passed should get the right props 1`] 
   }
   closeOnDimmerClick={true}
   closeOnDocumentClick={false}
-  dimmer={true}
+  dimmer="inverted"
   eventPool="Modal"
   onClose={[Function]}
   size="tiny"

--- a/src/components/elements/Modal/component.js
+++ b/src/components/elements/Modal/component.js
@@ -13,11 +13,11 @@ import { HorizontalGutters } from 'layout/HorizontalGutters';
 // eslint-disable-next-line jsdoc/require-jsdoc
 export const Component = ({
   children,
-  header,
+  className,
   hasCloseIcon,
   hasPadding,
   hasRoundedCorners,
-  isDark,
+  header,
   isFullscreen,
   isOpen,
   onClose,
@@ -25,12 +25,12 @@ export const Component = ({
   trigger,
 }) => (
   <Modal
-    className={classnames({
+    className={classnames(className, {
       'has-padding': hasPadding,
       'has-rounded-corners': hasRoundedCorners,
     })}
     closeIcon={hasCloseIcon && <Icon name={ICON_NAMES.CLOSE} />}
-    dimmer={isDark || 'inverted'}
+    dimmer="inverted"
     onClose={onClose}
     open={isOpen}
     size={isFullscreen ? 'fullscreen' : size}
@@ -48,11 +48,11 @@ export const Component = ({
 Component.displayName = 'Modal';
 
 Component.defaultProps = {
+  className: null,
   header: null,
   hasCloseIcon: true,
   hasPadding: false,
   hasRoundedCorners: false,
-  isDark: false,
   isFullscreen: false,
   isOpen: undefined,
   onClose: Function.prototype,
@@ -63,6 +63,8 @@ Component.defaultProps = {
 Component.propTypes = {
   /** The content of the modal when displayed. */
   children: PropTypes.node.isRequired,
+  /** Custom className for the Modal. */
+  className: PropTypes.string,
   /** Does the modal have a close icon. */
   hasCloseIcon: PropTypes.bool,
   /** Does the modal have padding around its content. */
@@ -71,8 +73,6 @@ Component.propTypes = {
   hasRoundedCorners: PropTypes.bool,
   /** The header fixed at the top of the modal. */
   header: PropTypes.node,
-  /** Is the modal dimmer dark. */
-  isDark: PropTypes.bool,
   /** Is the modal filling the whole screen when displayed. */
   isFullscreen: PropTypes.bool,
   /** Is the modal open. Used when consuming `Modal` as a controlled component. */

--- a/src/components/general-widgets/CookieAlert/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/CookieAlert/__snapshots__/component.spec.js.snap
@@ -23,11 +23,11 @@ exports[`The \`CookieAlert\` component if \`isOpen\` is true should return the 
   text="some text"
 >
   <Modal
+    className={null}
     hasCloseIcon={false}
     hasPadding={false}
     hasRoundedCorners={true}
     header={null}
-    isDark={false}
     isFullscreen={false}
     isOpen={true}
     onClose={[Function]}
@@ -1019,11 +1019,11 @@ exports[`The \`CookieAlert\` component if \`isUserOnMobile\` is true should retu
   text="some text"
 >
   <Modal
+    className={null}
     hasCloseIcon={false}
     hasPadding={false}
     hasRoundedCorners={true}
     header={null}
-    isDark={false}
     isFullscreen={false}
     isOpen={true}
     onClose={[Function]}

--- a/src/components/general-widgets/HomepageHero/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/HomepageHero/__snapshots__/component.spec.js.snap
@@ -1349,6 +1349,7 @@ exports[`HomepageHero should render the right structure 1`] = `
                                         willLocationDropdownOpenAbove={false}
                                       >
                                         <Modal
+                                          className={null}
                                           hasCloseIcon={true}
                                           hasPadding={true}
                                           hasRoundedCorners={false}
@@ -1363,7 +1364,6 @@ exports[`HomepageHero should render the right structure 1`] = `
                                               Check our availability
                                             </Heading>
                                           }
-                                          isDark={false}
                                           isFullscreen={true}
                                           isOpen={false}
                                           onClose={[Function]}

--- a/src/components/general-widgets/OwnerLogin/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/OwnerLogin/__snapshots__/component.spec.js.snap
@@ -23,11 +23,11 @@ exports[`<OwnerLogin /> if \`props.errorMessage\` is passed should render the er
     actionLink={
       Object {
         "text": <Modal
+          className={null}
           hasCloseIcon={true}
           hasPadding={false}
           hasRoundedCorners={false}
           header={null}
-          isDark={false}
           isFullscreen={false}
           onClose={[Function]}
           size="tiny"
@@ -319,11 +319,11 @@ exports[`<OwnerLogin /> if \`props.errorMessage\` is passed should render the er
                           type="button"
                         >
                           <Modal
+                            className={null}
                             hasCloseIcon={true}
                             hasPadding={false}
                             hasRoundedCorners={false}
                             header={null}
-                            isDark={false}
                             isFullscreen={false}
                             onClose={[Function]}
                             size="tiny"
@@ -504,11 +504,11 @@ exports[`<OwnerLogin /> if \`props.successMessage\` is passed should render the 
     actionLink={
       Object {
         "text": <Modal
+          className={null}
           hasCloseIcon={true}
           hasPadding={false}
           hasRoundedCorners={false}
           header={null}
-          isDark={false}
           isFullscreen={false}
           onClose={[Function]}
           size="tiny"
@@ -800,11 +800,11 @@ exports[`<OwnerLogin /> if \`props.successMessage\` is passed should render the 
                           type="button"
                         >
                           <Modal
+                            className={null}
                             hasCloseIcon={true}
                             hasPadding={false}
                             hasRoundedCorners={false}
                             header={null}
-                            isDark={false}
                             isFullscreen={false}
                             onClose={[Function]}
                             size="tiny"
@@ -985,11 +985,11 @@ exports[`<OwnerLogin /> should render the correct structure 1`] = `
     actionLink={
       Object {
         "text": <Modal
+          className={null}
           hasCloseIcon={true}
           hasPadding={false}
           hasRoundedCorners={false}
           header={null}
-          isDark={false}
           isFullscreen={false}
           onClose={[Function]}
           size="tiny"
@@ -1263,11 +1263,11 @@ exports[`<OwnerLogin /> should render the correct structure 1`] = `
                           type="button"
                         >
                           <Modal
+                            className={null}
                             hasCloseIcon={true}
                             hasPadding={false}
                             hasRoundedCorners={false}
                             header={null}
-                            isDark={false}
                             isFullscreen={false}
                             onClose={[Function]}
                             size="tiny"

--- a/src/components/general-widgets/OwnerLogin/utils/__snapshots__/getForgotPasswordFormMarkup.spec.js.snap
+++ b/src/components/general-widgets/OwnerLogin/utils/__snapshots__/getForgotPasswordFormMarkup.spec.js.snap
@@ -2,11 +2,11 @@
 
 exports[`getForgotPasswordFormMarkup if \`forgotPasswordErrorMessage\` is passed should render the error message above the reset button 1`] = `
 <Modal
+  className={null}
   hasCloseIcon={true}
   hasPadding={false}
   hasRoundedCorners={false}
   header={null}
-  isDark={false}
   isFullscreen={false}
   onClose={[Function]}
   size="tiny"
@@ -88,11 +88,11 @@ exports[`getForgotPasswordFormMarkup if \`forgotPasswordErrorMessage\` is passed
 
 exports[`getForgotPasswordFormMarkup if \`forgotPasswordSuccessMessage\` is passed should render the success message above the reset button 1`] = `
 <Modal
+  className={null}
   hasCloseIcon={true}
   hasPadding={false}
   hasRoundedCorners={false}
   header={null}
-  isDark={false}
   isFullscreen={false}
   onClose={[Function]}
   size="tiny"
@@ -174,11 +174,11 @@ exports[`getForgotPasswordFormMarkup if \`forgotPasswordSuccessMessage\` is pass
 
 exports[`getForgotPasswordFormMarkup should return the right structure  1`] = `
 <Modal
+  className={null}
   hasCloseIcon={true}
   hasPadding={false}
   hasRoundedCorners={false}
   header={null}
-  isDark={false}
   isFullscreen={false}
   onClose={[Function]}
   size="tiny"

--- a/src/components/general-widgets/SearchBar/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/SearchBar/__snapshots__/component.spec.js.snap
@@ -2436,6 +2436,7 @@ exports[`<SearchBar /> if \`props.isFixed\` is true should render the right stru
                 willLocationDropdownOpenAbove={false}
               >
                 <Modal
+                  className={null}
                   hasCloseIcon={true}
                   hasPadding={true}
                   hasRoundedCorners={false}
@@ -2450,7 +2451,6 @@ exports[`<SearchBar /> if \`props.isFixed\` is true should render the right stru
                       Check our availability
                     </Heading>
                   }
-                  isDark={false}
                   isFullscreen={true}
                   isOpen={false}
                   onClose={[Function]}

--- a/src/components/general-widgets/SearchBar/components/SearchModal/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/SearchBar/components/SearchModal/__snapshots__/component.spec.js.snap
@@ -12,11 +12,11 @@ exports[`getSearchBarModal if \`props.modalSummaryElement\` is passed should ret
   searchButton={<div />}
 >
   <Modal
+    className={null}
     hasCloseIcon={true}
     hasPadding={true}
     hasRoundedCorners={false}
     header={<div />}
-    isDark={false}
     isFullscreen={true}
     isOpen={false}
     onClose={[Function]}
@@ -122,6 +122,7 @@ exports[`getSearchBarModal should return the right structure 1`] = `
   searchButton={<div />}
 >
   <Modal
+    className={null}
     hasCloseIcon={true}
     hasPadding={true}
     hasRoundedCorners={false}
@@ -136,7 +137,6 @@ exports[`getSearchBarModal should return the right structure 1`] = `
         Hello world
       </Heading>
     }
-    isDark={false}
     isFullscreen={true}
     isOpen={false}
     onClose={[Function]}

--- a/src/components/media/Gallery/__snapshots__/component.spec.js.snap
+++ b/src/components/media/Gallery/__snapshots__/component.spec.js.snap
@@ -2,11 +2,11 @@
 
 exports[`<Gallery /> by default should render the right structure 1`] = `
 <Modal
+  className={null}
   hasCloseIcon={true}
   hasPadding={true}
   hasRoundedCorners={false}
   header={null}
-  isDark={false}
   isFullscreen={true}
   onClose={[Function]}
   size="tiny"
@@ -82,11 +82,11 @@ exports[`<Gallery /> by default should render the right structure 1`] = `
 
 exports[`<Gallery /> if \`props.headingText\` is defined should render the right structure 1`] = `
 <Modal
+  className={null}
   hasCloseIcon={true}
   hasPadding={true}
   hasRoundedCorners={false}
   header=":hurtrealbad:"
-  isDark={false}
   isFullscreen={true}
   onClose={[Function]}
   size="tiny"
@@ -162,11 +162,11 @@ exports[`<Gallery /> if \`props.headingText\` is defined should render the right
 
 exports[`<Gallery /> if any \`images\` have \`categoryText\` should render the right structure 1`] = `
 <Modal
+  className={null}
   hasCloseIcon={true}
   hasPadding={true}
   hasRoundedCorners={false}
   header={null}
-  isDark={false}
   isFullscreen={true}
   onClose={[Function]}
   size="tiny"

--- a/src/components/media/LightBox/Readme.md
+++ b/src/components/media/LightBox/Readme.md
@@ -1,0 +1,39 @@
+```jsx
+const images = [
+  {
+    url: "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
+    descriptionText: "Two cats"
+  },
+  {
+    url: "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
+    descriptionText: "Two more cats"
+  },
+  {
+    url: "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
+    descriptionText: "Much cats"
+  }
+];
+
+<LightBox
+  slideShowImages={images}
+  thumbnails={images}
+  trigger={<Button>Punch It!</Button>}
+/>;
+```
+
+### Single Image
+
+```jsx
+const images = [
+  {
+    url: "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
+    descriptionText: "Two cats"
+  }
+];
+
+<LightBox
+  slideShowImages={images}
+  thumbnails={images}
+  trigger={<Button>Punch It!</Button>}
+/>;
+```

--- a/src/components/media/LightBox/component.js
+++ b/src/components/media/LightBox/component.js
@@ -1,0 +1,64 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { Modal } from 'elements/Modal';
+import { Slideshow } from 'media/Slideshow';
+import { testidFactory } from 'utils/testid';
+
+const TEST_ID_PREFIX = 'lightbox';
+
+const testid = testidFactory(TEST_ID_PREFIX);
+
+/**
+ * A LightBox which displays an image or a series of images in a modal.
+ */
+// eslint-disable-next-line jsdoc/require-jsdoc
+export const Component = ({ slideShowImages, trigger }) => {
+  const areThumbnailsActive = slideShowImages.length > 1;
+
+  return (
+    <Modal
+      className="is-lightbox"
+      data-testid={testid()}
+      hasCloseIcon
+      isFullscreen
+      trigger={trigger}
+    >
+      <Slideshow
+        hasShadow={false}
+        images={slideShowImages}
+        isRounded={false}
+        isShowingBulletNavigation={false}
+        isShowingIndex={areThumbnailsActive}
+        isShowingThumbnails={areThumbnailsActive}
+        thumbnails={slideShowImages}
+      />
+    </Modal>
+  );
+};
+
+Component.displayName = 'LightBox';
+
+Component.defaultProps = {
+  trigger: null,
+};
+
+Component.propTypes = {
+  /**  The images to display inside the Slideshow. */
+  slideShowImages: PropTypes.arrayOf(
+    PropTypes.shape({
+      /** A description of the image to show above the slideshow when the image is showing. */
+      descriptionText: PropTypes.string,
+      /** A list of one or more strings separated by commas indicating a set of source sizes. See [the MDN docs for more information](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img). */
+      sizes: PropTypes.string,
+      /** A list of one or more strings separated by commas indicating a set of possible image sources for the user agent to use. See [the MDN docs for more information](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img). */
+      srcSet: PropTypes.string,
+      /** Title of the image to show when hovering over it on desktop browsers. */
+      title: PropTypes.string,
+      /** URL pointing to the image to display. */
+      url: PropTypes.string.isRequired,
+    })
+  ).isRequired,
+  /** The element to be clicked to display the modal. */
+  trigger: PropTypes.node,
+};

--- a/src/components/media/LightBox/component.spec.js
+++ b/src/components/media/LightBox/component.spec.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import { testidSelectorFactory } from 'utils/testid';
+
+import { Component as LigthBox } from './component';
+
+const props = {
+  slideShowImages: [
+    {
+      url: 'https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg',
+      descriptionText: 'Two cats',
+    },
+    {
+      url: 'https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg',
+      descriptionText: 'Two more cats',
+    },
+    {
+      url: 'https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg',
+      descriptionText: 'Much cats',
+    },
+  ],
+};
+
+const testid = testidSelectorFactory('lightbox');
+const shallowLightBox = props => mount(<LigthBox {...props} />);
+
+describe('`LightBox`', () => {
+  it('should render a `LightBox` component', () => {
+    const component = shallowLightBox(props);
+
+    expect(component.find(testid()).length).toEqual(1);
+  });
+});

--- a/src/components/media/LightBox/index.js
+++ b/src/components/media/LightBox/index.js
@@ -1,0 +1,1 @@
+export { Component as LightBox } from './component';

--- a/src/components/media/Slideshow/utils/__snapshots__/adaptImages.spec.js.snap
+++ b/src/components/media/Slideshow/utils/__snapshots__/adaptImages.spec.js.snap
@@ -12,7 +12,6 @@ Array [
         https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&h=1000&mode=max 1024w",
     "thumbnail": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
     "thumbnailAlt": "Two cats",
-    "thumbnailLabel": "Two cats",
   },
   Object {
     "original": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
@@ -24,7 +23,6 @@ Array [
         https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&h=1000&mode=max 1024w",
     "thumbnail": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
     "thumbnailAlt": "Two more cats",
-    "thumbnailLabel": "Two more cats",
   },
   Object {
     "original": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
@@ -36,7 +34,6 @@ Array [
         https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&h=1000&mode=max 1024w",
     "thumbnail": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
     "thumbnailAlt": "Much cats",
-    "thumbnailLabel": "Much cats",
   },
   Object {
     "original": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
@@ -48,7 +45,6 @@ Array [
         https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg?w=1024&h=1000&mode=max 1024w",
     "thumbnail": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
     "thumbnailAlt": "No dogs",
-    "thumbnailLabel": "No dogs",
   },
 ]
 `;

--- a/src/components/media/Slideshow/utils/adaptImages.js
+++ b/src/components/media/Slideshow/utils/adaptImages.js
@@ -10,7 +10,6 @@ export const adaptImages = images =>
     originalTitle: title,
     thumbnail: url,
     thumbnailAlt: title,
-    thumbnailLabel: title,
     sizes,
     srcSet,
   }));

--- a/src/components/property-page-widgets/Pictures/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Pictures/__snapshots__/component.spec.js.snap
@@ -1278,11 +1278,11 @@ exports[`<Pictures /> should render the correct structure 1`] = `
                 }
               >
                 <Modal
+                  className={null}
                   hasCloseIcon={true}
                   hasPadding={true}
                   hasRoundedCorners={false}
                   header={null}
-                  isDark={false}
                   isFullscreen={true}
                   onClose={[Function]}
                   size="tiny"

--- a/src/components/property-page-widgets/PolicyAndNotes/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/PolicyAndNotes/__snapshots__/component.spec.js.snap
@@ -378,11 +378,11 @@ exports[`<PolicyAndNotes /> if \`props.extraNotesText\` is passed should have th
                     className="top aligned twelve wide column"
                   >
                     <Modal
+                      className={null}
                       hasCloseIcon={true}
                       hasPadding={true}
                       hasRoundedCorners={false}
                       header={null}
-                      isDark={false}
                       isFullscreen={false}
                       onClose={[Function]}
                       size="tiny"

--- a/src/components/property-page-widgets/PropertyPageHero/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/PropertyPageHero/__snapshots__/component.spec.js.snap
@@ -768,11 +768,11 @@ exports[`PropertyPageHero should render the right structure 1`] = `
                       }
                     >
                       <Modal
+                        className={null}
                         hasCloseIcon={true}
                         hasPadding={true}
                         hasRoundedCorners={false}
                         header={null}
-                        isDark={false}
                         isFullscreen={true}
                         onClose={[Function]}
                         size="tiny"

--- a/src/components/property-page-widgets/PropertyPageSearchBar/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/PropertyPageSearchBar/__snapshots__/component.spec.js.snap
@@ -799,6 +799,7 @@ exports[`<PropertyPageSearchBar /> if \`isShowingPlaceholder\` === true should h
                         willLocationDropdownOpenAbove={false}
                       >
                         <Modal
+                          className={null}
                           hasCloseIcon={true}
                           hasPadding={true}
                           hasRoundedCorners={false}
@@ -813,7 +814,6 @@ exports[`<PropertyPageSearchBar /> if \`isShowingPlaceholder\` === true should h
                               Check our availability
                             </Heading>
                           }
-                          isDark={false}
                           isFullscreen={true}
                           isOpen={false}
                           onClose={[Function]}
@@ -1737,6 +1737,7 @@ exports[`<PropertyPageSearchBar /> if \`isShowingPlaceholder\` === true should h
                         willLocationDropdownOpenAbove={false}
                       >
                         <Modal
+                          className={null}
                           hasCloseIcon={true}
                           hasPadding={true}
                           hasRoundedCorners={false}
@@ -1752,7 +1753,6 @@ exports[`<PropertyPageSearchBar /> if \`isShowingPlaceholder\` === true should h
                               ratingNumber={4.5}
                             />
                           }
-                          isDark={false}
                           isFullscreen={true}
                           isOpen={false}
                           onClose={[Function]}
@@ -2934,6 +2934,7 @@ exports[`<PropertyPageSearchBar /> should have the right structure 1`] = `
                         willLocationDropdownOpenAbove={false}
                       >
                         <Modal
+                          className={null}
                           hasCloseIcon={true}
                           hasPadding={true}
                           hasRoundedCorners={false}
@@ -2948,7 +2949,6 @@ exports[`<PropertyPageSearchBar /> should have the right structure 1`] = `
                               Check our availability
                             </Heading>
                           }
-                          isDark={false}
                           isFullscreen={true}
                           isOpen={false}
                           onClose={[Function]}
@@ -4038,6 +4038,7 @@ exports[`<PropertyPageSearchBar /> should have the right structure 1`] = `
                         willLocationDropdownOpenAbove={false}
                       >
                         <Modal
+                          className={null}
                           hasCloseIcon={true}
                           hasPadding={true}
                           hasRoundedCorners={false}
@@ -4053,7 +4054,6 @@ exports[`<PropertyPageSearchBar /> should have the right structure 1`] = `
                               ratingNumber={4.5}
                             />
                           }
-                          isDark={false}
                           isFullscreen={true}
                           isOpen={false}
                           onClose={[Function]}

--- a/src/components/property-page-widgets/Reviews/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Reviews/__snapshots__/component.spec.js.snap
@@ -154,11 +154,11 @@ exports[`<Reviews /> if \`props.isShowingPlaceholder\` is \`true\` if \`props.re
                     className="right floated top aligned six wide computer seven wide mobile seven wide tablet column"
                   >
                     <Modal
+                      className={null}
                       hasCloseIcon={true}
                       hasPadding={false}
                       hasRoundedCorners={false}
                       header={null}
-                      isDark={false}
                       isFullscreen={false}
                       onClose={[Function]}
                       size="tiny"
@@ -1248,11 +1248,11 @@ exports[`<Reviews /> if \`props.isShowingPlaceholder\` is \`true\` should render
                     className="right floated top aligned six wide computer seven wide mobile seven wide tablet column"
                   >
                     <Modal
+                      className={null}
                       hasCloseIcon={true}
                       hasPadding={false}
                       hasRoundedCorners={false}
                       header={null}
-                      isDark={false}
                       isFullscreen={false}
                       onClose={[Function]}
                       size="tiny"
@@ -2365,11 +2365,11 @@ exports[`<Reviews /> should render the right structure 1`] = `
                     className="right floated top aligned six wide computer seven wide mobile seven wide tablet column"
                   >
                     <Modal
+                      className={null}
                       hasCloseIcon={true}
                       hasPadding={false}
                       hasRoundedCorners={false}
                       header={null}
-                      isDark={false}
                       isFullscreen={false}
                       onClose={[Function]}
                       size="tiny"

--- a/src/components/property-page-widgets/Reviews/utils/__snapshots__/getModalFormMarkup.spec.js.snap
+++ b/src/components/property-page-widgets/Reviews/utils/__snapshots__/getModalFormMarkup.spec.js.snap
@@ -2,11 +2,11 @@
 
 exports[`getModalFormMarkup if \`isBotProtected\` === true should render the right structure 1`] = `
 <Modal
+  className={null}
   hasCloseIcon={true}
   hasPadding={false}
   hasRoundedCorners={false}
   header={null}
-  isDark={false}
   isFullscreen={false}
   onClose={[Function]}
   size="tiny"
@@ -190,11 +190,11 @@ exports[`getModalFormMarkup if \`isBotProtected\` === true should render the rig
 
 exports[`getModalFormMarkup if \`isPrivacyConsentRequired\` is \`truthy\` should render the right structure 1`] = `
 <Modal
+  className={null}
   hasCloseIcon={true}
   hasPadding={false}
   hasRoundedCorners={false}
   header={null}
-  isDark={false}
   isFullscreen={false}
   onClose={[Function]}
   size="tiny"
@@ -378,11 +378,11 @@ exports[`getModalFormMarkup if \`isPrivacyConsentRequired\` is \`truthy\` should
 
 exports[`getModalFormMarkup if \`isShowingPlaceholder\` is \`true\` should render the right structure 1`] = `
 <Modal
+  className={null}
   hasCloseIcon={true}
   hasPadding={false}
   hasRoundedCorners={false}
   header={null}
-  isDark={false}
   isFullscreen={false}
   onClose={[Function]}
   size="tiny"
@@ -572,11 +572,11 @@ exports[`getModalFormMarkup if \`isShowingPlaceholder\` is \`true\` should rende
 
 exports[`getModalFormMarkup should have the right structure with default props 1`] = `
 <Modal
+  className={null}
   hasCloseIcon={true}
   hasPadding={false}
   hasRoundedCorners={false}
   header={null}
-  isDark={false}
   isFullscreen={false}
   onClose={[Function]}
   size="tiny"
@@ -748,11 +748,11 @@ exports[`getModalFormMarkup should have the right structure with default props 1
 
 exports[`getModalFormMarkup should render the right structure when props are passed 1`] = `
 <Modal
+  className={null}
   hasCloseIcon={true}
   hasPadding={false}
   hasRoundedCorners={false}
   header={null}
-  isDark={false}
   isFullscreen={false}
   onClose={[Function]}
   size="tiny"

--- a/src/components/property-page-widgets/RoomType/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/RoomType/__snapshots__/component.spec.js.snap
@@ -150,7 +150,6 @@ exports[`<RoomType /> by default should render the correct structure 1`] = `
                                   "srcSet": undefined,
                                   "thumbnail": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
                                   "thumbnailAlt": "Two cats",
-                                  "thumbnailLabel": "Two cats",
                                 },
                                 Object {
                                   "original": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
@@ -160,7 +159,6 @@ exports[`<RoomType /> by default should render the correct structure 1`] = `
                                   "srcSet": undefined,
                                   "thumbnail": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
                                   "thumbnailAlt": "Two more cats",
-                                  "thumbnailLabel": "Two more cats",
                                 },
                                 Object {
                                   "original": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
@@ -170,7 +168,6 @@ exports[`<RoomType /> by default should render the correct structure 1`] = `
                                   "srcSet": undefined,
                                   "thumbnail": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
                                   "thumbnailAlt": "Much cats",
-                                  "thumbnailLabel": "Much cats",
                                 },
                               ]
                             }
@@ -194,7 +191,6 @@ exports[`<RoomType /> by default should render the correct structure 1`] = `
                                   "srcSet": undefined,
                                   "thumbnail": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
                                   "thumbnailAlt": "Two cats",
-                                  "thumbnailLabel": "Two cats",
                                 },
                                 Object {
                                   "original": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
@@ -204,7 +200,6 @@ exports[`<RoomType /> by default should render the correct structure 1`] = `
                                   "srcSet": undefined,
                                   "thumbnail": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
                                   "thumbnailAlt": "Two more cats",
-                                  "thumbnailLabel": "Two more cats",
                                 },
                                 Object {
                                   "original": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
@@ -214,7 +209,6 @@ exports[`<RoomType /> by default should render the correct structure 1`] = `
                                   "srcSet": undefined,
                                   "thumbnail": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
                                   "thumbnailAlt": "Much cats",
-                                  "thumbnailLabel": "Much cats",
                                 },
                               ]
                             }
@@ -309,11 +303,11 @@ exports[`<RoomType /> by default should render the correct structure 1`] = `
                                     className="mobile only right aligned middle aligned two wide column"
                                   >
                                     <Modal
+                                      className={null}
                                       hasCloseIcon={true}
                                       hasPadding={true}
                                       hasRoundedCorners={false}
                                       header={null}
-                                      isDark={false}
                                       isFullscreen={false}
                                       onClose={[Function]}
                                       size="tiny"
@@ -563,11 +557,11 @@ exports[`<RoomType /> by default should render the correct structure 1`] = `
                                           className="tablet only computer only bottom aligned four wide column"
                                         >
                                           <Modal
+                                            className={null}
                                             hasCloseIcon={true}
                                             hasPadding={true}
                                             hasRoundedCorners={false}
                                             header={null}
-                                            isDark={false}
                                             isFullscreen={false}
                                             onClose={[Function]}
                                             size="small"
@@ -1211,7 +1205,6 @@ exports[`<RoomType /> if \`isUserOnMobile === true\` should render the correct s
                                   "srcSet": undefined,
                                   "thumbnail": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
                                   "thumbnailAlt": "Two cats",
-                                  "thumbnailLabel": "Two cats",
                                 },
                                 Object {
                                   "original": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
@@ -1221,7 +1214,6 @@ exports[`<RoomType /> if \`isUserOnMobile === true\` should render the correct s
                                   "srcSet": undefined,
                                   "thumbnail": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
                                   "thumbnailAlt": "Two more cats",
-                                  "thumbnailLabel": "Two more cats",
                                 },
                                 Object {
                                   "original": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
@@ -1231,7 +1223,6 @@ exports[`<RoomType /> if \`isUserOnMobile === true\` should render the correct s
                                   "srcSet": undefined,
                                   "thumbnail": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
                                   "thumbnailAlt": "Much cats",
-                                  "thumbnailLabel": "Much cats",
                                 },
                               ]
                             }
@@ -1255,7 +1246,6 @@ exports[`<RoomType /> if \`isUserOnMobile === true\` should render the correct s
                                   "srcSet": undefined,
                                   "thumbnail": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
                                   "thumbnailAlt": "Two cats",
-                                  "thumbnailLabel": "Two cats",
                                 },
                                 Object {
                                   "original": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
@@ -1265,7 +1255,6 @@ exports[`<RoomType /> if \`isUserOnMobile === true\` should render the correct s
                                   "srcSet": undefined,
                                   "thumbnail": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
                                   "thumbnailAlt": "Two more cats",
-                                  "thumbnailLabel": "Two more cats",
                                 },
                                 Object {
                                   "original": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
@@ -1275,7 +1264,6 @@ exports[`<RoomType /> if \`isUserOnMobile === true\` should render the correct s
                                   "srcSet": undefined,
                                   "thumbnail": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
                                   "thumbnailAlt": "Much cats",
-                                  "thumbnailLabel": "Much cats",
                                 },
                               ]
                             }
@@ -1370,11 +1358,11 @@ exports[`<RoomType /> if \`isUserOnMobile === true\` should render the correct s
                                     className="mobile only right aligned middle aligned two wide column"
                                   >
                                     <Modal
+                                      className={null}
                                       hasCloseIcon={true}
                                       hasPadding={true}
                                       hasRoundedCorners={false}
                                       header={null}
-                                      isDark={false}
                                       isFullscreen={false}
                                       onClose={[Function]}
                                       size="tiny"
@@ -1596,11 +1584,11 @@ exports[`<RoomType /> if \`isUserOnMobile === true\` should render the correct s
                                           className="tablet only computer only bottom aligned four wide column"
                                         >
                                           <Modal
+                                            className={null}
                                             hasCloseIcon={true}
                                             hasPadding={true}
                                             hasRoundedCorners={false}
                                             header={null}
-                                            isDark={false}
                                             isFullscreen={false}
                                             onClose={[Function]}
                                             size="small"

--- a/src/components/property-page-widgets/RoomType/utils/__snapshots__/getModalContentMarkup.spec.js.snap
+++ b/src/components/property-page-widgets/RoomType/utils/__snapshots__/getModalContentMarkup.spec.js.snap
@@ -218,7 +218,6 @@ exports[`getModalContentMarkup if \`props.amenities\` size is zero should not re
               "srcSet": undefined,
               "thumbnail": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
               "thumbnailAlt": "Two cats",
-              "thumbnailLabel": "Two cats",
             },
           ]
         }
@@ -242,7 +241,6 @@ exports[`getModalContentMarkup if \`props.amenities\` size is zero should not re
               "srcSet": undefined,
               "thumbnail": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
               "thumbnailAlt": "Two cats",
-              "thumbnailLabel": "Two cats",
             },
           ]
         }
@@ -621,7 +619,6 @@ exports[`getModalContentMarkup if \`props.description\` === null should not rend
               "srcSet": undefined,
               "thumbnail": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
               "thumbnailAlt": "Two cats",
-              "thumbnailLabel": "Two cats",
             },
           ]
         }
@@ -645,7 +642,6 @@ exports[`getModalContentMarkup if \`props.description\` === null should not rend
               "srcSet": undefined,
               "thumbnail": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
               "thumbnailAlt": "Two cats",
-              "thumbnailLabel": "Two cats",
             },
           ]
         }
@@ -1080,7 +1076,6 @@ exports[`getModalContentMarkup if \`props.ratingNumber\` === null should not ren
               "srcSet": undefined,
               "thumbnail": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
               "thumbnailAlt": "Two cats",
-              "thumbnailLabel": "Two cats",
             },
           ]
         }
@@ -1104,7 +1099,6 @@ exports[`getModalContentMarkup if \`props.ratingNumber\` === null should not ren
               "srcSet": undefined,
               "thumbnail": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
               "thumbnailAlt": "Two cats",
-              "thumbnailLabel": "Two cats",
             },
           ]
         }
@@ -1715,7 +1709,6 @@ exports[`getModalContentMarkup if \`props.slideShowImages.length\` > 1 should re
               "srcSet": undefined,
               "thumbnail": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
               "thumbnailAlt": "Two cats",
-              "thumbnailLabel": "Two cats",
             },
             Object {
               "original": "https://si5.cdbcdn.com/oh/c2d7df79-2d68-4fdf-a3ab-f6af3da46a77.jpg",
@@ -1725,7 +1718,6 @@ exports[`getModalContentMarkup if \`props.slideShowImages.length\` > 1 should re
               "srcSet": undefined,
               "thumbnail": "https://si5.cdbcdn.com/oh/c2d7df79-2d68-4fdf-a3ab-f6af3da46a77.jpg",
               "thumbnailAlt": "Two cats",
-              "thumbnailLabel": "Two cats",
             },
           ]
         }
@@ -1749,7 +1741,6 @@ exports[`getModalContentMarkup if \`props.slideShowImages.length\` > 1 should re
               "srcSet": undefined,
               "thumbnail": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
               "thumbnailAlt": "Two cats",
-              "thumbnailLabel": "Two cats",
             },
             Object {
               "original": "https://si5.cdbcdn.com/oh/c2d7df79-2d68-4fdf-a3ab-f6af3da46a77.jpg",
@@ -1759,7 +1750,6 @@ exports[`getModalContentMarkup if \`props.slideShowImages.length\` > 1 should re
               "srcSet": undefined,
               "thumbnail": "https://si5.cdbcdn.com/oh/c2d7df79-2d68-4fdf-a3ab-f6af3da46a77.jpg",
               "thumbnailAlt": "Two cats",
-              "thumbnailLabel": "Two cats",
             },
           ]
         }
@@ -2366,7 +2356,6 @@ exports[`getModalContentMarkup should return the correct structure 1`] = `
               "srcSet": undefined,
               "thumbnail": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
               "thumbnailAlt": "Two cats",
-              "thumbnailLabel": "Two cats",
             },
           ]
         }
@@ -2390,7 +2379,6 @@ exports[`getModalContentMarkup should return the correct structure 1`] = `
               "srcSet": undefined,
               "thumbnail": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
               "thumbnailAlt": "Two cats",
-              "thumbnailLabel": "Two cats",
             },
           ]
         }

--- a/src/components/property-page-widgets/RoomTypes/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/RoomTypes/__snapshots__/component.spec.js.snap
@@ -1710,7 +1710,6 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                         "srcSet": undefined,
                                         "thumbnail": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
                                         "thumbnailAlt": "Two more cats",
-                                        "thumbnailLabel": "Two more cats",
                                       },
                                       Object {
                                         "original": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
@@ -1720,7 +1719,6 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                         "srcSet": undefined,
                                         "thumbnail": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
                                         "thumbnailAlt": "Some cats",
-                                        "thumbnailLabel": "Some cats",
                                       },
                                     ]
                                   }
@@ -1744,7 +1742,6 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                         "srcSet": undefined,
                                         "thumbnail": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
                                         "thumbnailAlt": "Two more cats",
-                                        "thumbnailLabel": "Two more cats",
                                       },
                                       Object {
                                         "original": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
@@ -1754,7 +1751,6 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                         "srcSet": undefined,
                                         "thumbnail": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
                                         "thumbnailAlt": "Some cats",
-                                        "thumbnailLabel": "Some cats",
                                       },
                                     ]
                                   }
@@ -1849,11 +1845,11 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                           className="mobile only right aligned middle aligned two wide column"
                                         >
                                           <Modal
+                                            className={null}
                                             hasCloseIcon={true}
                                             hasPadding={true}
                                             hasRoundedCorners={false}
                                             header={null}
-                                            isDark={false}
                                             isFullscreen={false}
                                             onClose={[Function]}
                                             size="tiny"
@@ -2201,11 +2197,11 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                                 className="tablet only computer only bottom aligned four wide column"
                                               >
                                                 <Modal
+                                                  className={null}
                                                   hasCloseIcon={true}
                                                   hasPadding={true}
                                                   hasRoundedCorners={false}
                                                   header={null}
-                                                  isDark={false}
                                                   isFullscreen={false}
                                                   onClose={[Function]}
                                                   size="small"
@@ -2699,7 +2695,6 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                         "srcSet": undefined,
                                         "thumbnail": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
                                         "thumbnailAlt": "Two more cats",
-                                        "thumbnailLabel": "Two more cats",
                                       },
                                       Object {
                                         "original": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
@@ -2709,7 +2704,6 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                         "srcSet": undefined,
                                         "thumbnail": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
                                         "thumbnailAlt": "Some cats",
-                                        "thumbnailLabel": "Some cats",
                                       },
                                     ]
                                   }
@@ -2733,7 +2727,6 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                         "srcSet": undefined,
                                         "thumbnail": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
                                         "thumbnailAlt": "Two more cats",
-                                        "thumbnailLabel": "Two more cats",
                                       },
                                       Object {
                                         "original": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
@@ -2743,7 +2736,6 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                         "srcSet": undefined,
                                         "thumbnail": "https://li3.cdbcdn.com/oh/522a12d9-ab51-4635-94c1-42536f286e4d.jpg",
                                         "thumbnailAlt": "Some cats",
-                                        "thumbnailLabel": "Some cats",
                                       },
                                     ]
                                   }
@@ -2838,11 +2830,11 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                           className="mobile only right aligned middle aligned two wide column"
                                         >
                                           <Modal
+                                            className={null}
                                             hasCloseIcon={true}
                                             hasPadding={true}
                                             hasRoundedCorners={false}
                                             header={null}
-                                            isDark={false}
                                             isFullscreen={false}
                                             onClose={[Function]}
                                             size="tiny"
@@ -3190,11 +3182,11 @@ exports[`<RoomTypes /> should render the right structure 1`] = `
                                                 className="tablet only computer only bottom aligned four wide column"
                                               >
                                                 <Modal
+                                                  className={null}
                                                   hasCloseIcon={true}
                                                   hasPadding={true}
                                                   hasRoundedCorners={false}
                                                   header={null}
-                                                  isDark={false}
                                                   isFullscreen={false}
                                                   onClose={[Function]}
                                                   size="small"

--- a/src/index.js
+++ b/src/index.js
@@ -1,20 +1,14 @@
 // Collections
 export { Characteristics } from './components/collections/Characteristics';
-export {
-  CheckboxInputSegment,
-} from './components/collections/CheckboxInputSegment';
-export {
-  CounterInputSegment,
-} from './components/collections/CounterInputSegment';
+export { CheckboxInputSegment } from './components/collections/CheckboxInputSegment';
+export { CounterInputSegment } from './components/collections/CounterInputSegment';
 export { Footer } from './components/collections/Footer';
 export { Form } from './components/collections/Form';
 export { Header } from './components/collections/Header';
 export { Hero } from './components/collections/Hero';
 export { InputGroup } from './components/collections/InputGroup';
 export { TextInputSegment } from './components/collections/TextInputSegment';
-export {
-  ToggleInputSegment,
-} from './components/collections/ToggleInputSegment';
+export { ToggleInputSegment } from './components/collections/ToggleInputSegment';
 export { RangeInputSegment } from './components/collections/RangeInputSegment';
 
 // Elements
@@ -41,29 +35,17 @@ export { SummaryCard } from './components/elements/SummaryCard';
 export { CallMeBack } from './components/general-widgets/CallMeBack';
 export { Contact } from './components/general-widgets/Contact';
 export { CookieAlert } from './components/general-widgets/CookieAlert';
-export {
-  FeaturedProperties,
-} from './components/general-widgets/FeaturedProperties';
-export {
-  FeaturedProperty,
-} from './components/general-widgets/FeaturedProperty';
-export {
-  FeaturedRoomType,
-} from './components/general-widgets/FeaturedRoomType';
-export {
-  FeaturedRoomTypes,
-} from './components/general-widgets/FeaturedRoomTypes';
+export { FeaturedProperties } from './components/general-widgets/FeaturedProperties';
+export { FeaturedProperty } from './components/general-widgets/FeaturedProperty';
+export { FeaturedRoomType } from './components/general-widgets/FeaturedRoomType';
+export { FeaturedRoomTypes } from './components/general-widgets/FeaturedRoomTypes';
 export { HomepageHero } from './components/general-widgets/HomepageHero';
 export { HTML } from './components/general-widgets/HTML';
 export { OwnerLogin } from './components/general-widgets/OwnerLogin';
 export { OwnerSignUp } from './components/general-widgets/OwnerSignUp';
 export { Promotion } from './components/general-widgets/Promotion';
-export {
-  PropertySearchResult,
-} from './components/general-widgets/PropertySearchResult';
-export {
-  PropertySearchResultList,
-} from './components/general-widgets/PropertySearchResultList';
+export { PropertySearchResult } from './components/general-widgets/PropertySearchResult';
+export { PropertySearchResultList } from './components/general-widgets/PropertySearchResultList';
 export { Review } from './components/general-widgets/Review';
 export { SearchBar } from './components/general-widgets/SearchBar';
 
@@ -98,6 +80,7 @@ export { Viewport } from './components/layout/Viewport';
 // Media
 export { FullBleed } from './components/media/FullBleed';
 export { Gallery } from './components/media/Gallery';
+export { LightBox } from './components/media/LightBox';
 export { ResponsiveImage } from './components/media/ResponsiveImage';
 export { Slideshow } from './components/media/Slideshow';
 export { Thumbnail } from './components/media/Thumbnail';
@@ -110,24 +93,16 @@ export { Description } from './components/property-page-widgets/Description';
 export { HostProfile } from './components/property-page-widgets/HostProfile';
 export { KeyFacts } from './components/property-page-widgets/KeyFacts';
 export { Location } from './components/property-page-widgets/Location';
-export {
-  PolicyAndNotes,
-} from './components/property-page-widgets/PolicyAndNotes';
-export {
-  PropertyPageHero,
-} from './components/property-page-widgets/PropertyPageHero';
+export { PolicyAndNotes } from './components/property-page-widgets/PolicyAndNotes';
+export { PropertyPageHero } from './components/property-page-widgets/PropertyPageHero';
 export { Pictures } from './components/property-page-widgets/Pictures';
-export {
-  PropertyPageSearchBar,
-} from './components/property-page-widgets/PropertyPageSearchBar';
+export { PropertyPageSearchBar } from './components/property-page-widgets/PropertyPageSearchBar';
 export { RoomType } from './components/property-page-widgets/RoomType';
 export { RoomTypes } from './components/property-page-widgets/RoomTypes';
 export { Rates } from './components/property-page-widgets/Rates';
 export { Reviews } from './components/property-page-widgets/Reviews';
 export { Rules } from './components/property-page-widgets/Rules';
-export {
-  SleepingArrangements,
-} from './components/property-page-widgets/SleepingArrangements';
+export { SleepingArrangements } from './components/property-page-widgets/SleepingArrangements';
 export { Summary } from './components/property-page-widgets/Summary';
 
 // Typography

--- a/src/styles/semantic/definitions/lodgify-ui-components/lightbox.less
+++ b/src/styles/semantic/definitions/lodgify-ui-components/lightbox.less
@@ -1,0 +1,112 @@
+/*******************************
+            Theme
+*******************************/
+
+@type: "lodgify-ui-component";
+
+@element: "lightbox";
+
+@import (multiple) "../../theme.config";
+
+/*--------------------------
+        LightBox
+--------------------------*/
+
+.modals {
+  .modal {
+    &.is-lightbox {
+      &.fullscreen > .icon > svg {
+        background-color: transparent;
+        box-shadow: @lightboxButtonBoxShadow;
+      }
+
+      > .content {
+        background-color: @lightboxContentBackgroundColor;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        flex-direction: column;
+        overflow: hidden;
+
+        > p {
+          color: @white;
+        }
+
+        .image-gallery {
+          width: 100%;
+
+          .image-gallery-content {
+            .image-gallery-slide-wrapper {
+              height: @lightboxSlideshowContentHeight;
+              max-height: @lightboxSlideshowContentMaxHeight;
+              display: flex;
+              flex-direction: column;
+              justify-content: center;
+              margin-bottom: @lightboxSlideshowContentMarginBottom;
+
+              @media only screen and (max-width: @computerBreakpoint) {
+                min-height: @lightboxSlideshowContentMinHeight;
+              }
+
+              .image-gallery-index {
+                background-color: transparent;
+                top: initial;
+                align-self: center;
+                right: initial;
+                bottom: @lightboxSlideshowIndexBottomOffset;
+              }
+
+              .ui.circular.button {
+                background: transparent;
+                box-shadow: @lightboxButtonBoxShadow;
+              }
+            }
+
+            .image-gallery-thumbnails-wrapper {
+              &:before {
+                content: "";
+                width: @lightboxThumbnailLinearGradientWidth;
+                height: @lightboxThumbnailLinearGradientHeight;
+                position: absolute;
+                z-index: @lightboxThumbnailLinearGradientZIndex;
+                background: @lightboxThumbnailLinearGradientBackgroundColor;
+                background: @lightboxThumbnailLinearGradientLeft;
+                left: 0;
+                top: @lightboxThumbnailActiveGradientTopOffset;
+              }
+
+              &:after {
+                content: "";
+                width: @lightboxThumbnailLinearGradientWidth;
+                height: @lightboxThumbnailLinearGradientHeight;
+                position: absolute;
+                z-index: @lightboxThumbnailLinearGradientZIndex;
+                background: @lightboxThumbnailLinearGradientBackgroundColor;
+                background: @lightboxThumbnailLinearGradientRight;
+                right: 0;
+                top: @lightboxThumbnailActiveGradientTopOffset;
+              }
+
+              .image-gallery-thumbnails {
+                padding: @lightboxThumbnailWrapperPadding;
+
+                .image-gallery-thumbnails-container {
+                  .image-gallery-thumbnail {
+                    display: flex;
+                    align-items: center;
+                    transition: @lightboxThumbnailActiveTransition;
+
+                    &.active {
+                      box-shadow: @lightboxThumbNailActiveBoxShadow;
+                      transition: @lightboxThumbnailActiveTransition;
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/styles/semantic/lightbox.less
+++ b/src/styles/semantic/lightbox.less
@@ -1,0 +1,3 @@
+& {
+  @import "./definitions/lodgify-ui-components/lightbox.less";
+}

--- a/src/styles/semantic/lodgify-ui.less
+++ b/src/styles/semantic/lodgify-ui.less
@@ -138,5 +138,8 @@
 & {
   @import "./multi-paragraph.less";
 }
+& {
+  @import "./lightbox.less";
+}
 
 /* stylelint-enable no-duplicate-selectors */

--- a/src/styles/semantic/theme.config
+++ b/src/styles/semantic/theme.config
@@ -83,6 +83,7 @@
 @filter-trigger           : 'default';
 @flex-container           : 'default';
 @html                     : 'default';
+@lightbox                 : 'default';
 @marker                   : 'default';
 @property-page-search-bar : 'default';
 @property-search-result-list : 'default';

--- a/src/styles/semantic/themes/default/lodgify-ui-components/lightbox.variables
+++ b/src/styles/semantic/themes/default/lodgify-ui-components/lightbox.variables
@@ -1,0 +1,26 @@
+/*--------------------------
+  LightBox
+--------------------------*/
+@lightboxButtonBoxShadow: 0 0 0 1px rgba(255, 255, 255, 0.1);
+
+@lightboxContentBackgroundColor: rgba(0, 0, 0, 0.9);
+
+@lightboxSlideshowContentHeight: ~"calc(45vw - 130px)";
+@lightboxSlideshowContentMinHeight: 35vw;
+@lightboxSlideshowContentMaxHeight: 600px;
+@lightboxSlideshowContentMarginBottom: 45px;
+
+@lightboxSlideshowIndexBottomOffset: -40px;
+
+@lightboxThumbnailLinearGradientWidth: 50px;
+@lightboxThumbnailLinearGradientHeight: 102%;
+@lightboxThumbnailLinearGradientBackgroundColor: #191919;
+@lightboxThumbnailLinearGradientZIndex: 2;
+@lightboxThumbnailLinearGradientRight: linear-gradient(270deg, @lightboxThumbnailLinearGradientBackgroundColor 30%, rgba(25, 25, 25, 0) 100%);
+@lightboxThumbnailLinearGradientLeft: linear-gradient(90deg, @lightboxThumbnailLinearGradientBackgroundColor 30%, rgba(25, 25, 25, 0) 100%);
+@lightboxThumbnailActiveGradientTopOffset: -1px;
+@lightboxThumbnailWrapperPadding: 5px @lightBoxThumbNailActiveBoxShadowOutlineWidth;
+@lightboxThumbnailActiveTransition: transform 0.2s linear;
+@lightboxThumbnailActiveTranslationY: translateY(-8px);
+@lightboxThumbNailActiveBoxShadow: 0 0 0 1px rgba(255, 255, 255, 0.41);
+@lightBoxThumbNailActiveBoxShadowOutlineWidth: 1px;


### PR DESCRIPTION
[Related Jira issue](https://lodgify.atlassian.net/browse/WEB-682)

### What **one** thing does this PR do?

* Exposes a brand new `LightBox` component. ✨ 
* Removes `isDark` from `Modal` and exposes `className` instead; since there is 1 use case for `isDark` and dark background needs to be applied to `Modal Content` instead of `Modal Dimmer`.
* Introduces slight style modifications from user story, the aim of which is to refine the appearance of the ui when dark background are used.

* Introduces `--coverage` flag to `test:watch`; this triggering instanbul coverage report `exclusively` for the files that changed every time.

### Behaviour
![Kapture 2019-11-22 at 11 09 45](https://user-images.githubusercontent.com/33876435/69418954-eaa23b00-0d1b-11ea-902d-cae630e27f75.gif)

![6b5f80da4f564b4f895d03068854dc49](https://user-images.githubusercontent.com/33876435/69418976-f7bf2a00-0d1b-11ea-89f8-e01ea2ddfe91.gif)

<img width="1402" alt="Screenshot 2019-11-22 at 11 34 34" src="https://user-images.githubusercontent.com/33876435/69419055-17565280-0d1c-11ea-80c1-7515888a5dcd.png">


