### PR TITLE
WEB-958 Remove overflow for HorizontalMenu in PropertySubMenu

### DIFF
--- a/src/components/collections/HorizontalMenu/component.js
+++ b/src/components/collections/HorizontalMenu/component.js
@@ -63,7 +63,9 @@ export const Component = ({ items, onItemClick, isHeader, className }) => {
 
   return (
     <nav
-      className={classnames('horizontal-menu', 'is-overflowed', className)}
+      className={classnames('horizontal-menu', className, {
+        'is-overflowed': isHeader,
+      })}
       data-testid={testid()}
     >
       <ShowOn computer={isHeader} mobile tablet widescreen={isHeader}>

--- a/src/components/general-widgets/ContactHomeHero/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/ContactHomeHero/__snapshots__/component.spec.js.snap
@@ -1567,7 +1567,7 @@ exports[`ContactHomeHero should render the right structure 1`] = `
                   }
                 >
                   <nav
-                    className="horizontal-menu is-overflowed is-header"
+                    className="horizontal-menu is-header is-overflowed"
                     data-testid="horizontalMenu"
                   >
                     <ShowOn

--- a/src/styles/semantic/definitions/lodgify-ui-components/horizontal-menu.less
+++ b/src/styles/semantic/definitions/lodgify-ui-components/horizontal-menu.less
@@ -38,17 +38,18 @@
 
     .ui.container {
       height: @horizontalMenuContainerHeight;
+      overflow: hidden;
 
-    .ui.menu {
-      .menu-wrapper {
-        height: @horizontalMenuWrapperSubmenuWrapperHeight;
+      .ui.menu {
+        .menu-wrapper:hover {
+          height: @horizontalMenuWrapperSubmenuWrapperHeight;
 
-        .menu.transition {
-          max-height: @horizontalMenuWrapperSubmenuMenuHeight;
+          .menu.transition {
+            max-height: @horizontalMenuWrapperSubmenuMenuHeight;
+          }
         }
       }
     }
-  }
   }
 
   .ui.menu {

--- a/src/styles/semantic/themes/default/lodgify-ui-components/horizontal-menu.variables
+++ b/src/styles/semantic/themes/default/lodgify-ui-components/horizontal-menu.variables
@@ -10,7 +10,7 @@
 @horizontalMenuWrapperSubmenuWrapperHeight: ~"calc(68px + 288px)";
 @horizontalMenuWrapperSubmenuMenuHeight: 180px;
 
-@horizontalMenuWrapperHeight: 98px;
+@horizontalMenuWrapperHeight: 58px;
 @horizontalMenuWrapperScrollBarHeight: 10px;
 @horizontalMenuWrapperBackgroundColor: #fff;
 @horizontalMenuArrowGradientLeft: linear-gradient(270deg, rgba(0,0,0,0) 0%, @white 100%);


### PR DESCRIPTION
[Related Jira issue](https://lodgify.atlassian.net/browse/WEB-958)

### What **one** thing does this PR do?
Habilitates the overflow only on `Header` components making sure it doesn't collide with any other component

### Any other notes

![property](https://user-images.githubusercontent.com/33876435/73003614-33eb3580-3e06-11ea-9f8b-a002eb1f68a5.gif)

![search_app](https://user-images.githubusercontent.com/33876435/73003001-31d4a700-3e05-11ea-9dbf-e84852c799a4.gif)
