### PR TITLE
WEB-917 Expose className to stickyMenu

### DIFF
--- a/src/components/collections/StickyMenu/component.js
+++ b/src/components/collections/StickyMenu/component.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { PropTypes } from 'prop-types';
+import classnames from 'classnames';
 
 import { testidFactory } from 'utils/testid';
 
@@ -12,7 +13,7 @@ const TEST_ID_PREFIX = 'stickyMenu';
 
 const testid = testidFactory(TEST_ID_PREFIX);
 
-export const Component = ({ stickyMenuItems, isHeader }) => {
+export const Component = ({ className, stickyMenuItems, isHeader }) => {
   const [activeItem, setActiveItem] = useState('');
 
   useEffect(() => {
@@ -57,7 +58,7 @@ export const Component = ({ stickyMenuItems, isHeader }) => {
 
   return (
     <HorizontalMenu
-      className="sticky-menu"
+      className={classnames(className, 'sticky-menu')}
       data-testid={testid()}
       isHeader={isHeader}
       items={items}
@@ -69,11 +70,14 @@ export const Component = ({ stickyMenuItems, isHeader }) => {
 Component.displayName = 'StickyMenu';
 
 Component.defaultProps = {
+  className: null,
   isHeader: false,
   stickyMenuItems: [],
 };
 
 Component.propTypes = {
+  /** Custom className for the sticky menu. */
+  className: PropTypes.string,
   /** Is the component displaying as a header. */
   isHeader: PropTypes.bool,
   /** The sticky menu items to display. */

--- a/src/components/collections/StickyMenu/component.spec.js
+++ b/src/components/collections/StickyMenu/component.spec.js
@@ -11,9 +11,13 @@ import { useScroll } from '../../../hooks/useScroll';
 import { Component as StickyMenu } from './component';
 import { menuItems } from './mock-data/mock-data';
 
+const props = {
+  className: 'get out',
+};
+
 const testid = testidSelectorFactory('stickyMenu');
 const getStickyHeader = (items = menuItems) =>
-  mount(<StickyMenu stickyMenuItems={items} />);
+  mount(<StickyMenu {...props} stickyMenuItems={items} />);
 const link = '#availability';
 
 document.body.innerHTML = `<div id="availability"></div>`;


### PR DESCRIPTION
[Related Jira issue](https://lodgify.atlassian.net/browse/WEB-917)

### What **one** thing does this PR do?
Exposes a className to StickyMenu so it can be modified by `websites-template-selector`
