### PR TITLE
WEB-743 Expose id for property page components

### DIFF
--- a/src/components/property-page-widgets/Amenities/component.js
+++ b/src/components/property-page-widgets/Amenities/component.js
@@ -18,6 +18,7 @@ import { getExtraItems } from './utils/getExtraItems';
  */
 // eslint-disable-next-line jsdoc/require-jsdoc
 export const Component = ({
+  id,
   amenities,
   hasExtraItemsInModal,
   headingText,
@@ -25,7 +26,12 @@ export const Component = ({
   modalTriggerText,
   amenitiesConjunctionText,
 }) => (
-  <Grid className="is-amenities" columns={isStacked ? 1 : 3} isStackable>
+  <Grid
+    className="is-amenities"
+    columns={isStacked ? 1 : 3}
+    id={id}
+    isStackable
+  >
     <GridRow>
       {headingText && (
         <GridColumn width={12}>
@@ -49,6 +55,7 @@ export const Component = ({
 Component.displayName = 'Amenities';
 
 Component.defaultProps = {
+  id: null,
   hasExtraItemsInModal: false,
   headingText: null,
   isStacked: false,
@@ -76,6 +83,8 @@ Component.propTypes = {
   hasExtraItemsInModal: PropTypes.bool,
   /** The text to display as a heading at the top of the amenities. */
   headingText: PropTypes.string,
+  /** The html id of the container dom element. */
+  id: PropTypes.string,
   /** Are the amenities displayed stacked on top of one another. */
   isStacked: PropTypes.bool,
   /** The text for the modal trigger. */

--- a/src/components/property-page-widgets/Availability/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Availability/__snapshots__/component.spec.js.snap
@@ -23,7 +23,9 @@ exports[`<Availability /> if \`props.roomOptionsWithImages\` is passed should re
 `;
 
 exports[`<Availability /> the wrapped component by default should render the right structure 1`] = `
-<div>
+<div
+  id={null}
+>
   <Heading
     className={null}
     hasMargin={true}
@@ -322,7 +324,9 @@ exports[`<Availability /> the wrapped component by default should render the rig
 `;
 
 exports[`<Availability /> the wrapped component if \`size(props.roomOptionsWithImages) > 0\` should render the right structure 1`] = `
-<div>
+<div
+  id={null}
+>
   <Heading
     className={null}
     hasMargin={true}

--- a/src/components/property-page-widgets/Availability/component.js
+++ b/src/components/property-page-widgets/Availability/component.js
@@ -77,6 +77,7 @@ class Component extends PureComponent {
   render() {
     const { startDate } = this.state;
     const {
+      id,
       headingText,
       isUserOnMobile,
       legendLabel,
@@ -91,7 +92,7 @@ class Component extends PureComponent {
     moment.locale(this.props.localeCode);
 
     return (
-      <div>
+      <div id={id}>
         <Heading size="small">{headingText}</Heading>
         <Grid>
           <GridRow>
@@ -209,6 +210,7 @@ export const ComponentWithResponsive = withResponsive(Component);
 Component.displayName = 'Availability';
 
 Component.defaultProps = {
+  id: null,
   getIsDayBlocked: () => false,
   headingText: AVAILABILITY,
   legendLabel: UNAVAILABLE,
@@ -231,6 +233,8 @@ Component.propTypes = {
   getIsDayBlocked: PropTypes.func,
   /** The text to display as a heading at the top of the widget. */
   headingText: PropTypes.string,
+  /** The html id of the container dom element. */
+  id: PropTypes.string,
   /**
    * Is the user on a mobile device.
    * Provided by `withResponsive` so ignored in the styleguide.

--- a/src/components/property-page-widgets/Description/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Description/__snapshots__/component.spec.js.snap
@@ -4,6 +4,7 @@ exports[`<Description /> if \`props.descriptionText\` is HTML should have the co
 <Grid
   areColumnsCentered={false}
   columns={1}
+  id={null}
   isStackable={false}
 >
   <GridColumn
@@ -118,6 +119,7 @@ exports[`<Description /> if \`props.descriptionText\` is a plain string with few
 <Grid
   areColumnsCentered={false}
   columns={1}
+  id={null}
   isStackable={false}
 >
   <GridColumn
@@ -226,6 +228,7 @@ exports[`<Description /> if \`props.descriptionText\` is a plain string with mor
 <Grid
   areColumnsCentered={false}
   columns={1}
+  id={null}
   isStackable={false}
 >
   <GridColumn
@@ -338,6 +341,7 @@ exports[`<Description /> if \`props.homeHighlights\` is empty should not render 
 <Grid
   areColumnsCentered={false}
   columns={1}
+  id={null}
   isStackable={false}
 >
   <GridColumn
@@ -386,6 +390,7 @@ exports[`<Description /> if \`props.mainCharacteristics\` is empty should not re
 <Grid
   areColumnsCentered={false}
   columns={1}
+  id={null}
   isStackable={false}
 >
   <GridColumn
@@ -457,6 +462,7 @@ exports[`<Description /> should have the correct structure 1`] = `
 <Grid
   areColumnsCentered={false}
   columns={1}
+  id={null}
   isStackable={false}
 >
   <GridColumn

--- a/src/components/property-page-widgets/Description/component.js
+++ b/src/components/property-page-widgets/Description/component.js
@@ -18,6 +18,7 @@ import { Characteristics } from 'collections/Characteristics';
  */
 // eslint-disable-next-line jsdoc/require-jsdoc
 export const Component = ({
+  id,
   descriptionText,
   extraDescriptionButtonText,
   homeHighlights,
@@ -26,7 +27,7 @@ export const Component = ({
   propertyName,
   propertyType,
 }) => (
-  <Grid columns={1}>
+  <Grid columns={1} id={id}>
     <GridColumn width={12}>
       <Subheading>{propertyType}</Subheading>
       <Heading size="large">{propertyName}</Heading>
@@ -66,6 +67,7 @@ export const Component = ({
 Component.displayName = 'Description';
 
 Component.defaultProps = {
+  id: null,
   descriptionText: null,
   homeHighlightsHeadingText: HOME_HIGHLIGHTS,
   mainCharacteristics: [],
@@ -91,6 +93,8 @@ Component.propTypes = {
   ).isRequired,
   /** The heading displayed above the home highlights. */
   homeHighlightsHeadingText: PropTypes.string,
+  /** The html id of the container dom element. */
+  id: PropTypes.string,
   /** The main characteristics to display. Maximum four. */
   mainCharacteristics: PropTypes.arrayOf(
     PropTypes.shape({

--- a/src/components/property-page-widgets/Location/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Location/__snapshots__/component.spec.js.snap
@@ -3,6 +3,7 @@
 exports[`<Location /> the \`Child\` of the \`Location\` component should have the correct structure 1`] = `
 <Location
   headingText="Location"
+  id={null}
   isShowingApproximateLocation={false}
   isShowingExactLocation={false}
   isUserOnMobile={false}
@@ -39,14 +40,17 @@ exports[`<Location /> the \`Child\` of the \`Location\` component should have th
 >
   <Grid
     areColumnsCentered={false}
+    id={null}
     isStackable={true}
   >
     <Grid
       centered={false}
+      id={null}
       stackable={true}
     >
       <div
         className="ui stackable grid"
+        id={null}
       >
         <GridColumn
           verticalAlignContent="top"

--- a/src/components/property-page-widgets/Location/component.js
+++ b/src/components/property-page-widgets/Location/component.js
@@ -21,6 +21,7 @@ import { getLocationDescription } from './utils/getLocationDescription';
  */
 // eslint-disable-next-line jsdoc/require-jsdoc
 const Component = ({
+  id,
   apiKey,
   headingText,
   isShowingApproximateLocation,
@@ -32,7 +33,7 @@ const Component = ({
   longitude,
   transportOptions,
 }) => (
-  <Grid isStackable>
+  <Grid id={id} isStackable>
     <GridColumn width={12}>
       <Heading>{headingText}</Heading>
       <Subheading>{locationSummary}</Subheading>
@@ -71,6 +72,7 @@ const Component = ({
 Component.displayName = 'Location';
 
 Component.defaultProps = {
+  id: null,
   apiKey: undefined,
   headingText: LOCATION,
   isShowingApproximateLocation: false,
@@ -84,6 +86,8 @@ Component.propTypes = {
   apiKey: PropTypes.string,
   /** The text to display as a heading at the top of the widget. */
   headingText: PropTypes.string,
+  /** The html id of the container dom element. */
+  id: PropTypes.string,
   /** Is the map showing a marker for the approximate location. */
   isShowingApproximateLocation: PropTypes.bool,
   /** Is the map showing a marker for the exact location. */

--- a/src/components/property-page-widgets/Pictures/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Pictures/__snapshots__/component.spec.js.snap
@@ -3,6 +3,7 @@
 exports[`<Pictures /> should render the correct structure 1`] = `
 <Grid
   areColumnsCentered={false}
+  id={null}
   isStackable={false}
 >
   <GridColumn

--- a/src/components/property-page-widgets/Pictures/component.js
+++ b/src/components/property-page-widgets/Pictures/component.js
@@ -24,6 +24,7 @@ const testid = testidFactory(TEST_ID_PREFIX);
  */
 // eslint-disable-next-line jsdoc/require-jsdoc
 export const Component = ({
+  id,
   galleryImages,
   headingText,
   linkText,
@@ -46,7 +47,7 @@ export const Component = ({
     }));
 
   return (
-    <Grid>
+    <Grid id={id}>
       <GridColumn width={12}>
         <Heading>{headingText}</Heading>
       </GridColumn>
@@ -111,6 +112,7 @@ export const Component = ({
 Component.displayName = 'Pictures';
 
 Component.defaultProps = {
+  id: null,
   headingText: PROPERTY_PICTURES,
   linkText: EXPLORE_ALL_PICTURES,
   numberOfThumbnails: 6,
@@ -134,6 +136,8 @@ Component.propTypes = {
   ).isRequired,
   /** The text to display as a heading at the top of the widget. */
   headingText: PropTypes.string,
+  /** The html id of the container dom element. */
+  id: PropTypes.string,
   /** The text to display on the link at the bottom of the widget. */
   linkText: PropTypes.string,
   /** The number of images to display as thumbnails. */

--- a/src/components/property-page-widgets/Reviews/__snapshots__/component.spec.js.snap
+++ b/src/components/property-page-widgets/Reviews/__snapshots__/component.spec.js.snap
@@ -9,6 +9,7 @@ exports[`<Reviews /> if \`props.isShowingPlaceholder\` is \`true\` if \`props.re
   guestTypeInputLabel="Guest Type"
   guestTypeOptions={Array []}
   headingText="Reviews"
+  id={null}
   isBotProtected={false}
   isPrivacyConsentRequired={false}
   isShowingPlaceholder={true}
@@ -34,14 +35,17 @@ exports[`<Reviews /> if \`props.isShowingPlaceholder\` is \`true\` if \`props.re
 >
   <Grid
     areColumnsCentered={false}
+    id={null}
     isStackable={false}
   >
     <Grid
       centered={false}
+      id={null}
       stackable={false}
     >
       <div
         className="ui grid"
+        id={null}
       >
         <GridRow
           horizontalAlignContent="left"
@@ -1076,6 +1080,7 @@ exports[`<Reviews /> if \`props.isShowingPlaceholder\` is \`true\` should render
   guestTypeInputLabel="Guest Type"
   guestTypeOptions={Array []}
   headingText="Reviews"
+  id={null}
   isBotProtected={false}
   isPrivacyConsentRequired={false}
   isShowingPlaceholder={true}
@@ -1128,14 +1133,17 @@ exports[`<Reviews /> if \`props.isShowingPlaceholder\` is \`true\` should render
 >
   <Grid
     areColumnsCentered={false}
+    id={null}
     isStackable={false}
   >
     <Grid
       centered={false}
+      id={null}
       stackable={false}
     >
       <div
         className="ui grid"
+        id={null}
       >
         <GridRow
           horizontalAlignContent="left"
@@ -2054,6 +2062,7 @@ exports[`<Reviews /> should render the right structure 1`] = `
   guestTypeInputLabel="Guest Type"
   guestTypeOptions={Array []}
   headingText="Reviews"
+  id={null}
   isBotProtected={false}
   isPrivacyConsentRequired={false}
   isShowingPlaceholder={false}
@@ -2106,14 +2115,17 @@ exports[`<Reviews /> should render the right structure 1`] = `
 >
   <Grid
     areColumnsCentered={false}
+    id={null}
     isStackable={false}
   >
     <Grid
       centered={false}
+      id={null}
       stackable={false}
     >
       <div
         className="ui grid"
+        id={null}
       >
         <GridRow
           horizontalAlignContent="left"

--- a/src/components/property-page-widgets/Reviews/component.js
+++ b/src/components/property-page-widgets/Reviews/component.js
@@ -38,6 +38,7 @@ import { transformReviewFactory } from './utils/transformReviewFactory';
  */
 // eslint-disable-next-line jsdoc/require-jsdoc
 export const Component = ({
+  id,
   headingText,
   isShowingPlaceholder,
   ratingAverage,
@@ -49,7 +50,7 @@ export const Component = ({
     isShowingPlaceholder && reviews.length === 0 ? PLACEHOLDERS : reviews;
 
   return (
-    <Grid>
+    <Grid id={id}>
       <GridRow>
         <GridColumn width={12}>
           <Heading>{headingText}</Heading>
@@ -101,6 +102,7 @@ export const Component = ({
 Component.displayName = 'Reviews';
 
 Component.defaultProps = {
+  id: null,
   botProtectionMessage: FORM_PROTECTION,
   roomTypeInputLabel: ROOM,
   commentInputLabel: COMMENTS,
@@ -164,6 +166,8 @@ Component.propTypes = {
   ),
   /** The text to display as a heading at the top of the widget. */
   headingText: PropTypes.string,
+  /** The html id of the container dom element. */
+  id: PropTypes.string,
   /** Displays a bot protection message in the review form. */
   isBotProtected: PropTypes.bool,
   /** Displays a privacy consent checkbox to the review form. */

--- a/src/components/property-page-widgets/RoomType/utils/__snapshots__/getModalContentMarkup.spec.js.snap
+++ b/src/components/property-page-widgets/RoomType/utils/__snapshots__/getModalContentMarkup.spec.js.snap
@@ -766,6 +766,7 @@ exports[`getModalContentMarkup if \`props.description\` === null should not rend
       amenitiesConjunctionText="WALL-E"
       hasExtraItemsInModal={false}
       headingText="bibip-bop"
+      id={null}
       isStacked={false}
       modalTriggerText="View more"
     >
@@ -773,16 +774,19 @@ exports[`getModalContentMarkup if \`props.description\` === null should not rend
         areColumnsCentered={false}
         className="is-amenities"
         columns={3}
+        id={null}
         isStackable={true}
       >
         <Grid
           centered={false}
           className="is-amenities"
           columns={3}
+          id={null}
           stackable={true}
         >
           <div
             className="ui stackable three column grid is-amenities"
+            id={null}
           >
             <GridRow
               horizontalAlignContent="left"
@@ -1422,6 +1426,7 @@ exports[`getModalContentMarkup if \`props.images.length\` > 1 should render the 
       amenitiesConjunctionText="WALL-E"
       hasExtraItemsInModal={false}
       headingText="bibip-bop"
+      id={null}
       isStacked={false}
       modalTriggerText="View more"
     >
@@ -1429,16 +1434,19 @@ exports[`getModalContentMarkup if \`props.images.length\` > 1 should render the 
         areColumnsCentered={false}
         className="is-amenities"
         columns={3}
+        id={null}
         isStackable={true}
       >
         <Grid
           centered={false}
           className="is-amenities"
           columns={3}
+          id={null}
           stackable={true}
         >
           <div
             className="ui stackable three column grid is-amenities"
+            id={null}
           >
             <GridRow
               horizontalAlignContent="left"
@@ -1909,6 +1917,7 @@ exports[`getModalContentMarkup if \`props.ratingNumber\` === null should not ren
       amenitiesConjunctionText="WALL-E"
       hasExtraItemsInModal={false}
       headingText="bibip-bop"
+      id={null}
       isStacked={false}
       modalTriggerText="View more"
     >
@@ -1916,16 +1925,19 @@ exports[`getModalContentMarkup if \`props.ratingNumber\` === null should not ren
         areColumnsCentered={false}
         className="is-amenities"
         columns={3}
+        id={null}
         isStackable={true}
       >
         <Grid
           centered={false}
           className="is-amenities"
           columns={3}
+          id={null}
           stackable={true}
         >
           <div
             className="ui stackable three column grid is-amenities"
+            id={null}
           >
             <GridRow
               horizontalAlignContent="left"
@@ -2543,6 +2555,7 @@ exports[`getModalContentMarkup should return the correct structure 1`] = `
       amenitiesConjunctionText="WALL-E"
       hasExtraItemsInModal={false}
       headingText="bibip-bop"
+      id={null}
       isStacked={false}
       modalTriggerText="View more"
     >
@@ -2550,16 +2563,19 @@ exports[`getModalContentMarkup should return the correct structure 1`] = `
         areColumnsCentered={false}
         className="is-amenities"
         columns={3}
+        id={null}
         isStackable={true}
       >
         <Grid
           centered={false}
           className="is-amenities"
           columns={3}
+          id={null}
           stackable={true}
         >
           <div
             className="ui stackable three column grid is-amenities"
+            id={null}
           >
             <GridRow
               horizontalAlignContent="left"


### PR DESCRIPTION
[Related Jira issue](https://lodgify.atlassian.net/browse/WEB-743)

### What **one** thing does this PR do?
Exposes `id` prop for all the property page components related with the sticky menu.

PO details

The link menu bar contains the links:

Description → link to the section Description
Pictures → link to the section Property Pictures
Amenities → link to the section Amenities
Location → link to the section Location / Map
Availability → link to the section Availability
Reviews → link to the section Reviews

### Any other notes

<img width="487" alt="Screenshot 2019-12-03 at 09 01 54" src="https://user-images.githubusercontent.com/33876435/70032870-99613980-15ae-11ea-8930-b0e9ddaff0b3.png">
<img width="470" alt="Screenshot 2019-12-03 at 09 04 27" src="https://user-images.githubusercontent.com/33876435/70032871-99f9d000-15ae-11ea-81f5-cbe0b4202c79.png">

![Screenshot 2019-12-02 at 17 50 25](https://user-images.githubusercontent.com/33876435/70032872-99f9d000-15ae-11ea-8b2d-5ae4c89d8e03.png)

![Screenshot 2019-12-02 at 17 53 30](https://user-images.githubusercontent.com/33876435/70032873-9a926680-15ae-11ea-9d2e-af7a81df6329.png)

![Screenshot 2019-12-02 at 17 56 59](https://user-images.githubusercontent.com/33876435/70032876-9a926680-15ae-11ea-9b5d-525df9008d3b.png)
