### PR TITLE
WEB-797: Rating stars will have always the same system font

### DIFF
--- a/src/styles/semantic/themes/livingstone/modules/rating.overrides
+++ b/src/styles/semantic/themes/livingstone/modules/rating.overrides
@@ -6,6 +6,7 @@
   margin-left: @marginLeft;
   font-family: "Courier New", Courier, monospace;
   font-size: 1rem;
+
   /*-------------------
           Types
   --------------------*/
@@ -14,6 +15,7 @@
   .icon {
     outline-width: 0;
     font-family: "Courier New", Courier, monospace;
+
     &:before {
       font-family: "Courier New", Courier, monospace;
       content: "\2605";

--- a/src/styles/semantic/themes/livingstone/modules/rating.overrides
+++ b/src/styles/semantic/themes/livingstone/modules/rating.overrides
@@ -4,7 +4,8 @@
 
 .ui.rating {
   margin-left: @marginLeft;
-
+  font-family: "Courier New", Courier, monospace;
+  font-size: 1rem;
   /*-------------------
           Types
   --------------------*/
@@ -12,9 +13,10 @@
   /* Standard */
   .icon {
     outline-width: 0;
-
+    font-family: "Courier New", Courier, monospace;
     &:before {
-      content: '\2605';
+      font-family: "Courier New", Courier, monospace;
+      content: "\2605";
     }
   }
 


### PR DESCRIPTION
[Related Jira issue](https://lodgify.atlassian.net/browse/WEB-X)

### What **one** thing does this PR do?
Set a default system font (Courier New, monospace) to the rating component in order to not be affected by the custom font of the website. 

### Any other notes
<img width="1266" alt="image" src="https://user-images.githubusercontent.com/5032333/70899063-316f1200-1ff6-11ea-8e8b-1d65b4968050.png">
