### PR TITLE
WEB-865 Remove arrows from Contact Menu when content does not overflow

### DIFF
--- a/src/components/collections/ContactHeader/component.js
+++ b/src/components/collections/ContactHeader/component.js
@@ -107,7 +107,7 @@ export const Component = ({
       </div>
       <HorizontalMenu
         className="is-header"
-        isHeader
+        hasOverflow
         items={navigationMenuItems}
       />
     </ShowOn>

--- a/src/components/collections/HorizontalMenu/constants.js
+++ b/src/components/collections/HorizontalMenu/constants.js
@@ -1,0 +1,1 @@
+export const HORIZONTAL_MENU_MARGINS = 43;

--- a/src/components/collections/StickyMenu/component.js
+++ b/src/components/collections/StickyMenu/component.js
@@ -13,7 +13,7 @@ const TEST_ID_PREFIX = 'stickyMenu';
 
 const testid = testidFactory(TEST_ID_PREFIX);
 
-export const Component = ({ className, stickyMenuItems, isHeader }) => {
+export const Component = ({ className, stickyMenuItems, hasOverflow }) => {
   const [activeItem, setActiveItem] = useState('');
 
   useEffect(() => {
@@ -60,7 +60,7 @@ export const Component = ({ className, stickyMenuItems, isHeader }) => {
     <HorizontalMenu
       className={classnames(className, 'sticky-menu')}
       data-testid={testid()}
-      isHeader={isHeader}
+      hasOverflow={hasOverflow}
       items={items}
       onItemClick={scrollToComponentOnMenuClick}
     />
@@ -71,15 +71,15 @@ Component.displayName = 'StickyMenu';
 
 Component.defaultProps = {
   className: null,
-  isHeader: false,
+  hasOverflow: false,
   stickyMenuItems: [],
 };
 
 Component.propTypes = {
   /** Custom className for the sticky menu. */
   className: PropTypes.string,
-  /** Is the component displaying as a header. */
-  isHeader: PropTypes.bool,
+  /** Is the component allowing overflow. */
+  hasOverflow: PropTypes.bool,
   /** The sticky menu items to display. */
   stickyMenuItems: PropTypes.arrayOf(
     PropTypes.shape({

--- a/src/components/general-widgets/ContactHomeHero/__snapshots__/component.spec.js.snap
+++ b/src/components/general-widgets/ContactHomeHero/__snapshots__/component.spec.js.snap
@@ -1514,7 +1514,7 @@ exports[`ContactHomeHero should render the right structure 1`] = `
                 </div>
                 <HorizontalMenu
                   className="is-header"
-                  isHeader={true}
+                  hasOverflow={true}
                   items={
                     Array [
                       Object {
@@ -1570,54 +1570,41 @@ exports[`ContactHomeHero should render the right structure 1`] = `
                     className="horizontal-menu is-header is-overflowed"
                     data-testid="horizontalMenu"
                   >
-                    <ShowOn
-                      computer={true}
-                      mobile={true}
-                      parent="div"
-                      parentProps={Object {}}
-                      tablet={true}
-                      widescreen={true}
+                    <div
+                      className="arrow left"
+                      data-testid="horizontalMenu-arrow-left"
+                      onClick={[Function]}
+                      role="button"
                     >
-                      <div
-                        className="show-on-mobile show-on-tablet show-on-computer show-on-widescreen"
+                      <Icon
+                        className={null}
+                        color={null}
+                        hasBorder={false}
+                        isButton={false}
+                        isCircular={false}
+                        isColorInverted={false}
+                        isDisabled={false}
+                        isLabelLeft={false}
+                        labelText={null}
+                        labelWeight={null}
+                        name="chevron left"
+                        path={null}
+                        size={null}
                       >
-                        <div
-                          className="arrow left is-active"
-                          data-testid="horizontalMenu-arrow-left"
-                          onClick={[Function]}
-                          role="button"
+                        <i
+                          className="icon"
                         >
-                          <Icon
-                            className={null}
-                            color={null}
-                            hasBorder={false}
-                            isButton={false}
-                            isCircular={false}
-                            isColorInverted={false}
-                            isDisabled={false}
-                            isLabelLeft={false}
-                            labelText={null}
-                            labelWeight={null}
-                            name="chevron left"
-                            path={null}
-                            size={null}
+                          <svg
+                            viewBox="0 0 24 24"
                           >
-                            <i
-                              className="icon"
-                            >
-                              <svg
-                                viewBox="0 0 24 24"
-                              >
-                                <path
-                                  d="M15.19,18a.55.55,0,0,1-.36-.13L8.44,12.42a.56.56,0,0,1,0-.84L14.83,6.1a.57.57,0,0,1,.79.06.55.55,0,0,1-.06.78L9.66,12l5.9,5.05a.57.57,0,0,1,.06.79A.56.56,0,0,1,15.19,18Z"
-                                  fill="currentColor"
-                                />
-                              </svg>
-                            </i>
-                          </Icon>
-                        </div>
-                      </div>
-                    </ShowOn>
+                            <path
+                              d="M15.19,18a.55.55,0,0,1-.36-.13L8.44,12.42a.56.56,0,0,1,0-.84L14.83,6.1a.57.57,0,0,1,.79.06.55.55,0,0,1-.06.78L9.66,12l5.9,5.05a.57.57,0,0,1,.06.79A.56.56,0,0,1,15.19,18Z"
+                              fill="currentColor"
+                            />
+                          </svg>
+                        </i>
+                      </Icon>
+                    </div>
                     <HorizontalGutters>
                       <Container>
                         <div
@@ -2637,51 +2624,38 @@ exports[`ContactHomeHero should render the right structure 1`] = `
                       </Container>
                     </HorizontalGutters>
                     <div
-                      className="arrow right is-active"
+                      className="arrow right"
                       data-testid="horizontalMenu-arrow-right"
                       onClick={[Function]}
                     >
-                      <ShowOn
-                        computer={true}
-                        mobile={true}
-                        parent="div"
-                        parentProps={Object {}}
-                        tablet={true}
-                        widescreen={true}
+                      <Icon
+                        className={null}
+                        color={null}
+                        hasBorder={false}
+                        isButton={false}
+                        isCircular={false}
+                        isColorInverted={false}
+                        isDisabled={false}
+                        isLabelLeft={false}
+                        labelText={null}
+                        labelWeight={null}
+                        name="chevron right"
+                        path={null}
+                        size={null}
                       >
-                        <div
-                          className="show-on-mobile show-on-tablet show-on-computer show-on-widescreen"
+                        <i
+                          className="icon"
                         >
-                          <Icon
-                            className={null}
-                            color={null}
-                            hasBorder={false}
-                            isButton={false}
-                            isCircular={false}
-                            isColorInverted={false}
-                            isDisabled={false}
-                            isLabelLeft={false}
-                            labelText={null}
-                            labelWeight={null}
-                            name="chevron right"
-                            path={null}
-                            size={null}
+                          <svg
+                            viewBox="0 0 24 24"
                           >
-                            <i
-                              className="icon"
-                            >
-                              <svg
-                                viewBox="0 0 24 24"
-                              >
-                                <path
-                                  d="M8.81,18a.56.56,0,0,1-.43-.19.57.57,0,0,1,.06-.79L14.34,12,8.44,6.94a.55.55,0,0,1-.06-.78.57.57,0,0,1,.79-.06l6.39,5.48a.56.56,0,0,1,0,.84L9.17,17.9A.55.55,0,0,1,8.81,18Z"
-                                  fill="currentColor"
-                                />
-                              </svg>
-                            </i>
-                          </Icon>
-                        </div>
-                      </ShowOn>
+                            <path
+                              d="M8.81,18a.56.56,0,0,1-.43-.19.57.57,0,0,1,.06-.79L14.34,12,8.44,6.94a.55.55,0,0,1-.06-.78.57.57,0,0,1,.79-.06l6.39,5.48a.56.56,0,0,1,0,.84L9.17,17.9A.55.55,0,0,1,8.81,18Z"
+                              fill="currentColor"
+                            />
+                          </svg>
+                        </i>
+                      </Icon>
                     </div>
                   </nav>
                 </HorizontalMenu>

--- a/src/styles/semantic/definitions/lodgify-ui-components/contact-header.less
+++ b/src/styles/semantic/definitions/lodgify-ui-components/contact-header.less
@@ -27,11 +27,11 @@
   }
 
   > div > .header-grid {
+    height: @contactHeaderHeight;
     display: grid;
     grid-template-columns: @contactHeaderGridTemplate;
     grid-template-rows: 100%;
-    padding-top: @contactHeaderContainerPadding;
-    padding-bottom: @contactHeaderContainerPadding;
+    padding: @contactHeaderContainerPadding;
     box-shadow: @contactHeaderContainerBoxShadow;
     z-index: @contactHeaderContainerZIndex;
     position: relative;
@@ -48,7 +48,6 @@
       height: @contactHeaderButtonHeight;
       border-radius: @contactHeaderButtonBorderRadius;
       box-shadow: @contactHeaderButtonBoxShadow;
-      color: @contactHeaderButtonColor;
       margin-right: @contactHeaderButtonMarginRight;
     }
 
@@ -63,6 +62,10 @@
 
   .header-grid {
     background-color: @white;
+
+    a {
+      text-decoration: none;
+    }
 
     .link.item {
       margin: auto;
@@ -96,33 +99,93 @@
   }
 
   .horizontal-menu {
+    max-height: @contactHeaderHorizontalMenuHeight;
+    height: @contactHeaderHorizontalMenuHeight;
+
+    .arrow {
+      height: @contactHeaderHorizontalMenuHeight;
+    }
 
     &.is-header {
+      max-height: unset;
       margin: @contactHeaderHorizontalMenuMargin;
+  
+      .ui.container {
+        position: absolute;
+        overflow: hidden;
+        height: @contactHeaderHorizontalMenuHeight;
+        padding: @contactHeaderHorizontalMenuPadding;
+      }
+    }
+  
+    &.is-overflowed {
+      overflow: visible;
+      max-height: unset;
+      margin: @contactHeaderHorizontalMenuMargin;
+  
+      .ui.container {
+        position: absolute;
+        overflow: hidden;
+        height: @contactHeaderHorizontalMenuHeight;
+        padding: @contactHeaderHorizontalMenuPadding;
+        height: @contactHeaderHorizontalMenuHeight;
+        overflow: hidden;
+      }
+  
+      &:hover {
+  
+        .ui.container {
+          height: @contactHeaderHorizontalMenuContainerHeightOnHover;
+        }
+  
+        .ui.menu {
+          .menu-wrapper {
+            height: @contactHeaderHorizontalMenuWrapperHeightOnHover;
+  
+            .menu.transition {
+              max-height: @contactHeaderHorizontalMenuSubmenuMaxHeight;
+            }
+          }
+        }
+      }
     }
 
-    .menu-wrapper {
-      justify-content: center;
+    .ui.menu {
 
-      .ui.item.simple.dropdown {
-        padding: 0;
+      .menu-wrapper {
+
+        &:before,
+        &:after {
+          height: @contactHeaderHorizontalMenuHeight;
+        }
+        
+        > .item {
+          height: @contactHeaderHorizontalMenuHeight;
+        }
+
+        .ui.item.simple.dropdown {
+          padding: 0;
+        }
+
+        .menu-wrapper > a:last-child {
+          margin-right: @contactHeaderMenuMargin;
+        }
+
+        .menu-wrapper > a:first-child {
+          margin-left: @contactHeaderMenuMargin;
       }
 
-      .menu-wrapper > a:last-child {
-        margin-right: @contactHeaderMenuMargin;
-      }
-
-      .menu-wrapper > a:first-child {
-        margin-left: @contactHeaderMenuMargin;
-    }
-
-      .ui.item.pointing.dropdown {
-        margin-right: 0 !important;
+        .ui.item.pointing.dropdown {
+          margin-right: 0 !important;
+        }
       }
     }
   }
 
   .hidden-contact-header {
+    height: @hiddenContactHeaderHeight;
+    padding-top: @hiddenContactHeaderVerticalPadding;
+    padding-bottom: @hiddenContactHeaderVerticalPadding;
 
     .ui.header {
       margin-left: 0;
@@ -130,20 +193,42 @@
   }
 }
 
-.ui.modal.hidden-contact-header-modal {
+/*--------------------------
+      Contact Header Modal
+--------------------------*/
+
+.ui.modal.fullscreen.visible.hidden-contact-header-modal {
   display: inline-block;
 
-  .header {
-    border-bottom: none;
-    padding-top: @contactHeaderModalPaddingTop;
+  a {
+    text-decoration: none;
+  }
 
-    .link.item {
-      text-decoration: none;
-    }
+  > .header {
+    border-bottom: none;
+    padding: @hiddenContactHeaderModalHeaderpadding;
+    height: @contactModalHeaderHeight;
+    display: flex;
+    align-items: center;
+
+    .ui.container { 
+      padding: 0;
+
+      .link.item {
+        text-decoration: none;
+      }
+    } 
   }
 
   .content {
     height: @contactModalContentHeight;
+    padding: @hiddenContactHeaderModalHeaderpadding;
+
+    .link.item,
+    .item.accordion.ui,
+    .ui.vertical.menu > .item {
+      padding-left: 0;
+    }
   }
 
    > .icon.has-label {

--- a/src/styles/semantic/definitions/lodgify-ui-components/horizontal-menu.less
+++ b/src/styles/semantic/definitions/lodgify-ui-components/horizontal-menu.less
@@ -22,36 +22,6 @@
   display: flex;
   justify-content: center;
 
-  &.is-header {
-    max-height: unset;
-
-    .ui.container {
-      position: absolute;
-      overflow: hidden;
-      height: @horizontalMenuHeight;
-      padding: @contactHeaderMenuContainerHorizontalPadding;
-    }
-  }
-
-  &.is-overflowed {
-    overflow: visible;
-
-    .ui.container {
-      height: @horizontalMenuContainerHeight;
-      overflow: hidden;
-
-      .ui.menu {
-        .menu-wrapper:hover {
-          height: @horizontalMenuWrapperSubmenuWrapperHeight;
-
-          .menu.transition {
-            max-height: @horizontalMenuWrapperSubmenuMenuHeight;
-          }
-        }
-      }
-    }
-  }
-
   .ui.menu {
     margin: 0;
     padding: 0;
@@ -63,7 +33,7 @@
       > .item {
         padding-top: 0;
         padding-bottom: 0;
-        height: @horizontalMenuItemHeight;
+        height: @horizontalMenuHeight;
 
         &.simple {
           margin: 0 !important;
@@ -73,12 +43,13 @@
   }
 
   .menu-wrapper {
+    padding: @horizontalMenuHorizontalPadding;
     position: relative;
     display: flex;
-    width: 100%;
+    margin: auto;
     overflow-x: auto;
     overflow-y: hidden;
-    height: @horizontalMenuWrapperHeight;
+    height: @horizontalMenuOverflowHeight;
     &:before,
     &:after {
       content: "";

--- a/src/styles/semantic/definitions/lodgify-ui-components/logo.less
+++ b/src/styles/semantic/definitions/lodgify-ui-components/logo.less
@@ -12,21 +12,26 @@
         Logo
 --------------------------*/
 
-.ui.image {
+.logo {
+  text-decoration: none;
+  display: block;
 
-  &.medium-logo {
-    max-height: @headerLogoMaxHeight;
-    max-width: @headerLogoMaxWidth;
-  }
+  .ui.image {
 
-  &.large-logo {
-    max-height: @headerLargeLogoMaxHeight;
-    max-width: @headerLargeLogoMaxWidth;
-  }
-
-  &.huge-logo {
-    max-height: @headerHugeLogoMaxHeight;
-    max-width: @headerHugeLogoMaxWidth;
+    &.medium-logo {
+      max-height: @headerLogoMaxHeight;
+      max-width: @headerLogoMaxWidth;
+    }
+  
+    &.large-logo {
+      max-height: @headerLargeLogoMaxHeight;
+      max-width: @headerLargeLogoMaxWidth;
+    }
+  
+    &.huge-logo {
+      max-height: @headerHugeLogoMaxHeight;
+      max-width: @headerHugeLogoMaxWidth;
+    }
   }
 }
 

--- a/src/styles/semantic/themes/default/lodgify-ui-components/contact-header.variables
+++ b/src/styles/semantic/themes/default/lodgify-ui-components/contact-header.variables
@@ -2,6 +2,7 @@
     Contact Header
 -----------------------*/
 
+@contactHeaderHeight: 120px;
 @contactHeaderMenuMargin: 1.25em;
 @contactHeaderGridTemplate: ~"calc(100% / 3) calc(100% / 3) calc(100% / 3)";
 
@@ -11,7 +12,7 @@
 @contactHeaderModalIconTextMarginRight: 0.313em;
 @contactHeaderModalIconSize: 1.11em;
 
-@contactModalHeaderHeight: 142px;
+@contactModalHeaderHeight: 140px;
 @contactModalContentHeight: ~"calc(100% - @{contactModalHeaderHeight})";
 
 @contactHeaderVerticalMenuItemPaddingTop: 0.938em;
@@ -22,7 +23,7 @@
 @contactHeaderButtonColor: @white;
 @contactHeaderButtonMarginRight: 0;
 
-@contactHeaderContainerPadding: 1.9em;
+@contactHeaderContainerPadding: 1.2em 0;
 @contactHeaderContainerBoxShadow: 0 1px 0 0 #ced0d2;
 @contactHeaderContainerZIndex: 4;
 
@@ -31,4 +32,15 @@
 
 @contactHeaderTextGray:  #9897af;
 
-@contactHeaderHorizontalMenuMargin: 10px 0;
+@contactHeaderHorizontalMenuMargin: 5px 0;
+@contactHeaderHorizontalMenuHeight: 40px;
+@contactHeaderHorizontalMenuPadding: 0 1.563em;
+@contactHeaderHorizontalMenuSubmenuMaxHeight: 180px;
+@contactHeaderHorizontalMenuContainerHeightOnHover: ~"calc(70px + 260px)";
+@contactHeaderHorizontalMenuWrapperHeightOnHover: ~"calc(70px + 290px)";
+
+@contactHeaderLogoMaxWidth: 82px;
+
+@hiddenContactHeaderHeight: @contactModalHeaderHeight !important;
+@hiddenContactHeaderVerticalPadding: 20px;
+@hiddenContactHeaderModalHeaderpadding: 20px 1.78rem !important;

--- a/src/styles/semantic/themes/default/lodgify-ui-components/horizontal-menu.variables
+++ b/src/styles/semantic/themes/default/lodgify-ui-components/horizontal-menu.variables
@@ -3,14 +3,12 @@
 -----------------------*/
 
 @horizontalMenuBoxShadowY: 0 1px 0 0 #D8D8D8;
-@horizontalMenuHeight: 58px;
-@horizontalMenuItemHeight: 58px;
-@horizontalMenuContainerHeight: 240px;
+@horizontalMenuHeight: 60px;
+@horizontalMenuOverflowHeight: 70px;
 @contactHeaderMenuContainerHorizontalPadding: 0 1.563em;
-@horizontalMenuWrapperSubmenuWrapperHeight: ~"calc(68px + 288px)";
 @horizontalMenuWrapperSubmenuMenuHeight: 180px;
+@horizontalMenuHorizontalPadding: 0 50px;
 
-@horizontalMenuWrapperHeight: 58px;
 @horizontalMenuWrapperScrollBarHeight: 10px;
 @horizontalMenuWrapperBackgroundColor: #fff;
 @horizontalMenuArrowGradientLeft: linear-gradient(270deg, rgba(0,0,0,0) 0%, @white 100%);

--- a/src/styles/semantic/themes/default/lodgify-ui-components/logo.variables
+++ b/src/styles/semantic/themes/default/lodgify-ui-components/logo.variables
@@ -3,7 +3,7 @@
 -----------------------*/
 
 @headerLogoMaxWidth: 125px;
-@headerLogoMaxHeight: 55px;
+@headerLogoMaxHeight: 60px;
 @headerLargeLogoMaxWidth: 145px;
 @headerLargeLogoMaxHeight: 65px;
 @headerHugeLogoMaxWidth: 155px;


### PR DESCRIPTION
[Related Jira issue](https://lodgify.atlassian.net/browse/WEB-865)

### What **one** thing does this PR do?

* Removes the navigation arrows of the `HorizontalMenu` component when the number of items does not require navigation.

* Also, hides the scrolling bar from the menu.
* Also, makes a couple more fixes for Capucine paddings in order to make paddings and margins more consistent. 

NOTE: For all of this to work properly, another PR in `websites-template-selector` will need to be approved as well. Some styles where removed from there in order to make components easier and more consistent. 

### Any other notes
<img width="1403" alt="Screenshot 2020-01-30 at 19 06 47" src="https://user-images.githubusercontent.com/33876435/73527843-0ad53100-4414-11ea-8976-ec9c23bead24.png">
<img width="756" alt="Screenshot 2020-01-30 at 19 07 11" src="https://user-images.githubusercontent.com/33876435/73527844-0ad53100-4414-11ea-862d-e3cdeb142cf9.png">
<img width="251" alt="Screenshot 2020-01-30 at 19 07 28" src="https://user-images.githubusercontent.com/33876435/73527845-0ad53100-4414-11ea-85d7-da8246d3d806.png">
<img width="1278" alt="Screenshot 2020-01-30 at 19 07 53" src="https://user-images.githubusercontent.com/33876435/73527846-0ad53100-4414-11ea-9649-04f4efeed3f0.png">
<img width="827" alt="Screenshot 2020-01-30 at 19 08 04" src="https://user-images.githubusercontent.com/33876435/73527847-0b6dc780-4414-11ea-8daf-5b4d9e7d5744.png">
<img width="500" alt="Screenshot 2020-01-30 at 19 08 15" src="https://user-images.githubusercontent.com/33876435/73527848-0b6dc780-4414-11ea-9f89-77179b948c2e.png">
<img width="501" alt="Screenshot 2020-01-30 at 19 08 25" src="https://user-images.githubusercontent.com/33876435/73527850-0b6dc780-4414-11ea-83e5-732f6f8e7548.png">

