### PR TITLE
WEB-734 Contact empties all inputs after submission

### DIFF
--- a/src/components/collections/Form/utils/getEmptyState.js
+++ b/src/components/collections/Form/utils/getEmptyState.js
@@ -6,9 +6,7 @@ export const getEmptyState = state =>
   Object.keys(state).reduce(
     (accumulator, key) => ({
       ...accumulator,
-      [key]: {
-        value: null,
-      },
+      [key]: { value: key === 'dates' ? null : '' },
     }),
     {}
   );

--- a/src/components/collections/Form/utils/getEmptyState.spec.js
+++ b/src/components/collections/Form/utils/getEmptyState.spec.js
@@ -11,12 +11,17 @@ describe('getEmptyState', () => {
         more: 'are',
         here: 'as well',
       },
+      dates: {
+        nothing: 'else',
+        matters: 'like really',
+      },
     };
     const actual = getEmptyState(state);
 
     expect(actual).toEqual({
-      abc: { value: null },
-      def: { value: null },
+      abc: { value: '' },
+      def: { value: '' },
+      dates: { value: null },
     });
   });
 });


### PR DESCRIPTION
[Related Jira issue](https://lodgify.atlassian.net/browse/WEB-734)

### What **one** thing does this PR do?
Makes all the `Contact` inputs empty after submission.

### Any other notes

* Discovered an issue where, after submission, recaptcha is not refreshed causing the form to error on a second submission; even if all fields are correct.
[Related Jira Issue](https://lodgify.atlassian.net/browse/WEB-856?atlOrigin=eyJpIjoiMTQ3NmQ3ZjhiZmNkNGI1OWJjZDQ5ODljNWQ3NWIxODMiLCJwIjoiaiJ9)

![asdasd](https://user-images.githubusercontent.com/33876435/71995463-e9c95800-323a-11ea-8f68-ef397a47a659.gif)
